### PR TITLE
Added functions to set image button images directly from resource icons

### DIFF
--- a/engine/ui/gGUIImageButton.cpp
+++ b/engine/ui/gGUIImageButton.cpp
@@ -15,6 +15,10 @@ gGUIImageButton::gGUIImageButton() {
 	stretch = true;
 	buttonimagepath = "";
 	pressedbuttonimagepath = "";
+
+	res.initialize();
+	iconid = gGUIResources::ICON_NONE;
+	pressediconid = gGUIResources::ICON_NONE;
 }
 
 gGUIImageButton::~gGUIImageButton() {
@@ -42,10 +46,12 @@ void gGUIImageButton::draw() {
             imageh = buttonh;
         }
     if(isPressed()) {
-        buttonimage.draw(left, top + ispressed, buttonw, buttonh);
+    	if (iconid != gGUIResources::ICON_NONE) res.getIconImage(iconid)->draw(left, top + ispressed, buttonw, buttonh);
+    	else buttonimage.draw(left, top + ispressed, buttonw, buttonh);
     }
     else {
-        pressedbuttonimage.draw(left, top + ispressed, buttonw, buttonh);
+    	if (pressediconid != gGUIResources::ICON_NONE) res.getIconImage(pressediconid)->draw(left, top + ispressed, buttonw, buttonh);
+    	else pressedbuttonimage.draw(left, top + ispressed, buttonw, buttonh);
     }
     setSize(imagew, imageh);
 }
@@ -85,4 +91,11 @@ void gGUIImageButton::stretche(bool stretchMod) {
    }
    std::string gGUIImageButton::getPressedButtonImagePath() {
     return pressedbuttonimagepath;
+   }
+
+   void gGUIImageButton::setButtonImageFromIcon(int iconId){
+   	iconid = iconId;
+   }
+   void gGUIImageButton::setPressedButtonImageFromIcon(int pressedIconId){
+   	pressediconid = pressedIconId;
    }

--- a/engine/ui/gGUIImageButton.h
+++ b/engine/ui/gGUIImageButton.h
@@ -42,6 +42,7 @@
 
 #include "gGUIButton.h"
 #include "gImage.h"
+#include "gGUIResources.h"
 
 /**
  * Uploaded image acts as a button. The Image adding both as an image and file
@@ -118,6 +119,16 @@ public:
  */
     int getButtonHeight();
 
+/**
+ * Sets the button image using icons from the resources.
+ */
+    void setButtonImageFromIcon(int iconId);
+
+/**
+ * Sets the pressed button image using icons from the resources.
+ */
+    void setPressedButtonImageFromIcon(int pressedIconId);
+
 
 private:
         float imagew, imageh, proportion;
@@ -126,7 +137,10 @@ private:
         std::string pressedbuttonimagepath;
         gImage buttonimage;
         gImage pressedbuttonimage;
+
+        gGUIResources res;
+        int iconid;
+        int pressediconid;
 };
 
 #endif /* UI_GGUIIMAGEBUTTONH */
-


### PR DESCRIPTION
For gGUIDialogue, this function will be used to set images for minimize; maximize and exit buttons from Base64 encoded icons.