### PR TITLE
Correcting mouse movement on HiDPI screens for accurate cursor placement

### DIFF
--- a/engine/core/gGLFWWindow.cpp
+++ b/engine/core/gGLFWWindow.cpp
@@ -21,6 +21,9 @@ gGLFWWindow::gGLFWWindow() {
 #if defined(WIN32) || defined(LINUX) || defined(APPLE)
 	window = nullptr;
 	cursor = new GLFWcursor*[6];
+	scalex = 1.0f;
+	scaley = 1.0f;
+
 #endif
 }
 
@@ -84,6 +87,14 @@ void gGLFWWindow::initialize(int width, int height, int windowMode) {
 	glfwGetFramebufferSize(window, &width, &height);
 	this->width = width;
 	this->height = height;
+
+	// Fix mouse movement for HiDPI (scaled) displays.
+	int windowWidth;
+	int windowHeight;
+	glfwGetWindowSize(window, &windowWidth, &windowHeight);
+	// Currently, this is not updated from anywhere, we might need to update this value inside framebuffer_size_callback in some rare edge case.
+	this->scalex = (float) width / (float) windowWidth;
+	this->scaley = (float) height / (float) windowHeight;
 
 	GLFWimage images[1];
 	std::string iconpath = gGetImagesDir() + "gameicon/icon.png";
@@ -200,7 +211,8 @@ void gGLFWWindow::key_callback(GLFWwindow* window, int key, int scancode, int ac
 }
 
 void gGLFWWindow::mouse_pos_callback(GLFWwindow* window, double xpos, double ypos) {
-	(static_cast<gGLFWWindow *>(glfwGetWindowUserPointer(window)))->onMouseMoveEvent(xpos, ypos);
+	auto handle = static_cast<gGLFWWindow *>(glfwGetWindowUserPointer(window));
+	handle->onMouseMoveEvent(xpos * handle->scalex, ypos * handle->scaley);
 }
 
 void gGLFWWindow::mouse_button_callback(GLFWwindow* window, int button, int action, int mods) {

--- a/engine/core/gGLFWWindow.h
+++ b/engine/core/gGLFWWindow.h
@@ -68,6 +68,7 @@ private:
 #if defined(WIN32) || defined(LINUX) || defined(APPLE)
 	GLFWwindow* window;
 	GLFWcursor** cursor;
+	float scalex, scaley;
 
 	/**
 	 * Invoking by GLFW if the window size changed.


### PR DESCRIPTION
This PR addresses the issue of inaccurate cursor placement on HiDPI screens, such as Apple Retina displays. If the framebuffer size is higher than the window size, it can result in incorrect coordinates being passed to the onMouseMoveEvent which , leading to misaligned cursor movements. Related to https://github.com/GlistEngine/GlistEngine/pull/491

Please let me know if there are any further improvements I can make to this implementation.