### PR TITLE
Fix-Grid

### DIFF
--- a/engine/base/gBaseGUIObject.cpp
+++ b/engine/base/gBaseGUIObject.cpp
@@ -74,6 +74,15 @@ bool gBaseGUIObject::isEnabled() {
 
 void gBaseGUIObject::setTitleOn(bool isTitleOn) {
 	istitleon = isTitleOn;
+	if(istitleon) {
+		titlex = left + font->getStringWidth("i");
+		titley = top + font->getStringHeight("AE");
+		titledy = font->getSize() * 1.8f;
+	} else {
+		titlex = 0;
+		titley = 0;
+		titledy = 0;
+	}
 }
 
 bool gBaseGUIObject::isTitleOn() {

--- a/engine/base/gBaseGUIObject.h
+++ b/engine/base/gBaseGUIObject.h
@@ -112,6 +112,7 @@ public:
 
 	int id, type;
 	int left, top, right, bottom, width, height;
+	int titlex, titley, titledy;
 	bool isfocused, iscursoron;
 	bool issizer, iscontainer;
 	static int focusid, previousfocusid;

--- a/engine/ui/gGUIGrid.cpp
+++ b/engine/ui/gGUIGrid.cpp
@@ -231,6 +231,8 @@ void gGUIGrid::drawContent() {
 	drawCellBackground();
 	if(isselected) drawSelectedBox();
 	drawCellContents();
+	textbox.setFirstX(firstx);
+	textbox.setFirstY(firsty);
 	if(istextboxactive)textbox.draw();
 	drawTitleRowBackground();
 	drawRowContents();
@@ -242,13 +244,13 @@ void gGUIGrid::drawContent() {
 
 void gGUIGrid::drawCellBackground() {
 	renderer->setColor(*textbackgroundcolor);
-	gDrawRectangle(gridx + (gridboxw / 2), gridy + gridboxh, gridw, gridh, true);
+	gDrawRectangle(gridx + (gridboxw / 2) - firstx, gridy + gridboxh - firsty, gridw, gridh, true);
 }
 
 void gGUIGrid::drawSelectedBox() {
 	renderer->setColor(0.0f, 1.0f, 0.0f, 1.0f);
-	gDrawRectangle(allcells.at(selectedbox).cellx + 1, (allcells.at(selectedbox).celly + 1) - firsty, gridboxw - 2, gridboxh - 2, false);
-	gDrawRectangle(allcells.at(selectedbox).cellx + (gridboxw - 2) - 6, allcells.at(selectedbox).celly + (gridboxh - 2) - 4 - firsty, 6, 6, true); // FLAG
+	gDrawRectangle(allcells.at(selectedbox).cellx + 1 - firstx, (allcells.at(selectedbox).celly + 1) - firsty, gridboxw - 2, gridboxh - 2, false);
+	gDrawRectangle(allcells.at(selectedbox).cellx + (gridboxw - 2) - 6 - firstx, allcells.at(selectedbox).celly + (gridboxh - 2) - 4 - firsty, 6, 6, true); // FLAG
 }
 
 void gGUIGrid::drawTitleRowBackground() {
@@ -258,7 +260,7 @@ void gGUIGrid::drawTitleRowBackground() {
 
 void gGUIGrid::drawTitleColumnBackground() {
 	renderer->setColor(*buttoncolor);
-	gDrawRectangle(gridx, gridy, gridw + (gridboxw / 2), gridboxh , true);
+	gDrawRectangle(gridx - firstx, gridy, gridw + (gridboxw / 2), gridboxh , true);
 }
 
 void gGUIGrid::drawRowContents() {
@@ -270,7 +272,7 @@ void gGUIGrid::drawRowContents() {
 		font->drawText(rowtitlestring, gridx + (gridboxw / 4) - (font->getStringWidth(rowtitlestring) / 2), gridy + (gridboxh / 2) + (i * gridboxh)  + (font->getStringHeight(rowtitlestring) / 2) - firsty);
 		temprow++;
 		renderer->setColor(*pressedbuttoncolor);
-		gDrawLine(gridx, gridy + ((i + 1) * gridboxh) - firsty, gridx + gridw + (gridboxw / 2), gridy + ((i + 1) * gridboxh) - firsty);
+		gDrawLine(gridx - firstx, gridy + ((i + 1) * gridboxh) - firsty, gridx + gridw + (gridboxw / 2) - firstx, gridy + ((i + 1) * gridboxh) - firsty);
 	}
 }
 
@@ -279,17 +281,18 @@ void gGUIGrid::drawColumnContents() {
 	for(int i = 1; i <= columnnum; i++) {
 	    std::string columntitlestring(1, (char) tempcol);
 	    renderer->setColor(*fontcolor);
-		font->drawText(columntitlestring, gridx + (i * gridboxw) - (font->getStringWidth(columntitlestring) / 2), gridy + (gridboxh / 2) + (font->getStringHeight(columntitlestring) / 2));
+		font->drawText(columntitlestring, gridx + (i * gridboxw) - (font->getStringWidth(columntitlestring) / 2) - firstx, gridy + (gridboxh / 2) + (font->getStringHeight(columntitlestring) / 2));
 		tempcol++;
 		renderer->setColor(*pressedbuttoncolor);
-		gDrawLine(gridx - (gridboxw / 2) + ((i + 1) * gridboxw), gridy - firsty, gridx - (gridboxw / 2) + ((i + 1) * gridboxw), gridy + gridboxh +gridh - firsty);
+		gDrawLine(gridx - (gridboxw / 2) + ((i + 1) * gridboxw) - firstx, gridy - firsty, gridx - (gridboxw / 2) + ((i + 1) * gridboxw) - firstx, gridy + gridboxh +gridh - firsty);
+		gDrawRectangle(gridx, gridy, allcells.at(0).cellw / 2, allcells.at(0).cellh, true);
 	}
 }
 
 void gGUIGrid::drawTitleLines() {
 	renderer->setColor(*backgroundcolor);
-	gDrawLine(gridx + (gridboxw / 2) + 1, gridy, gridx + (gridboxw / 2) + 1, gridy + gridboxh + gridh);
-	gDrawLine(gridx, gridy + (gridboxh), gridx + gridboxw / 2 + gridw, gridy + (gridboxh));
+	gDrawLine(gridx + (gridboxw / 2) + 1 - firstx, gridy - firsty, gridx + (gridboxw / 2) + 1 - firstx, gridy + gridboxh + gridh - firsty);
+	gDrawLine(gridx - firstx, gridy + (gridboxh) - firsty, gridx + gridboxw / 2 + gridw - firstx, gridy + (gridboxh) - firsty);
 }
 
 void gGUIGrid::drawCellContents() {
@@ -297,7 +300,7 @@ void gGUIGrid::drawCellContents() {
 	int cellindexcounter = 0;
 	for(int i = 0; i < rownum; i++) {
 		for(int j = 0; j < columnnum; j++) {
-			font->drawText(allcells.at(cellindexcounter).showncontent, allcells.at(cellindexcounter).cellx, allcells.at(cellindexcounter).celly + (gridboxh / 2) + (font->getStringHeight(allcells.at(cellindexcounter).showncontent) / 2) - firsty);
+			font->drawText(allcells.at(cellindexcounter).showncontent, allcells.at(cellindexcounter).cellx - firstx, allcells.at(cellindexcounter).celly + (gridboxh / 2) + (font->getStringHeight(allcells.at(cellindexcounter).showncontent) / 2) - firsty);
 			cellindexcounter++;
 		}
 	}
@@ -305,9 +308,9 @@ void gGUIGrid::drawCellContents() {
 
 void gGUIGrid::mousePressed(int x, int y, int button) {
 	gGUIScrollable::mousePressed(x, y, button);
-	int pressedx = x - left;
+	int pressedx = x - left - firstx;
 	int pressedy = y - top - firsty - titledy;
-	if(pressedx >= gridx + (gridboxw / 2) && pressedx <= gridx + (gridboxw / 2) + gridw && pressedy >= gridy + gridboxh && pressedy <= gridy + gridboxh + gridh) {
+	if(pressedx >= gridx + (gridboxw / 2) - firstx && pressedx <= gridx + (gridboxw / 2) + gridw - firstx && pressedy >= gridy + gridboxh - firsty && pressedy <= gridy + gridboxh + gridh - firsty) {
 		previousclicktime = clicktime;
 		clicktime = gGetSystemTimeMillis();
 		if(clicktime - previousclicktime <= clicktimediff) {
@@ -321,7 +324,7 @@ void gGUIGrid::mousePressed(int x, int y, int button) {
 			istextboxactive = true;
 		} else istextboxactive = false;
 		isselected = true;
-		int newcellindex = ((int)((x - left - (gridboxw / 2)) / gridboxw)) + ((int)((y + firsty - top - gridboxh - 20) / gridboxh))  * columnnum ; // * gridboxw + (gridboxw / 2);
+		int newcellindex = ((int)((x + firstx - left - (gridboxw / 2)) / gridboxw)) + ((int)((y + firsty - top - gridboxh - titletopmargin + ((font->getSize() * 1.8f) * !istitleon)) / gridboxh))  * columnnum ; // * gridboxw + (gridboxw / 2);
 		if(newcellindex != selectedbox) {
 			if(istextboxactive) changeCell();
 			selectedbox = newcellindex;
@@ -332,11 +335,13 @@ void gGUIGrid::mousePressed(int x, int y, int button) {
 
 void gGUIGrid::mouseReleased(int x, int y, int button) {
 	if(istextboxactive) textbox.mouseReleased((x - left), (y - top - firsty - titledy), button);
+	gGUIScrollable::mouseReleased(x, y, button);
 }
 
 void gGUIGrid::mouseDragged(int x, int y, int button) {
 //	gLogi("Grid") << x << " " << y;
 	if(istextboxactive) textbox.mouseDragged((x - left), (y - top - firsty), button);
+	gGUIScrollable::mouseDragged(x, y, button);
 }
 
 void gGUIGrid::keyPressed(int key){

--- a/engine/ui/gGUIScrollable.cpp
+++ b/engine/ui/gGUIScrollable.cpp
@@ -48,6 +48,7 @@ gGUIScrollable::gGUIScrollable() {
 	firstx = 0;
 	firsty = 0;
 	vsbmy = -1;
+	hsbmx = -1;
 	titlex = left;
 	titley = top + font->getStringHeight("AE");
 	titledy = font->getSize() * 1.8f;
@@ -105,9 +106,9 @@ void gGUIScrollable::draw() {
 	drawScrollbars();
 	boxfbo->unbind();
 	renderer->setColor(255, 255, 255);
-	boxfbo->drawSub(left, top + (titledy * istitleon), boxw, boxh, 0, renderer->getHeight() - boxh, boxw, boxh);
+	boxfbo->drawSub(left, top + titledy, boxw, boxh, 0, renderer->getHeight() - boxh, boxw, boxh);
 	renderer->setColor(foregroundcolor);
-	gDrawRectangle(left, top + (titledy * istitleon), boxw, boxh, false);
+	gDrawRectangle(left, top + titledy, boxw, boxh, false);
 	if(isalpha) {
 		renderer->enableAlphaBlending();
 		renderer->enableAlphaTest();
@@ -160,11 +161,11 @@ void gGUIScrollable::drawScrollbars() {
 */
 			sbbgcolor.a = hsbalpha;
 			renderer->setColor(&sbbgcolor);
-			gDrawRectangle(0, boxh - hsbh, hsbw, hsbh, true);
+			gDrawRectangle(0, boxh - hsbh - (titletopmargin * istitleon), hsbw, hsbh, true);
 
 			sbfgcolor.a = hsbalpha;
 			renderer->setColor(&sbfgcolor);
-			gDrawRectangle(hrx, hry, hrw, hrh, true);
+			gDrawRectangle(hrx, hry - (titletopmargin * istitleon), vsbh, hrh, true);
 		}
 
 		if(!alphablending) {
@@ -185,12 +186,15 @@ void gGUIScrollable::mouseMoved(int x, int y) {
 	iscursoronvsb = false;
 	iscursoronhsb = false;
 	if(x >= left + vsbx && x < left + vsbx + vsbw && y >= top + titledy + vsby && y < top + titledy + vsby + vsbh) iscursoronvsb = true;
-	if(x >= left + hsbx && x < left + hsbx + hsbw && y >= top + titledy + hsby && y < top + titledy + hsby + hsbh) iscursoronhsb = true;
+	if(x >= left + hsbx && x < left + hsbx + hsbw && y >= top + titledy + hsby - (titletopmargin * istitleon) && y < top + titledy + hsby - (titletopmargin * istitleon) + hsbh) iscursoronhsb = true;
 }
 
 void gGUIScrollable::mousePressed(int x, int y, int button) {
 	if(vsbenabled && x >= left + vrx && x < left + vrx + vrw && y >= top + titledy + vry && y < top + titledy + vry + vrh) {
 		vsbmy = y;
+	}
+	if(hsbenabled && x >= left + hrx && x < left + hrx + hrw && y >= top + titledy + hry - (titletopmargin * istitleon) && y < top + titledy + hry - (titletopmargin * istitleon) + hrh) {
+		hsbmx = x;
 	}
 }
 
@@ -208,10 +212,23 @@ void gGUIScrollable::mouseDragged(int x, int y, int button) {
 
 		vsbmy = y;
 	}
+
+	if(hsbmx > -1) {
+		hrx += x - hsbmx;
+		if(hrx < 0) hrx = 0;
+		if(hrx > boxw - vsbh) hrx = boxw - vsbh;
+
+		firstx += x - hsbmx;
+		if(firstx < 0) firstx = 0;
+		if(firstx > boxw - vsbh) firstx = boxw - vsbh;
+
+		hsbmx = x;
+	}
 }
 
 void gGUIScrollable::mouseReleased(int x, int y, int button) {
 	vsbmy = -1;
+	hsbmx = -1;
 }
 
 void gGUIScrollable::mouseScrolled(int x, int y) {
@@ -223,7 +240,8 @@ void gGUIScrollable::mouseScrolled(int x, int y) {
 
 	firstx -= x * scrolldiff;
 	if(firstx < 0) firstx = 0;
-	//gLogi("Scrollable") << "t:" << top << ", y:" << vry << ", h:" << vrh;
+	if(firstx > boxw - vsbh) firstx = boxw - vsbh;
+	if(hsbenabled) hrx = firstx;
 }
 
 void gGUIScrollable::windowResized(int w, int h) {
@@ -240,5 +258,3 @@ gFbo* gGUIScrollable::getFbo() {
 int gGUIScrollable::getTitleTop() {
 	return titledy;
 }
-
-

--- a/engine/ui/gGUIScrollable.h
+++ b/engine/ui/gGUIScrollable.h
@@ -126,6 +126,8 @@ public:
 
 	int getTitleTop();
 
+	const int titletopmargin = 20;
+
 protected:
 
 	/*
@@ -142,7 +144,6 @@ protected:
 	int firstx, firsty;
 	int vsbx, vsby, vsbw, vsbh;
 	int hsbx, hsby, hsbw, hsbh;
-	int titlex, titley, titledy;
 	int scrolldiff;
 
 private:
@@ -158,6 +159,7 @@ private:
 	int vrx, vry, vrw, vrh;
 	int hrx, hry, hrw, hrh;
 	int vsbmy;
+	int hsbmx;
 	bool isalpha;
 };
 

--- a/engine/ui/gGUITextbox.cpp
+++ b/engine/ui/gGUITextbox.cpp
@@ -78,6 +78,8 @@ gGUITextbox::gGUITextbox() {
 	isbackgroundenabled = true;
 	totalh = boxh;
 	hdiff = boxh / 4;
+	firstx = 0;
+	firsty = 0;
 }
 
 
@@ -237,10 +239,10 @@ void gGUITextbox::draw() {
 	gColor oldcolor = *renderer->getColor();
 	if(isbackgroundenabled) {
 		renderer->setColor(foregroundcolor);
-		gDrawRectangle(left, top + hdiff, width, boxh / 2 + totalh, false);
+		gDrawRectangle(left - firstx, top + hdiff - firsty, width, boxh / 2 + totalh, false);
 	}
 	renderer->setColor(textbackgroundcolor);
-	gDrawRectangle(left, top + hdiff, width,  totalh, true);
+	gDrawRectangle(left - firstx, top + hdiff - firsty, width,  totalh, true);
 
 	if(selectionmode) {
 		if(selectionposx2 >= selectionposx1) {
@@ -264,19 +266,19 @@ void gGUITextbox::draw() {
 		if(dotlimit > text.size()) dotlimit = text.size();
 		for(int i = 0; i < dotlimit; i++) gDrawCircle(left + dotinit + i * dotlen, doty, dotradius, true);
 	} else if(linecount == 1) {
-		font->drawText(text.substr(firstutf, lastutf), left + initx - 2, top + hdiff + lineheight + linetopmargin);
+		font->drawText(text.substr(firstutf, lastutf), left + initx - 2 - firstx, top + hdiff + lineheight + linetopmargin - firsty);
 	} else {
 		if(text.size() == 0) currentline = 1;
 		for(int i = 0; i < linecount; i++) {
 			if(lines[i] == "") continue;
-			font->drawText(lines[i], left + initx - 2, top + hdiff + (i + 1) * (lineheight + linetopmargin));
+			font->drawText(lines[i], left + initx - 2 - firstx, top + hdiff + (i + 1) * (lineheight + linetopmargin) - firsty);
 		}
 	}
 
 	if(editmode && (cursorshowcounter <= cursorshowlimit || keystate)) {
-		int linebottom = top + hdiff + currentline * (lineheight + linetopmargin);
-		gDrawLine(left + initx + 1 + cursorposx, linebottom - lineheight,
-				left + initx + 1 + cursorposx, linebottom + lineheight * 2 / 3);
+		int linebottom = top + hdiff + currentline * (lineheight + linetopmargin) - firsty;
+		gDrawLine(left + initx + 1 + cursorposx - firstx, linebottom - lineheight,
+				left + initx + 1 + cursorposx - firstx, linebottom + lineheight * 2 / 3);
 	}
 	renderer->setColor(&oldcolor);
 }
@@ -1049,7 +1051,7 @@ int gGUITextbox::findFirstSpace(int lineend) {
 void gGUITextbox::mousePressed(int x, int y, int button) {
 	if(!iseditable) return;
 
-	if(x >= left && x < right && y >= top + hdiff && y < top + totalh + hdiff && button == 0) {
+	if(x >= left - (firstx * 2) && x < right - (firstx * 2) && y >= top + hdiff - (firsty * 2) && y < top + totalh + hdiff - (firsty * 2) && button == 0) {
 		firstclicktime = previousclicktime;
 		previousclicktime = clicktime;
 		clicktime = gGetSystemTimeMillis();
@@ -1358,4 +1360,13 @@ void gGUITextbox::pushToStack() {
 	firstcharstack.push(firstchar);
 	firstutfstack.push(firstutf);
 	firstposxstack.push(firstposx);
+}
+
+
+void gGUITextbox::setFirstX(int firstx) {
+	this->firstx = firstx;
+}
+
+void gGUITextbox::setFirstY(int firsty) {
+	this->firsty = firsty;
 }

--- a/engine/ui/gGUITextbox.h
+++ b/engine/ui/gGUITextbox.h
@@ -200,6 +200,9 @@ public:
 	int getTextboxh();
 	void cleanText();
 
+	void setFirstX(int firstx);
+	void setFirstY(int firsty);
+
 private:
 	static const int KEY_NONE = 0, KEY_BACKSPACE = 1, KEY_LEFT = 2, KEY_RIGHT = 4, KEY_DELETE = 8, KEY_ENTER = 16, KEY_UP = 32, KEY_DOWN = 64;
 
@@ -259,6 +262,7 @@ private:
 	int dotradius;
 	bool isbackgroundenabled;
 	int totalh;
+	int firstx, firsty;
 
 	//undo stacks
 	std::stack<std::string> undostack;


### PR DESCRIPTION
- Added side scrolling for Grid
- A small box has been drawn there so that the titles are not displayed in the upper left corner when horizontal scrolling is performed.
- Horizontal scroll bar in the grid has been activated.
- Horizontal scrollbar positioned properly when title is closed.
- Fixed textbox and cursor when scrolling while a cell is selected.
- Scroll bars on the grid are also enabled to work by dragging the mouse.
- Added the ability to click on the horizontal scroll bar.
- Fixed overflowing parts of grid drawing.
- The condition of clicking the textbox on the grid after scrolling has been fixed.