### PR TITLE
Canvas deletion fix

### DIFF
--- a/engine/core/gAppManager.cpp
+++ b/engine/core/gAppManager.cpp
@@ -47,7 +47,6 @@ gAppManager::gAppManager() {
 	canvas = nullptr;
 	canvasmanager = nullptr;
 	guimanager = nullptr;
-	tempbasecanvas = nullptr;
 	ismouseentered = false;
 	buttonpressed[0] = false;
 	buttonpressed[1] = false;
@@ -145,7 +144,7 @@ gBaseCanvas* gAppManager::getCurrentCanvas() {
 }
 
 void gAppManager::setScreenSize(int width, int height) {
-	tempbasecanvas->setScreenSize(width, height);
+	canvas->setScreenSize(width, height);
 }
 
 void gAppManager::setFramerate(int targetFramerate) {

--- a/engine/core/gAppManager.cpp
+++ b/engine/core/gAppManager.cpp
@@ -77,11 +77,6 @@ void gAppManager::runApp(std::string appName, gBaseApp *baseApp, int width, int 
 	// Create window
 	window->initialize(width, height, windowMode);
 
-	tempbasecanvas = new gBaseCanvas(app);
-	tempbasecanvas->setScreenSize(width, height);
-	tempbasecanvas->setUnitScreenSize(unitWidth, unitHeight);
-	tempbasecanvas->setScreenScaling(screenScaling);
-
 	canvasmanager = new gCanvasManager();
 	guimanager = new gGUIManager(app);
 
@@ -90,6 +85,12 @@ void gAppManager::runApp(std::string appName, gBaseApp *baseApp, int width, int 
 //	if (canvasmanager->getTempCanvas() != nullptr) {
 //		canvasmanager->getTempCanvas()->setup(); // Commented out because was invoking first canvas's setup 2 times in the app launch
 //	}
+
+	gBaseCanvas *tempcanvas = canvasmanager->getTempCanvas();
+	tempcanvas->setScreenSize(width, height);
+	tempcanvas->setUnitScreenSize(unitWidth, unitHeight);
+	tempcanvas->setScreenScaling(screenScaling);
+
 
 	starttime = std::chrono::high_resolution_clock::now();
 
@@ -136,8 +137,7 @@ gCanvasManager* gAppManager::getCanvasManager() {
 }
 
 void gAppManager::setCurrentCanvas(gBaseCanvas *baseCanvas) {
-	canvas = baseCanvas;
-	canvasmanager->setCurrentCanvas(canvas);
+	canvasmanager->setCurrentCanvas(baseCanvas);
 }
 
 gBaseCanvas* gAppManager::getCurrentCanvas() {

--- a/engine/core/gAppManager.h
+++ b/engine/core/gAppManager.h
@@ -417,7 +417,6 @@ private:
 	gBaseCanvas* canvas;
 	gCanvasManager* canvasmanager;
 	gGUIManager* guimanager;
-	gBaseCanvas* tempbasecanvas;
 	bool ismouseentered;
 	bool buttonpressed[3];
 	int pressed;

--- a/engine/core/gCanvasManager.cpp
+++ b/engine/core/gCanvasManager.cpp
@@ -24,9 +24,7 @@ void gCanvasManager::update() {
 		case DISPLAY_CHANGE_CURRENT:
 			if (currentCanvas != nullptr) {
 				currentCanvas->hideNotify();
-#ifndef WIN32
 				delete currentCanvas;
-#endif
 			}
 			if (tempCanvas != nullptr) {
 				currentCanvas = tempCanvas;

--- a/engine/graphics/gTexture.cpp
+++ b/engine/graphics/gTexture.cpp
@@ -102,7 +102,7 @@ gTexture::gTexture(int w, int h, int format, bool isFbo) {
 }
 
 gTexture::~gTexture() {
-	if (ismutable) delete data;
+	if (ismutable) stbi_image_free(data);
 }
 
 unsigned int gTexture::load(std::string fullPath) {


### PR DESCRIPTION
**Problem:** In gTexture, data was being deleted by `delete`, which caused the engine crash on deleting the canvas that contained any object which inherits gTexture.

**Why:** The allocated memory on data is returned by stbi. Stbi uses `malloc` instead of `new` keyword. Therefore not dynamically allocating memory. `delete` can't be used to free the space that's allocated by malloc.

**Solution:**  Fixed by changing `delete data` to `stbi_image_free(data)`.