### PR TITLE
Fixed interaction of items in menubar

### DIFF
--- a/engine/ui/gGUIMenubar.cpp
+++ b/engine/ui/gGUIMenubar.cpp
@@ -220,7 +220,7 @@ void gGUIMenuItem::draw() {
 }
 
 void gGUIMenuItem::mouseMoved(int x, int y) {
-	if(itemid == 0 || menuboxshown) {
+	if(menuboxshown && isparentpressed) {
 		for(int i = 0; i < childs.size(); i++) {
 			childs[i].hovered = false;
 //			if(parentitemid == 0 && x >= childs[i].left && x < childs[i].right && y >= childs[i].top && y < childs[i].bottom){
@@ -237,12 +237,25 @@ void gGUIMenuItem::mouseMoved(int x, int y) {
 			childs[i].mouseMoved(x, y);
 		}
 	}
+
+	for(int i = 0; i < childs.size(); i++) {
+		if(childs[i].selected) {
+			childs[i].hovered = false;
+			if(x >= childs[i].left && x < childs[i].right && y >= childs[i].top && y < childs[i].bottom) {
+				childs[i].hovered = true;
+			}
+			else{
+				childs[i].counter = 0;
+			}
+			childs[i].mouseMoved(x, y);
+		}
+	}
 }
 
 void gGUIMenuItem::mousePressed(int x, int y, int button) {
 	for(int i = 0; i < parentitems.size(); i++){
-		isparentpressed = false;
-		menuboxshown = false;
+		isparentpressed = true;
+		menuboxshown = true;
 	}
 
 	for(int i = 0; i < childs.size(); i++) {
@@ -264,7 +277,10 @@ void gGUIMenuItem::mousePressed(int x, int y, int button) {
 	}
 }
 
-
+void gGUIMenuItem::mouseReleased(int x, int y, int button) {
+	isparentpressed = false;
+	menuboxshown = true;
+}
 
 gGUIMenubar::gGUIMenubar() : gGUIMenuItem("") {
 	totaltextw = 0;

--- a/engine/ui/gGUIMenubar.h
+++ b/engine/ui/gGUIMenubar.h
@@ -135,6 +135,7 @@ public:
 
 	void mouseMoved(int x, int y);
 	void mousePressed(int x, int y, int button);
+	void mouseReleased(int x, int y, int button);
 	void update();
 
 	void resInitialize();
@@ -166,6 +167,7 @@ private:
 	bool seperator;
 	static bool isresinitialized;
 	bool isparentpressed;
+	bool pressed;
 };
 
 

--- a/engine/ui/gGUIToolbarButton.cpp
+++ b/engine/ui/gGUIToolbarButton.cpp
@@ -8,6 +8,7 @@
 #include "gGUIToolbarButton.h"
 #include "gImage.h"
 
+
 //gGUIResources gGUIToolbarButton::res;
 
 
@@ -61,8 +62,7 @@ void gGUIToolbarButton::draw() {
 		else renderer->setColor(&bcolor);
 	}
 //	renderer->setColor(gColor(0.1f, 0.45f, 0.87f));
-	gDrawRectangle(left, top + ispressed, buttonw, buttonh, true);
-
+	gDrawRectangle(left, top + ispressed, buttonw, buttonh * 3 / 4, true);
 	renderer->setColor(255, 255, 255);
 	// icon image
 	if(iconid != gGUIResources::ICON_NONE) res.getIconImage(iconid)->draw(left + ix, top + iy, iw, ih);


### PR DESCRIPTION
-When an item is opened and the next is changed, the previous one does not close
- children of parent elements are opened automatically.
Problems solved