### PR TITLE
Game Loop framerate fixed

### DIFF
--- a/engine/base/gBaseApp.cpp
+++ b/engine/base/gBaseApp.cpp
@@ -51,3 +51,7 @@ int gBaseApp::getFramerate() {
 double gBaseApp::getElapsedTime() {
 	return appmanager->getElapsedTime();
 }
+
+void gBaseApp::enableFpsDisplay(bool shouldDisplay) {
+	appmanager->shouldDisplayFramerate(shouldDisplay);
+}

--- a/engine/base/gBaseApp.cpp
+++ b/engine/base/gBaseApp.cpp
@@ -52,6 +52,10 @@ double gBaseApp::getElapsedTime() {
 	return appmanager->getElapsedTime();
 }
 
-void gBaseApp::enableFpsDisplay(bool shouldDisplay) {
-	appmanager->shouldDisplayFramerate(shouldDisplay);
+void gBaseApp::enableVsync() {
+	appmanager->enableVsync();
+}
+
+void gBaseApp::disableVsync() {
+	appmanager->disableVsync();
 }

--- a/engine/base/gBaseApp.h
+++ b/engine/base/gBaseApp.h
@@ -30,7 +30,8 @@ public:
 	int getFramerate();
 	double getElapsedTime();
 
-	void enableFpsDisplay(bool shouldDisplay);
+	void enableVsync();
+	void disableVsync();
 
 protected:
 	gAppManager *appmanager;

--- a/engine/base/gBaseApp.h
+++ b/engine/base/gBaseApp.h
@@ -30,6 +30,8 @@ public:
 	int getFramerate();
 	double getElapsedTime();
 
+	void enableFpsDisplay(bool shouldDisplay);
+
 protected:
 	gAppManager *appmanager;
 };

--- a/engine/core/gAppManager.cpp
+++ b/engine/core/gAppManager.cpp
@@ -235,7 +235,7 @@ int gAppManager::getFramerate() {
 }
 
 double gAppManager::getElapsedTime() {
-	return deltatime.count();
+	return deltatime.count() / 1'000'000'000.0f;
 }
 
 void gAppManager::onCharEvent(unsigned int key) {

--- a/engine/core/gAppManager.cpp
+++ b/engine/core/gAppManager.cpp
@@ -17,25 +17,23 @@
 #endif
 
 
-void gStartEngine(gBaseApp* baseApp, std::string appName, int windowMode, int width, int height, bool vsync) {
+void gStartEngine(gBaseApp* baseApp, std::string appName, int windowMode, int width, int height) {
 	gAppManager appmanager;
 	gGLFWWindow gbwindow;
 	gbwindow.setAppManager(&appmanager);
 	if (appName == "") appName = "GlistApp";
 	gbwindow.setTitle(appName);
-	gbwindow.enableVsync(vsync);
 	appmanager.setWindow(&gbwindow);
 	baseApp->setAppManager(&appmanager);
 	appmanager.runApp(appName, baseApp, width, height, windowMode, width, height, gRenderer::SCREENSCALING_AUTO);
 }
 
-void gStartEngine(gBaseApp* baseApp, std::string appName, int windowMode, int width, int height, int screenScaling, int unitWidth, int unitHeight, bool vsync) {
+void gStartEngine(gBaseApp* baseApp, std::string appName, int windowMode, int width, int height, int screenScaling, int unitWidth, int unitHeight) {
 	gAppManager appmanager;
 	gGLFWWindow gbwindow;
 	gbwindow.setAppManager(&appmanager);
 	if (appName == "") appName = "GlistApp";
 	gbwindow.setTitle(appName);
-	gbwindow.enableVsync(vsync);
 	appmanager.setWindow(&gbwindow);
 	baseApp->setAppManager(&appmanager);
 	appmanager.runApp(appName, baseApp, width, height, windowMode, unitWidth, unitHeight, screenScaling);
@@ -67,7 +65,6 @@ gAppManager::gAppManager() {
 	mpj = 0;
 	upi = 0;
 	upj = 0;
-	isloggingon = false;
 }
 
 gAppManager::~gAppManager() {
@@ -144,7 +141,6 @@ void gAppManager::internalUpdate() {
 	window->update();
 
 	if (elapsedtime >= 1'000'000'000){
-//		if(isloggingon) logger.drawText("FPS: " + gToStr(draws / renderpassnum), 0, loggery);
 		elapsedtime = 0;
 		updates = 0;
 		draws = 0;
@@ -229,6 +225,13 @@ gGUIFrame* gAppManager::getCurrentGUIFrame() {
 	return guimanager->getCurrentFrame();
 }
 
+void gAppManager::enableVsync() {
+	window->enableVsync(true);
+}
+
+void gAppManager::disableVsync() {
+	window->enableVsync(false);
+}
 
 int gAppManager::getFramerate() {
     return (long long)(1'000'000'000 / deltatime.count());
@@ -333,8 +336,4 @@ void gAppManager::onMouseScrollEvent(double xoffset, double yoffset) {
 	if (!canvasmanager->getCurrentCanvas()) return;
 	for (upi = 0; upi < gBasePlugin::usedplugins.size(); upi++) gBasePlugin::usedplugins[upi]->mouseScrolled(xoffset, yoffset);
 	canvasmanager->getCurrentCanvas()->mouseScrolled(xoffset, yoffset);
-}
-
-void gAppManager::shouldDisplayFramerate(bool displayFramerate) {
-	isloggingon = displayFramerate;
 }

--- a/engine/core/gAppManager.h
+++ b/engine/core/gAppManager.h
@@ -44,6 +44,7 @@
 #include <iostream>
 #include <chrono>
 #include "gGUIManager.h"
+#include "gFont.h"
 class gBaseWindow;
 class gBaseApp;
 class gBaseCanvas;
@@ -75,8 +76,11 @@ class gCanvasManager;
  * @param height application window's width to be shown on the user's computer.
  * User should choose this parameter suitable according to their screen resolution
  * to prevent distorted images.
+ *
+ * @param vsync When true, application framerate will be bound to current
+ * monitor's refresh rate. Defaults value is false
  */
-void gStartEngine(gBaseApp* baseApp, std::string appName = "GlistApp", int windowMode = 2, int width = gDefaultWidth(), int height = gDefaultHeight());
+void gStartEngine(gBaseApp* baseApp, std::string appName = "GlistApp", int windowMode = 2, int width = gDefaultWidth(), int height = gDefaultHeight(), bool vsync = true);
 
 /**
  * Sets the app settings for engine according to given name, mode of window,
@@ -115,8 +119,11 @@ void gStartEngine(gBaseApp* baseApp, std::string appName = "GlistApp", int windo
  * can differ from developer to user. GlistEngine has scaling methods. User and
  * developer can have different resolutions, but the engine can adapt to users
  * resolution by scaling. Thus, unitHeight is developer's unit height.
+ *
+ * @param vsync When true, application framerate will be bound to current
+ * monitor's refresh rate.
  */
-void gStartEngine(gBaseApp* baseApp, std::string appName, int windowMode, int width, int height, int screenScaling, int unitWidth, int unitHeight);
+void gStartEngine(gBaseApp* baseApp, std::string appName, int windowMode, int width, int height, int screenScaling, int unitWidth, int unitHeight, bool vsync = false);
 
 /**
  * This class controls basically everything which is shown to user from beginning
@@ -144,6 +151,7 @@ void gStartEngine(gBaseApp* baseApp, std::string appName, int windowMode, int wi
  */
 class gAppManager : gObject {
 public:
+
 	/**
 	 * Constructor of gAppManager class. Constructor is automatically called when
 	 * object(instance of class) is created. A constructor will have exact same name as
@@ -411,7 +419,16 @@ public:
 	 */
 	gGUIManager* getGUIManager();
 
+	void shouldDisplayFramerate(bool displayFramerate);
+
 private:
+	using AppClock = std::chrono::steady_clock;
+	using AppClockDuration = AppClock::duration;
+	using AppClockTimePoint = AppClock::time_point;
+
+	void internalUpdate();
+	void preciseSleep(double seconds);
+
 	std::string appname;
 	gBaseWindow* window;
 	gBaseApp* app;
@@ -423,12 +440,18 @@ private:
 	int pressed;
 	int myPow (int x, int p);
 	int mpi, mpj;
-	std::chrono::high_resolution_clock::time_point starttime;
-	std::chrono::duration<double, std::milli> timediff, timediff2;
-	float millisecondsperframe, delaycoef;
-	std::chrono::duration<double, std::milli> minWorkTime, delay;
+	AppClockTimePoint starttime, endtime;
+	AppClockDuration deltatime;
+	AppClockDuration timestepnano;
+	AppClockDuration lag;
+	long long elapsedtime;
+	int updates, draws;
 	int framerate;
 	int upi, upj;
+
+//	gFont logger;
+	bool isloggingon;
+//	float loggery;
 };
 
 #endif /* ENGINE_CORE_GAPPMANAGER_H_ */

--- a/engine/core/gAppManager.h
+++ b/engine/core/gAppManager.h
@@ -76,11 +76,8 @@ class gCanvasManager;
  * @param height application window's width to be shown on the user's computer.
  * User should choose this parameter suitable according to their screen resolution
  * to prevent distorted images.
- *
- * @param vsync When true, application framerate will be bound to current
- * monitor's refresh rate. Defaults value is false
  */
-void gStartEngine(gBaseApp* baseApp, std::string appName = "GlistApp", int windowMode = 2, int width = gDefaultWidth(), int height = gDefaultHeight(), bool vsync = true);
+void gStartEngine(gBaseApp* baseApp, std::string appName = "GlistApp", int windowMode = 2, int width = gDefaultWidth(), int height = gDefaultHeight());
 
 /**
  * Sets the app settings for engine according to given name, mode of window,
@@ -123,7 +120,7 @@ void gStartEngine(gBaseApp* baseApp, std::string appName = "GlistApp", int windo
  * @param vsync When true, application framerate will be bound to current
  * monitor's refresh rate.
  */
-void gStartEngine(gBaseApp* baseApp, std::string appName, int windowMode, int width, int height, int screenScaling, int unitWidth, int unitHeight, bool vsync = false);
+void gStartEngine(gBaseApp* baseApp, std::string appName, int windowMode, int width, int height, int screenScaling, int unitWidth, int unitHeight);
 
 /**
  * This class controls basically everything which is shown to user from beginning
@@ -419,7 +416,8 @@ public:
 	 */
 	gGUIManager* getGUIManager();
 
-	void shouldDisplayFramerate(bool displayFramerate);
+	void enableVsync();
+	void disableVsync();
 
 private:
 	using AppClock = std::chrono::steady_clock;
@@ -448,10 +446,6 @@ private:
 	int updates, draws;
 	int framerate;
 	int upi, upj;
-
-//	gFont logger;
-	bool isloggingon;
-//	float loggery;
 };
 
 #endif /* ENGINE_CORE_GAPPMANAGER_H_ */

--- a/engine/core/gBaseWindow.cpp
+++ b/engine/core/gBaseWindow.cpp
@@ -87,6 +87,14 @@ void gBaseWindow::close() {
 
 }
 
+bool gBaseWindow::isVyncEnabled() {
+	return false;
+}
+
+void gBaseWindow::enableVsync(bool vsync) {
+
+}
+
 void gBaseWindow::setCursor(int cursorNo) {
 
 }

--- a/engine/core/gBaseWindow.h
+++ b/engine/core/gBaseWindow.h
@@ -58,6 +58,9 @@ public:
 	 */
 	virtual void close();
 
+	virtual bool isVyncEnabled();
+	virtual void enableVsync(bool vsync);
+
 	virtual void setCursor(int cursorNo);
 	virtual void setCursorMode(int cursorMode);
 

--- a/engine/core/gGLFWWindow.cpp
+++ b/engine/core/gGLFWWindow.cpp
@@ -154,9 +154,10 @@ bool gGLFWWindow::isVyncEnabled() {
 	return vsync;
 }
 
-void gGLFWWindow::enableVsync(bool vsync = false) {
+void gGLFWWindow::enableVsync(bool vsync) {
 #if defined(WIN32) || defined(LINUX) || defined(APPLE)
 	this->vsync = vsync;
+	glfwSwapInterval(vsync);
 #endif
 }
 

--- a/engine/core/gGLFWWindow.cpp
+++ b/engine/core/gGLFWWindow.cpp
@@ -20,6 +20,7 @@ gGLFWWindow::gGLFWWindow() {
 #if defined(WIN32) || defined(LINUX) || defined(APPLE)
 	window = nullptr;
 	cursor = new GLFWcursor*[6];
+	vsync = true;
 #endif
 }
 
@@ -69,7 +70,6 @@ void gGLFWWindow::initialize(int width, int height, int windowMode) {
     window = glfwCreateWindow(width, height, title.c_str(),
 			(windowMode==gBaseWindow::WINDOWMODE_GAME?glfwGetPrimaryMonitor():NULL), NULL);
 
-
 	if (window == NULL) {
 	    std::cout << "Failed to create GLFW window" << std::endl;
 	    glfwTerminate();
@@ -97,6 +97,7 @@ void gGLFWWindow::initialize(int width, int height, int windowMode) {
 	glfwSetCursor(window, cursor[0]);
 
 	glfwMakeContextCurrent(window);
+    glfwSwapInterval(vsync ? 1 : 0);
 	glewExperimental = GL_TRUE;
 	glewInit();
 
@@ -146,6 +147,16 @@ void gGLFWWindow::close() {
 #if defined(WIN32) || defined(LINUX) || defined(APPLE)
 	// Deallocate glfw resources
 	glfwTerminate();
+#endif
+}
+
+bool gGLFWWindow::isVyncEnabled() {
+	return vsync;
+}
+
+void gGLFWWindow::enableVsync(bool vsync = false) {
+#if defined(WIN32) || defined(LINUX) || defined(APPLE)
+	this->vsync = vsync;
 #endif
 }
 

--- a/engine/core/gGLFWWindow.h
+++ b/engine/core/gGLFWWindow.h
@@ -55,6 +55,9 @@ public:
 	 */
 	void close();
 
+	bool isVyncEnabled();
+	void enableVsync(bool vsync);
+
 	void setCursor(int cursorNo);
 	void setCursorMode(int cursorMode);
 
@@ -62,6 +65,7 @@ private:
 #if defined(WIN32) || defined(LINUX) || defined(APPLE)
 	GLFWwindow* window;
 	GLFWcursor** cursor;
+	bool vsync;
 
 	/**
 	 * Invoking by GLFW if the window size changed.


### PR DESCRIPTION
Implemented 2 versions of the main loop;

- First one that works with vsync, so there is no need for fixating the framerates
- Second one that limits the frames by implementing a special sleep function that uses [Welford's Algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford%27s_online_algorithm).

Without the Vsync, the CPU usage is ~9%, instead of pure spin-lock that causes around 15-100% CPU usage.