### PR TITLE
Initialize an uninitialized member which causes SIGSEGV

### DIFF
--- a/engine/graphics/gTexture.cpp
+++ b/engine/graphics/gTexture.cpp
@@ -68,6 +68,7 @@ gTexture::gTexture() {
 	isfbo = false;
 	ishdr = false;
 	isfont = false;
+	ismaskloaded = false;
 	setupRenderData();
 }
 


### PR DESCRIPTION
This commit fixes a rare (not so) SIGSEGV issue.