### PR TITLE
Grid Fixes

### DIFF
--- a/engine/base/gBaseGUIObject.cpp
+++ b/engine/base/gBaseGUIObject.cpp
@@ -74,6 +74,15 @@ bool gBaseGUIObject::isEnabled() {
 
 void gBaseGUIObject::setTitleOn(bool isTitleOn) {
 	istitleon = isTitleOn;
+	if(istitleon) {
+		titlex = left + font->getStringWidth("i");
+		titley = top + font->getStringHeight("AE");
+		titledy = font->getSize() * 1.8f;
+	} else {
+		titlex = 0;
+		titley = 0;
+		titledy = 0;
+	}
 }
 
 bool gBaseGUIObject::isTitleOn() {

--- a/engine/base/gBaseGUIObject.h
+++ b/engine/base/gBaseGUIObject.h
@@ -112,6 +112,7 @@ public:
 
 	int id, type;
 	int left, top, right, bottom, width, height;
+	int titlex, titley, titledy;
 	bool isfocused, iscursoron;
 	bool issizer, iscontainer;
 	static int focusid, previousfocusid;

--- a/engine/ui/gGUIGrid.cpp
+++ b/engine/ui/gGUIGrid.cpp
@@ -321,7 +321,7 @@ void gGUIGrid::mousePressed(int x, int y, int button) {
 			istextboxactive = true;
 		} else istextboxactive = false;
 		isselected = true;
-		int newcellindex = ((int)((x - left - (gridboxw / 2)) / gridboxw)) + ((int)((y + firsty - top - gridboxh - 20) / gridboxh))  * columnnum ; // * gridboxw + (gridboxw / 2);
+		int newcellindex = ((int)((x - left - (gridboxw / 2)) / gridboxw)) + ((int)((y + firsty - top - gridboxh - 20 + ((font->getSize() * 1.8f) * !istitleon)) / gridboxh))  * columnnum ; // * gridboxw + (gridboxw / 2);
 		if(newcellindex != selectedbox) {
 			if(istextboxactive) changeCell();
 			selectedbox = newcellindex;

--- a/engine/ui/gGUIGrid.cpp
+++ b/engine/ui/gGUIGrid.cpp
@@ -244,7 +244,7 @@ void gGUIGrid::drawContent() {
 
 void gGUIGrid::drawCellBackground() {
 	renderer->setColor(*textbackgroundcolor);
-	gDrawRectangle(gridx + (gridboxw / 2), gridy + gridboxh, gridw, gridh, true);
+	gDrawRectangle(gridx + (gridboxw / 2) - firstx, gridy + gridboxh - firsty, gridw, gridh, true);
 }
 
 void gGUIGrid::drawSelectedBox() {
@@ -272,7 +272,7 @@ void gGUIGrid::drawRowContents() {
 		font->drawText(rowtitlestring, gridx + (gridboxw / 4) - (font->getStringWidth(rowtitlestring) / 2), gridy + (gridboxh / 2) + (i * gridboxh)  + (font->getStringHeight(rowtitlestring) / 2) - firsty);
 		temprow++;
 		renderer->setColor(*pressedbuttoncolor);
-		gDrawLine(gridx, gridy + ((i + 1) * gridboxh) - firsty, gridx + gridw + (gridboxw / 2), gridy + ((i + 1) * gridboxh) - firsty);
+		gDrawLine(gridx - firstx, gridy + ((i + 1) * gridboxh) - firsty, gridx + gridw + (gridboxw / 2) - firstx, gridy + ((i + 1) * gridboxh) - firsty);
 	}
 }
 
@@ -291,8 +291,8 @@ void gGUIGrid::drawColumnContents() {
 
 void gGUIGrid::drawTitleLines() {
 	renderer->setColor(*backgroundcolor);
-	gDrawLine(gridx + (gridboxw / 2) + 1, gridy, gridx + (gridboxw / 2) + 1, gridy + gridboxh + gridh);
-	gDrawLine(gridx, gridy + (gridboxh), gridx + gridboxw / 2 + gridw, gridy + (gridboxh));
+	gDrawLine(gridx + (gridboxw / 2) + 1 - firstx, gridy - firsty, gridx + (gridboxw / 2) + 1 - firstx, gridy + gridboxh + gridh - firsty);
+	gDrawLine(gridx - firstx, gridy + (gridboxh) - firsty, gridx + gridboxw / 2 + gridw - firstx, gridy + (gridboxh) - firsty);
 }
 
 void gGUIGrid::drawCellContents() {

--- a/engine/ui/gGUIGrid.cpp
+++ b/engine/ui/gGUIGrid.cpp
@@ -231,6 +231,8 @@ void gGUIGrid::drawContent() {
 	drawCellBackground();
 	if(isselected) drawSelectedBox();
 	drawCellContents();
+	textbox.setFirstX(firstx);
+	textbox.setFirstY(firsty);
 	if(istextboxactive)textbox.draw();
 	drawTitleRowBackground();
 	drawRowContents();
@@ -247,8 +249,8 @@ void gGUIGrid::drawCellBackground() {
 
 void gGUIGrid::drawSelectedBox() {
 	renderer->setColor(0.0f, 1.0f, 0.0f, 1.0f);
-	gDrawRectangle(allcells.at(selectedbox).cellx + 1, (allcells.at(selectedbox).celly + 1) - firsty, gridboxw - 2, gridboxh - 2, false);
-	gDrawRectangle(allcells.at(selectedbox).cellx + (gridboxw - 2) - 6, allcells.at(selectedbox).celly + (gridboxh - 2) - 4 - firsty, 6, 6, true); // FLAG
+	gDrawRectangle(allcells.at(selectedbox).cellx + 1 - firstx, (allcells.at(selectedbox).celly + 1) - firsty, gridboxw - 2, gridboxh - 2, false);
+	gDrawRectangle(allcells.at(selectedbox).cellx + (gridboxw - 2) - 6 - firstx, allcells.at(selectedbox).celly + (gridboxh - 2) - 4 - firsty, 6, 6, true); // FLAG
 }
 
 void gGUIGrid::drawTitleRowBackground() {
@@ -258,7 +260,7 @@ void gGUIGrid::drawTitleRowBackground() {
 
 void gGUIGrid::drawTitleColumnBackground() {
 	renderer->setColor(*buttoncolor);
-	gDrawRectangle(gridx, gridy, gridw + (gridboxw / 2), gridboxh , true);
+	gDrawRectangle(gridx - firstx, gridy, gridw + (gridboxw / 2), gridboxh , true);
 }
 
 void gGUIGrid::drawRowContents() {
@@ -279,10 +281,11 @@ void gGUIGrid::drawColumnContents() {
 	for(int i = 1; i <= columnnum; i++) {
 	    std::string columntitlestring(1, (char) tempcol);
 	    renderer->setColor(*fontcolor);
-		font->drawText(columntitlestring, gridx + (i * gridboxw) - (font->getStringWidth(columntitlestring) / 2), gridy + (gridboxh / 2) + (font->getStringHeight(columntitlestring) / 2));
+		font->drawText(columntitlestring, gridx + (i * gridboxw) - (font->getStringWidth(columntitlestring) / 2) - firstx, gridy + (gridboxh / 2) + (font->getStringHeight(columntitlestring) / 2));
 		tempcol++;
 		renderer->setColor(*pressedbuttoncolor);
-		gDrawLine(gridx - (gridboxw / 2) + ((i + 1) * gridboxw), gridy - firsty, gridx - (gridboxw / 2) + ((i + 1) * gridboxw), gridy + gridboxh +gridh - firsty);
+		gDrawLine(gridx - (gridboxw / 2) + ((i + 1) * gridboxw) - firstx, gridy - firsty, gridx - (gridboxw / 2) + ((i + 1) * gridboxw) - firstx, gridy + gridboxh +gridh - firsty);
+		gDrawRectangle(gridx, gridy, allcells.at(0).cellw / 2, allcells.at(0).cellh, true);
 	}
 }
 
@@ -297,7 +300,7 @@ void gGUIGrid::drawCellContents() {
 	int cellindexcounter = 0;
 	for(int i = 0; i < rownum; i++) {
 		for(int j = 0; j < columnnum; j++) {
-			font->drawText(allcells.at(cellindexcounter).showncontent, allcells.at(cellindexcounter).cellx, allcells.at(cellindexcounter).celly + (gridboxh / 2) + (font->getStringHeight(allcells.at(cellindexcounter).showncontent) / 2) - firsty);
+			font->drawText(allcells.at(cellindexcounter).showncontent, allcells.at(cellindexcounter).cellx - firstx, allcells.at(cellindexcounter).celly + (gridboxh / 2) + (font->getStringHeight(allcells.at(cellindexcounter).showncontent) / 2) - firsty);
 			cellindexcounter++;
 		}
 	}
@@ -305,7 +308,7 @@ void gGUIGrid::drawCellContents() {
 
 void gGUIGrid::mousePressed(int x, int y, int button) {
 	gGUIScrollable::mousePressed(x, y, button);
-	int pressedx = x - left;
+	int pressedx = x - left - firstx;
 	int pressedy = y - top - firsty - titledy;
 	if(pressedx >= gridx + (gridboxw / 2) && pressedx <= gridx + (gridboxw / 2) + gridw && pressedy >= gridy + gridboxh && pressedy <= gridy + gridboxh + gridh) {
 		previousclicktime = clicktime;
@@ -321,7 +324,7 @@ void gGUIGrid::mousePressed(int x, int y, int button) {
 			istextboxactive = true;
 		} else istextboxactive = false;
 		isselected = true;
-		int newcellindex = ((int)((x - left - (gridboxw / 2)) / gridboxw)) + ((int)((y + firsty - top - gridboxh - 20 + ((font->getSize() * 1.8f) * !istitleon)) / gridboxh))  * columnnum ; // * gridboxw + (gridboxw / 2);
+		int newcellindex = ((int)((x + firstx - left - (gridboxw / 2)) / gridboxw)) + ((int)((y + firsty - top - gridboxh - titletopmargin + ((font->getSize() * 1.8f) * !istitleon)) / gridboxh))  * columnnum ; // * gridboxw + (gridboxw / 2);
 		if(newcellindex != selectedbox) {
 			if(istextboxactive) changeCell();
 			selectedbox = newcellindex;

--- a/engine/ui/gGUIGrid.cpp
+++ b/engine/ui/gGUIGrid.cpp
@@ -335,11 +335,13 @@ void gGUIGrid::mousePressed(int x, int y, int button) {
 
 void gGUIGrid::mouseReleased(int x, int y, int button) {
 	if(istextboxactive) textbox.mouseReleased((x - left), (y - top - firsty - titledy), button);
+	gGUIScrollable::mouseReleased(x, y, button);
 }
 
 void gGUIGrid::mouseDragged(int x, int y, int button) {
 //	gLogi("Grid") << x << " " << y;
 	if(istextboxactive) textbox.mouseDragged((x - left), (y - top - firsty), button);
+	gGUIScrollable::mouseDragged(x, y, button);
 }
 
 void gGUIGrid::keyPressed(int key){

--- a/engine/ui/gGUIScrollable.cpp
+++ b/engine/ui/gGUIScrollable.cpp
@@ -105,9 +105,9 @@ void gGUIScrollable::draw() {
 	drawScrollbars();
 	boxfbo->unbind();
 	renderer->setColor(255, 255, 255);
-	boxfbo->drawSub(left, top + (titledy * istitleon), boxw, boxh, 0, renderer->getHeight() - boxh, boxw, boxh);
+	boxfbo->drawSub(left, top + titledy, boxw, boxh, 0, renderer->getHeight() - boxh, boxw, boxh);
 	renderer->setColor(foregroundcolor);
-	gDrawRectangle(left, top + (titledy * istitleon), boxw, boxh, false);
+	gDrawRectangle(left, top + titledy, boxw, boxh, false);
 	if(isalpha) {
 		renderer->enableAlphaBlending();
 		renderer->enableAlphaTest();

--- a/engine/ui/gGUIScrollable.cpp
+++ b/engine/ui/gGUIScrollable.cpp
@@ -48,6 +48,7 @@ gGUIScrollable::gGUIScrollable() {
 	firstx = 0;
 	firsty = 0;
 	vsbmy = -1;
+	hsbmx = -1;
 	titlex = left;
 	titley = top + font->getStringHeight("AE");
 	titledy = font->getSize() * 1.8f;
@@ -185,12 +186,15 @@ void gGUIScrollable::mouseMoved(int x, int y) {
 	iscursoronvsb = false;
 	iscursoronhsb = false;
 	if(x >= left + vsbx && x < left + vsbx + vsbw && y >= top + titledy + vsby && y < top + titledy + vsby + vsbh) iscursoronvsb = true;
-	if(x >= left + hsbx && x < left + hsbx + hsbw && y >= top + titledy + hsby && y < top + titledy + hsby + hsbh) iscursoronhsb = true;
+	if(x >= left + hsbx && x < left + hsbx + hsbw && y >= top + titledy + hsby - (titletopmargin * istitleon) && y < top + titledy + hsby - (titletopmargin * istitleon) + hsbh) iscursoronhsb = true;
 }
 
 void gGUIScrollable::mousePressed(int x, int y, int button) {
 	if(vsbenabled && x >= left + vrx && x < left + vrx + vrw && y >= top + titledy + vry && y < top + titledy + vry + vrh) {
 		vsbmy = y;
+	}
+	if(hsbenabled && x >= left + hrx && x < left + hrx + hrw && y >= top + titledy + hry - (titletopmargin * istitleon) && y < top + titledy + hry - (titletopmargin * istitleon) + hrh) {
+		hsbmx = x;
 	}
 }
 
@@ -208,10 +212,23 @@ void gGUIScrollable::mouseDragged(int x, int y, int button) {
 
 		vsbmy = y;
 	}
+
+	if(hsbmx > -1) {
+		hrx += x - hsbmx;
+		if(hrx < 0) hrx = 0;
+		if(hrx > boxw - vsbh) hrx = boxw - vsbh;
+
+		firstx += x - hsbmx;
+		if(firstx < 0) firstx = 0;
+		if(firstx > boxw - vsbh) firstx = boxw - vsbh;
+
+		hsbmx = x;
+	}
 }
 
 void gGUIScrollable::mouseReleased(int x, int y, int button) {
 	vsbmy = -1;
+	hsbmx = -1;
 }
 
 void gGUIScrollable::mouseScrolled(int x, int y) {
@@ -225,7 +242,6 @@ void gGUIScrollable::mouseScrolled(int x, int y) {
 	if(firstx < 0) firstx = 0;
 	if(firstx > boxw - vsbh) firstx = boxw - vsbh;
 	if(hsbenabled) hrx = firstx;
-	//gLogi("Scrollable") << "t:" << top << ", y:" << vry << ", h:" << vrh;
 }
 
 void gGUIScrollable::windowResized(int w, int h) {

--- a/engine/ui/gGUIScrollable.cpp
+++ b/engine/ui/gGUIScrollable.cpp
@@ -160,11 +160,11 @@ void gGUIScrollable::drawScrollbars() {
 */
 			sbbgcolor.a = hsbalpha;
 			renderer->setColor(&sbbgcolor);
-			gDrawRectangle(0, boxh - hsbh, hsbw, hsbh, true);
+			gDrawRectangle(0, boxh - hsbh - (titletopmargin * istitleon), hsbw, hsbh, true);
 
 			sbfgcolor.a = hsbalpha;
 			renderer->setColor(&sbfgcolor);
-			gDrawRectangle(hrx, hry, hrw, hrh, true);
+			gDrawRectangle(hrx, hry - (titletopmargin * istitleon), vsbh, hrh, true);
 		}
 
 		if(!alphablending) {
@@ -223,6 +223,8 @@ void gGUIScrollable::mouseScrolled(int x, int y) {
 
 	firstx -= x * scrolldiff;
 	if(firstx < 0) firstx = 0;
+	if(firstx > boxw - vsbh) firstx = boxw - vsbh;
+	if(hsbenabled) hrx = firstx;
 	//gLogi("Scrollable") << "t:" << top << ", y:" << vry << ", h:" << vrh;
 }
 
@@ -240,5 +242,3 @@ gFbo* gGUIScrollable::getFbo() {
 int gGUIScrollable::getTitleTop() {
 	return titledy;
 }
-
-

--- a/engine/ui/gGUIScrollable.h
+++ b/engine/ui/gGUIScrollable.h
@@ -159,6 +159,7 @@ private:
 	int vrx, vry, vrw, vrh;
 	int hrx, hry, hrw, hrh;
 	int vsbmy;
+	int hsbmx;
 	bool isalpha;
 };
 

--- a/engine/ui/gGUIScrollable.h
+++ b/engine/ui/gGUIScrollable.h
@@ -126,6 +126,8 @@ public:
 
 	int getTitleTop();
 
+	const int titletopmargin = 20;
+
 protected:
 
 	/*

--- a/engine/ui/gGUIScrollable.h
+++ b/engine/ui/gGUIScrollable.h
@@ -142,7 +142,6 @@ protected:
 	int firstx, firsty;
 	int vsbx, vsby, vsbw, vsbh;
 	int hsbx, hsby, hsbw, hsbh;
-	int titlex, titley, titledy;
 	int scrolldiff;
 
 private:

--- a/engine/ui/gGUITextbox.cpp
+++ b/engine/ui/gGUITextbox.cpp
@@ -77,6 +77,8 @@ gGUITextbox::gGUITextbox() {
 	dotradius = 0;
 	isbackgroundenabled = true;
 	totalh = boxh;
+	firstx = 0;
+	firsty = 0;
 }
 
 gGUITextbox::~gGUITextbox() {
@@ -234,10 +236,10 @@ void gGUITextbox::draw() {
 	gColor oldcolor = *renderer->getColor();
 	if(isbackgroundenabled) {
 		renderer->setColor(foregroundcolor);
-		gDrawRectangle(left, top, width, boxh / 2 + totalh, false);
+		gDrawRectangle(left - firstx, top - firsty, width, boxh / 2 + totalh, false);
 	}
 	renderer->setColor(textbackgroundcolor);
-	gDrawRectangle(left, top + boxh / 4, width,  totalh, true);
+	gDrawRectangle(left - firstx, top + boxh / 4 - firsty, width,  totalh, true);
 
 	if(selectionmode) {
 		if(selectionposx2 >= selectionposx1) {
@@ -261,19 +263,19 @@ void gGUITextbox::draw() {
 		if(dotlimit > text.size()) dotlimit = text.size();
 		for(int i = 0; i < dotlimit; i++) gDrawCircle(left + dotinit + i * dotlen, doty, dotradius, true);
 	} else if(linecount == 1) {
-		font->drawText(text.substr(firstutf, lastutf), left + initx - 2, top + boxh / 4 + lineheight + linetopmargin);
+		font->drawText(text.substr(firstutf, lastutf), left + initx - 2 - firstx, top + boxh / 4 + lineheight + linetopmargin - firsty);
 	} else {
 		if(text.size() == 0) currentline = 1;
 		for(int i = 0; i < linecount; i++) {
 			if(lines[i] == "") continue;
-			font->drawText(lines[i], left + initx - 2, top + boxh / 4 + (i + 1) * (lineheight + linetopmargin));
+			font->drawText(lines[i], left + initx - 2 - firstx, top + boxh / 4 + (i + 1) * (lineheight + linetopmargin) - firsty);
 		}
 	}
 
 	if(editmode && (cursorshowcounter <= cursorshowlimit || keystate)) {
-		int linebottom = top + boxh / 4 + currentline * (lineheight + linetopmargin);
-		gDrawLine(left + initx + 1 + cursorposx, linebottom - lineheight,
-				left + initx + 1 + cursorposx, linebottom + lineheight * 2 / 3);
+		int linebottom = top + boxh / 4 + currentline * (lineheight + linetopmargin) - firsty;
+		gDrawLine(left + initx + 1 + cursorposx - firstx, linebottom - lineheight,
+				left + initx + 1 + cursorposx - firstx, linebottom + lineheight * 2 / 3);
 
 	}
 	renderer->setColor(&oldcolor);
@@ -1316,4 +1318,12 @@ void gGUITextbox::cleanText() {
 
 int gGUITextbox::getTextboxh() {
 	return boxh;
+}
+
+void gGUITextbox::setFirstX(int firstx) {
+	this->firstx = firstx;
+}
+
+void gGUITextbox::setFirstY(int firsty) {
+	this->firsty = firsty;
 }

--- a/engine/ui/gGUITextbox.h
+++ b/engine/ui/gGUITextbox.h
@@ -39,6 +39,7 @@
 #define UI_GGUITEXTBOX_H_
 
 #include "gGUIControl.h"
+#include "gGUIScrollable.h"
 
 
 class gGUITextbox: public gGUIControl {
@@ -194,6 +195,9 @@ public:
 	int getTextboxh();
 	void cleanText();
 
+	void setFirstX(int firstx);
+	void setFirstY(int firsty);
+
 private:
 	static const int KEY_NONE = 0, KEY_BACKSPACE = 1, KEY_LEFT = 2, KEY_RIGHT = 4, KEY_DELETE = 8, KEY_ENTER = 16, KEY_UP = 32, KEY_DOWN = 64;
 
@@ -252,6 +256,7 @@ private:
 	int dotradius;
 	bool isbackgroundenabled;
 	int totalh;
+	int firstx, firsty;
 };
 
 #endif /* UI_GGUITEXTBOX_H_ */


### PR DESCRIPTION
Since title variable is defined in gBaseGUIObject class, titlex, titley, titledy variables have been moved there. Thus, there is no need to multiply with istitleon wherever titledy is seen. Instead, it makes more sense to deactivate the title to 0 and return it to its old value if the title is activated again.