### PR TITLE
Set base64 icons for default title bar buttons

### DIFF
--- a/engine/ui/gGUIDialogue.cpp
+++ b/engine/ui/gGUIDialogue.cpp
@@ -108,17 +108,23 @@ void gGUIDialogue::resetTitleBar() {
 
 	deftitlebarsizer.setControl(0, 2, &deftitlebarminimizebutton);
 	deftitlebarminimizebutton.setSize(deftitlebar.height, deftitlebar.height);
-	// deftitlebarminimizebutton.loadButtonImages("dicons/tminb32.png");
+	// deftitlebarminimizebutton.loadButtonImages("dicons/nzwmin16.png");
+	deftitlebarminimizebutton.setButtonImageFromIcon(gGUIResources::ICON_MINIMIZEBLACK);
+	deftitlebarminimizebutton.setPressedButtonImageFromIcon(gGUIResources::ICON_MINIMIZEBLACK);
 	setMinimizeButton(&deftitlebarminimizebutton);
 
 	deftitlebarsizer.setControl(0, 3, &deftitlebarmaximizebutton);
 	deftitlebarmaximizebutton.setSize(deftitlebar.height, deftitlebar.height);
-	// deftitlebarmaximizebutton.loadButtonImages("dicons/tmaxb32.png");
+	// deftitlebarmaximizebutton.loadButtonImages("dicons/nzwr16.png");
+	deftitlebarmaximizebutton.setButtonImageFromIcon(gGUIResources::ICON_MAXIMIZEBLACK);
+	deftitlebarmaximizebutton.setPressedButtonImageFromIcon(gGUIResources::ICON_MAXIMIZEBLACK);
 	setMaximizeButton(&deftitlebarmaximizebutton);
 
 	deftitlebarsizer.setControl(0, 4, &deftitlebarexitbutton);
 	deftitlebarexitbutton.setSize(deftitlebar.height, deftitlebar.height);
-	// deftitlebarexitbutton.loadButtonImages("dicons/tcb32.png");
+	// deftitlebarexitbutton.loadButtonImages("dicons/nzwe16.png");
+	deftitlebarexitbutton.setButtonImageFromIcon(gGUIResources::ICON_EXITBLACK);
+	deftitlebarexitbutton.setPressedButtonImageFromIcon(gGUIResources::ICON_EXITBLACK);
 	setExitButton(&deftitlebarexitbutton);
 }
 

--- a/engine/ui/gGUIDialogue.cpp
+++ b/engine/ui/gGUIDialogue.cpp
@@ -134,7 +134,7 @@ void gGUIDialogue::resetButtonsBar() {
 
 	defbuttonsbar.setSizer(&defbuttonsbarsizer);
 	defbuttonsbarsizer.setSize(1, 5);
-	defbuttonsbarsizer.enableBorders(true);
+	defbuttonsbarsizer.enableBorders(false);
 
 	setButtonsBar(&defbuttonsbar);
 

--- a/engine/ui/gGUISizer.cpp
+++ b/engine/ui/gGUISizer.cpp
@@ -246,6 +246,7 @@ void gGUISizer::setControl(int lineNo, int columnNo, gGUIControl* guiControl) {
 }
 
 gGUIControl* gGUISizer::getControl(int lineNo, int columnNo) {
+	if (!iscontrolset[lineNo][columnNo]) return nullptr;
 	return guicontrol[lineNo][columnNo];
 }
 


### PR DESCRIPTION
Additionally made getControl() of gGUISizer class to return null pointer when there's no control object in given row and column, which will be used for drag function of gGUIDialogue.