### PR TITLE
Improve fog system

### DIFF
--- a/engine/core/gRenderer.cpp
+++ b/engine/core/gRenderer.cpp
@@ -26,6 +26,9 @@ const int gRenderer::SCREENSCALING_AUTO = 2;
 const int gRenderer::DEPTHTESTTYPE_LESS = 0;
 const int gRenderer::DEPTHTESTTYPE_ALWAYS = 1;
 
+const int gRenderer::FOGMODE_LINEAR = 0;
+const int gRenderer::FOGMODE_EXP = 1;
+
 int gRenderer::width;
 int gRenderer::height;
 int gRenderer::unitwidth;
@@ -625,11 +628,13 @@ gRenderer::gRenderer() {
 	lightingposition = glm::vec3(0.0f);
 	li = 0;
 
-	isfogenabled = false;
-	fogcolor = new gColor();
-	fogcolor->set(0.3f, 0.3f, 0.3f);
-	fogdensity = 0.15;
-	foggradient = 1.5f;
+	fogno = -1;
+	fogcolor.set(0.3f, 0.3f, 0.3f);
+	fogmode = gRenderer::FOGMODE_EXP;
+	fogdensity = 0.3f;
+	foggradient = 2.0f;
+	foglinearstart = 0.0f;
+	foglinearend = 1.0f;
 
 	isdepthtestenabled = false;
 	depthtesttype = 0;
@@ -896,15 +901,72 @@ void gRenderer::enableFog() {
 }
 
 void gRenderer::disableFog() {
-    isfogenabled = false;
+	isfogenabled = false;
+	fogno = -1;
+}
+
+void gRenderer::setFogNo(int no) {
+	fogno = no;
+}
+
+void gRenderer::setFogColor(float r, float g, float b) {
+	fogcolor.set(r, g, b);
+}
+
+void gRenderer::setFogColor(const gColor& color) {
+	fogcolor.set(color.r, color.g, color.b);
+}
+
+void gRenderer::setFogMode(int mode) {
+	fogmode = mode;
+}
+
+void gRenderer::setFogDensity(float value) {
+	fogdensity = value;
+}
+
+void gRenderer::setFogGradient(float value) {
+	foggradient = value;
+}
+
+void gRenderer::setFogLinearStart(float value) {
+	foglinearstart = value;
+}
+
+void gRenderer::setFogLinearEnd(float value) {
+	foglinearend = value;
 }
 
 bool gRenderer::isFogEnabled() {
 	return isfogenabled;
 }
 
-void gRenderer::setFogColor(float r, float g, float b) {
-	fogcolor->set(r, g, b);
+int gRenderer::getFogNo() const {
+	return fogno;
+}
+
+const gColor& gRenderer::getFogColor() const {
+	return fogcolor;
+}
+
+int gRenderer::getFogMode() const {
+	return fogmode;
+}
+
+float gRenderer::getFogDensity() const {
+	return fogdensity;
+}
+
+float gRenderer::getFogGradient() const {
+	return foggradient;
+}
+
+float gRenderer::getFogLinearStart() const {
+	return foglinearstart;
+}
+
+float gRenderer::getFogLinearEnd() const {
+	return foglinearend;
 }
 
 void gRenderer::enableLighting() {
@@ -1055,7 +1117,6 @@ const std::string gRenderer::getShaderSrcColorVertex() {
 "	layout (location = 4) in vec3 aBitangent;\n"
 "	layout (location = 5) in int aUseNormalMap;\n"
 "   uniform int aUseShadowMap;\n"
-"   uniform int aUseFog;\n"
 "\n"
 "	uniform mat4 model;\n"
 "	uniform mat4 view;\n"
@@ -1063,13 +1124,9 @@ const std::string gRenderer::getShaderSrcColorVertex() {
 "	uniform vec3 lightPos;\n"
 "	uniform vec3 viewPos;\n"
 "	uniform mat4 lightMatrix;\n"
-"   out float visibility;\n"
-"   uniform float fogdensity;\n"
-"   uniform float foggradient;\n"
 "\n"
 "	flat out int mUseNormalMap;\n"
 "	flat out int mUseShadowMap;\n"
-"	flat out int mUseFog;\n"
 "\n"
 "	out vec3 Normal;\n"
 "	out vec3 FragPos;\n"
@@ -1078,10 +1135,10 @@ const std::string gRenderer::getShaderSrcColorVertex() {
 "	out vec3 TangentLightPos;\n"
 "	out vec3 TangentViewPos;\n"
 "	out vec3 TangentFragPos;\n"
+"	out vec4 EyePosition;\n"
 "\n"
 "	void main() {\n"
 "    	mUseShadowMap = aUseShadowMap;\n"
-"    	mUseFog = aUseFog;\n"
 "	    FragPos = vec3(model * vec4(aPos, 1.0));\n"
 "	    Normal = mat3(transpose(inverse(model))) * aNormal;\n"
 "	    TexCoords = aTexCoords;\n"
@@ -1101,13 +1158,11 @@ const std::string gRenderer::getShaderSrcColorVertex() {
 "		    TangentFragPos  = TBN * FragPos;\n"
 "	    }\n"
 "\n"
-"	    gl_Position = projection * view * model * vec4(aPos, 1.0);\n"
-"	    if (aUseFog > 0) {\n"
-"          float distance = length(gl_Position.xyz);\n"
-"          visibility = exp(-pow((distance * fogdensity), foggradient));\n"
-"          visibility = clamp(visibility, 0.0, 1.0);\n"
-"       }\n"
-"\n"
+"    	mat4 modelViewMatrix = view * model;\n"
+"    	mat4 projectedMatrix = projection * modelViewMatrix;\n"
+"    	vec4 aPosVec4 = vec4(aPos, 1.0);\n"
+"    	gl_Position = projectedMatrix * aPosVec4;\n"
+"    	EyePosition = modelViewMatrix * aPosVec4;\n"
 "	}\n";
 
 	return std::string(shadersource);
@@ -1145,13 +1200,24 @@ const std::string gRenderer::getShaderSrcColorFragment() {
 "	    float quadratic;\n"
 "	};\n"
 "\n"
+"struct Fog {\n"
+"    vec3 color;\n"
+"    float linearStart;\n"
+"    float linearEnd;\n"
+"    float density;\n"
+"    float gradient;\n"
+"\n"
+"    int mode;\n"
+"    bool enabled;\n"
+"};\n"
+"\n"
 "	uniform Material material;\n"
 "	#define MAX_LIGHTS 8\n"
 "	uniform Light lights[MAX_LIGHTS];\n"
 "\n"
 "	uniform vec4 renderColor;\n"
 "	uniform vec3 viewPos;\n"
-"	uniform vec3 fogColor;\n"
+"	uniform Fog fog;\n"
 "\n"
 "	in vec3 Normal;\n"
 "	in vec3 FragPos;\n"
@@ -1161,10 +1227,9 @@ const std::string gRenderer::getShaderSrcColorFragment() {
 "	in vec3 TangentLightPos;\n"
 "	in vec3 TangentViewPos;\n"
 "	in vec3 TangentFragPos;\n"
-"	in float visibility;\n"
+"	in vec4 EyePosition;\n"
 "\n"
 "	flat in int mUseShadowMap;\n"
-"	flat in int mUseFog;\n"
 "	uniform sampler2D shadowMap;\n"
 "   uniform vec3 shadowLightPos;\n"
 "\n"
@@ -1294,6 +1359,19 @@ const std::string gRenderer::getShaderSrcColorFragment() {
 "		return (ambient + diffuse + specular);\n"
 "	}\n"
 "\n"
+"	float getFogVisibility(Fog fog, float distance) {\n"
+"   	 float visibility = 0.0;\n"
+"   	 if(fog.mode == 0) { // linear\n"
+"      	 	float fogLength = fog.linearEnd - fog.linearStart;\n"
+"        	visibility = (fog.linearEnd - distance) / fogLength;\n"
+"    	} else if(fog.mode == 1) { // exp\n"
+"       	 visibility = exp(-pow((distance * fog.density), fog.gradient));\n"
+"    	}\n"
+"\n"
+"    	visibility = clamp(visibility, 0.0, 1.0);\n"
+"    	return visibility;\n"
+"	}\n"
+"\n"
 "	void main() {\n"
 "		vec4 result = vec4(0.0);\n"
 "		vec3 norm;\n"
@@ -1305,8 +1383,7 @@ const std::string gRenderer::getShaderSrcColorFragment() {
 "		vec3 viewDir;\n"
 "		if (mUseNormalMap > 0) {\n"
 "			viewDir = normalize(TangentViewPos - TangentFragPos);\n"
-"		}\n"
-"		else {\n"
+"		} else {\n"
 "			viewDir = normalize(viewPos - FragPos);\n"
 "		}\n"
 "		vec4 materialAmbient;\n"
@@ -1349,9 +1426,10 @@ const std::string gRenderer::getShaderSrcColorFragment() {
 "\n"
 "		FragColor = result * renderColor;\n"
 "\n"
-"	    if (mUseFog > 0) {\n"
-"			FragColor = mix(vec4(fogColor, 1.0), FragColor, visibility);\n"
-"	    }"
+"    	if(fog.enabled) {\n"
+"        	float distance = abs(EyePosition.z / EyePosition.w);\n"
+"       	FragColor = mix(vec4(fog.color, 1.0), FragColor, getFogVisibility(fog, distance));\n"
+"    	}\n"
 "	}\n";
 
 	return std::string(shadersource);
@@ -2193,3 +2271,5 @@ const std::string gRenderer::getShaderSrcFboFragment() {
 			"}\n";
 	return std::string(shadersource);
 }
+
+

--- a/engine/core/gRenderer.h
+++ b/engine/core/gRenderer.h
@@ -63,6 +63,7 @@ class gRenderer: public gObject {
 public:
 	static const int SCREENSCALING_NONE, SCREENSCALING_MIPMAP, SCREENSCALING_AUTO;
 	static const int DEPTHTESTTYPE_LESS, DEPTHTESTTYPE_ALWAYS;
+	static const int FOGMODE_LINEAR, FOGMODE_EXP;
 
 	gRenderer();
 	virtual ~gRenderer();
@@ -140,12 +141,25 @@ public:
 	void setGlobalAmbientColor(gColor color);
 	gColor* getGlobalAmbientColor();
 
-	bool isFogEnabled();
 	void enableFog();
 	void disableFog();
+	void setFogNo(int no);
 	void setFogColor(float r, float g, float b);
-	void setFogDensity(float d);
-	void setFogGradient(float g);
+	void setFogColor(const gColor& color);
+	void setFogMode(int fogMode);
+	void setFogDensity(float value);
+	void setFogGradient(float value);
+	void setFogLinearStart(float value);
+	void setFogLinearEnd(float value);
+
+	bool isFogEnabled();
+	int getFogNo() const;
+	const gColor& getFogColor() const;
+	int getFogMode() const;
+	float getFogDensity() const;
+	float getFogGradient() const;
+	float getFogLinearStart() const;
+	float getFogLinearEnd() const;
 
 	void addSceneLight(gLight* light);
 	gLight* getSceneLight(int lightNo);
@@ -191,10 +205,6 @@ public:
 	void backupMatrices();
 	void restoreMatrices();
 
-	gColor* fogcolor;
-	float fogdensity;
-	float foggradient;
-
 private:
 	static int width, height;
 	static int unitwidth, unitheight;
@@ -210,7 +220,16 @@ private:
 
 	gColor* lightingcolor;
 	bool islightingenabled;
+
 	bool isfogenabled;
+	int fogno;
+	gColor fogcolor;
+	float fogdensity;
+	float foggradient;
+	int fogmode;
+	float foglinearstart;
+	float foglinearend;
+
 	glm::vec3 lightingposition;
 	gColor* globalambientcolor;
 	int li;

--- a/engine/graphics/gFog.cpp
+++ b/engine/graphics/gFog.cpp
@@ -1,18 +1,35 @@
 /*
  * gFog.cpp
  *
- *  Created on: 15 A�u 2021
+ *  Created on: Aug 15, 2021
  *      Author: furka
  */
 
 #include "gFog.h"
 
+int gFog::fognum = 0;
+
 gFog::gFog() {
-	
+	color.set(0.3f, 0.3f, 0.3f);
+	mode = gRenderer::FOGMODE_EXP;
+	density = 0.3f;
+	gradient = 2.0f;
+	linearstart = 0.0f;
+	linearend = 1.0f;
+	fogno = fognum++;
 }
 
 void gFog::enable() {
-   renderer->enableFog();
+	renderer->enableFog();
+	if(renderer->getFogNo() == fogno) return;
+
+	renderer->setFogNo(fogno);
+	renderer->setFogColor(&color);
+	renderer->setFogMode(mode);
+	renderer->setFogDensity(density);
+	renderer->setFogGradient(gradient);
+	renderer->setFogLinearStart(linearstart);
+	renderer->setFogLinearEnd(linearend);
 }
 
 void gFog::disable() {
@@ -20,28 +37,57 @@ void gFog::disable() {
 }
 
 void gFog::setColor(float r, float g, float b) {
-	renderer->setFogColor(r, g, b);
+	color.set(r, g, b);
+	if(renderer->getFogNo() == fogno) renderer->setFogColor(r, g, b);
 }
 
-void gFog::setDensity(float d) {
-	renderer->fogdensity = d;
+void gFog::setMode(int value) {
+	mode = value;
+	if(renderer->getFogNo() == fogno) renderer->setFogMode(value);
 }
 
-void gFog::setGradient(float g) {
-	renderer->foggradient = g;
+void gFog::setDensity(float value) {
+	density = value;
+	if(renderer->getFogNo() == fogno) renderer->setFogDensity(value);
+}
+
+void gFog::setGradient(float value) {
+	density = value;
+	if(renderer->getFogNo() == fogno) renderer->setFogGradient(value);
+}
+
+void gFog::setLinearStart(float value) {
+	linearstart = value;
+	if(renderer->getFogNo() == fogno) renderer->setFogLinearStart(value);
+}
+
+void gFog::setLinearEnd(float value) {
+	linearend = value;
+	if(renderer->getFogNo() == fogno) renderer->setFogLinearEnd(value);
 }
 
 const gColor& gFog::getColor() const {
-    return *renderer->fogcolor;
+	return color;
+}
+
+int gFog::getMode() const {
+	return mode;
 }
 
 float gFog::getDensity() const {
-    return renderer->fogdensity;
+	return density;
 }
 
 float gFog::getGradient() const {
-    return renderer->foggradient;
+	return gradient;
 }
 
+float gFog::getLinearStart() const {
+	return linearstart;
+}
+
+float gFog::getLinearEnd() const {
+	return linearend;
+}
 
 

--- a/engine/graphics/gFog.h
+++ b/engine/graphics/gFog.h
@@ -1,7 +1,7 @@
 /*
  * gFog.h
  *
- *  Created on: 15 Aðu 2021
+ *  Created on: Aug 15, 2021
  *      Author: furka
  */
 
@@ -12,50 +12,113 @@
 #include <gRenderObject.h>
 #include <gColor.h>
 
-// This is a class that allows creating fog
-
-class gFog : public gRenderObject{
+/**
+ * Represents a fog object that can be enabled and configured.
+ * Inherits from gRenderObject.
+*/
+class gFog : public gRenderObject {
 public:
+	static int fognum;
+
 	gFog();
 
-	/* Activates the fog.This function creates a fog by giving objects a visibility index and
-	 * multiplying this visibility index by the fog color thanks to these two formula
-	 * visibility = exp(-pow((distance * fogdensity), foggradient))
-	 * objectColor = mix(vec4(fogColor, 1.0), FragColor, visibility)
+	/**
+	 * Sets the current fog as active. You can have multiple fog instances with different properties.
 	 */
 	void enable();
 
-	// Deactivates the fog.
+	/**
+	 * Deactivates the fog
+	 */
 	void disable();
 
-	/* Sets fogColor.
+	/**
+	 * Sets the color of the fog.
+	 *
 	 * @param r = red value of fogColor.
 	 * @param g = green value of fogColor.
 	 * @param b = blue value of fogColor.
-	*/
+	 */
 	void setColor(float r, float g, float b);
 
-	/* Sets density of fog
-	 * @param d = density value.
+	/**
+	 * Sets mode of the fog
+	 * @param value New fog mode. Possible values are:
+	 * - gRenderer::FOGMODE_LINEAR -> Linear Fog (only linear start/end affects visuals)
+	 * - gRenderer::FOGMODE_EXP -> Exponential Fog (only density and gradient affects visuals)
 	 */
-	void setDensity(float d);
+	void setMode(int value);
 
-	/* Sets the gradient curve that distributes the fog in the field.
-	 * @param g = Gradient value.
+	/**
+ 	 * Sets density of the fog, increasing this will make it appear closer to the camera.
+ 	 * @param value Density value.
 	 */
-	void setGradient(float g);
+	void setDensity(float value);
 
-	//Returns fogColor.
+	/**
+	 * Sets the rate at which the fog density increases. A higher value will cause the fog to become denser more quickly.
+	 *
+	 * @param rate The rate of fog density increase. Default is 2.0
+	 */
+	void setGradient(float value);
+
+	/**
+	 * Sets the start value of the linear fog.
+	 * @param value Start value of the linear mode.
+	 */
+	void setLinearStart(float value);
+
+	/**
+	 * Sets the end value of the linear fog.
+	 * @param value End value of the linear mode.
+	 */
+	void setLinearEnd(float value);
+
+	/**
+	 * Gets the fog color.
+	 * @return The fog color.
+	 */
 	const gColor& getColor() const;
 
-	//Returns density value.
+	/**
+	 * Gets the fog mode.
+	 * @return The fog mode. Possible values are:
+	 * - gRenderer::FOGMODE_LINEAR -> Linear Fog (only linear start/end affects visuals)
+	 * - gRenderer::FOGMODE_EXP -> Exponential Fog (only density and gradient affects visuals)
+	 */
+	int getMode() const;
+
+	/**
+	 * Gets the fog density.
+	 * @return The fog density.
+	 */
 	float getDensity() const;
 
-	//Returns fog value.
+	/**
+	 * Gets the fog gradient.
+	 * @return The fog gradient.
+	 */
 	float getGradient() const;
 
-private:
+	/**
+	 * Gets the start value of the linear mode.
+	 * @return The start value of the linear mode. Default is 0.0.
+	 */
+	float getLinearStart() const;
 
+	/**
+	 * Gets the end value of the linear mode.
+	 * @return The end value of the linear mode. Default is 1.0.
+	 */
+	float getLinearEnd() const;
+
+private:
+	int fogno;
+	gColor color;
+	float density;
+	float gradient;
+	int mode;
+	float linearstart, linearend;
 };
 
 

--- a/engine/graphics/gMesh.cpp
+++ b/engine/graphics/gMesh.cpp
@@ -228,18 +228,22 @@ void gMesh::drawStart() {
 				colorshader->setFloat("lights[" + gToStr(sli) + "].linear", scenelight->getAttenuationLinear());
 				colorshader->setFloat("lights[" + gToStr(sli) + "].quadratic", scenelight->getAttenuationQuadratic());
 			}
-		}
-		else {
+		} else {
 			colorshader->setInt("lights[0].type", gLight::LIGHTTYPE_AMBIENT);
 			colorshader->setVec4("lights[0].ambient", renderer->getLightingColor()->r, renderer->getLightingColor()->g, renderer->getLightingColor()->b, renderer->getLightingColor()->a);
 		}
 
-	    if(renderer->isFogEnabled()){
-	            	    colorshader->setInt("aUseFog", 1);
-	            	    colorshader->setVec3("fogColor", renderer->fogcolor->r, renderer->fogcolor->g, renderer->fogcolor->b);
-	            	    colorshader->setFloat("fogdensity", renderer->fogdensity);
-	            	    colorshader->setFloat("foggradient", renderer->foggradient);
-	            	}
+		if(renderer->isFogEnabled()) {
+			colorshader->setBool("fog.enabled", true);
+			colorshader->setVec3("fog.color", renderer->getFogColor().r, renderer->getFogColor().g, renderer->getFogColor().b);
+			colorshader->setInt("fog.mode", renderer->getFogMode());
+			colorshader->setFloat("fog.density", renderer->getFogDensity());
+			colorshader->setFloat("fog.gradient", renderer->getFogGradient());
+			colorshader->setFloat("fog.linearStart", renderer->getFogLinearStart());
+			colorshader->setFloat("fog.linearEnd", renderer->getFogLinearEnd());
+		} else {
+			colorshader->setBool("fog.enabled", false);
+		}
 	    // Set matrices
 	    if(isprojection2d)colorshader->setMat4("projection", renderer->getProjectionMatrix2d());
 	    else colorshader->setMat4("projection", renderer->getProjectionMatrix());


### PR DESCRIPTION
This pull request adds a linear mode to the fog, improves its documentation, and fixes the distance calculations. It also introduces the ability for developers to have multiple gFog classes with each of their own properties, which they can be switched between by enabling and disabling them as needed. Additionally, it makes the color shader sources string literals for ease of readability and editability.

If requested I can revert the string literals.

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/23135761/226029488-d7768060-d57a-4da9-990b-64374155434d.png">
