### PR TITLE
Fixed scrollbars in the grid

### DIFF
--- a/engine/ui/gGUIGrid.cpp
+++ b/engine/ui/gGUIGrid.cpp
@@ -22,15 +22,19 @@ gGUIGrid::gGUIGrid() {
 	gridh = gridboxh * rownum;
 	selectedbox = 0;
 	isselected = false;
+	totalw = columnnum * gridboxw;
 	totalh = rownum * gridboxh;
 	rowtitle = 1;
 	columntitle = 65; // 'A' char in ASCII
 	clicktimediff = 250;
+	titlediff = 20;
 	clicktime = gGetSystemTimeMillis();
 	previousclicktime = clicktime - 2 * clicktimediff;
 	firstclicktime = previousclicktime - 2 * clicktimediff;
 	isdoubleclicked = false;
 	enableScrollbars(true, false);
+	Cell tempcell;
+	setMargin(tempcell.cellw / 2, tempcell.cellh);
 }
 
 gGUIGrid::~gGUIGrid() {
@@ -38,6 +42,7 @@ gGUIGrid::~gGUIGrid() {
 }
 
 void gGUIGrid::set(gBaseApp* root, gBaseGUIObject* topParentGUIObject, gBaseGUIObject* parentGUIObject, int parentSlotLineNo, int parentSlotColumnNo, int x, int y, int w, int h) {
+	totalw = columnnum * gridboxw;
 	totalh = h;
 	totalh = rownum * gridboxh;
 	gGUIScrollable::set(root, topParentGUIObject, parentGUIObject, parentSlotLineNo, parentSlotColumnNo, x, y, w, h);

--- a/engine/ui/gGUIScrollable.h
+++ b/engine/ui/gGUIScrollable.h
@@ -139,12 +139,14 @@ protected:
 	 *	@param h is the new height value.
 	 */
 	void setDimensions(int width, int height);
+	void setMargin(float marginx, float marginy);
 	int boxw, boxh;
-	int totalh;
+	int totalw, totalh;
 	int firstx, firsty;
 	int vsbx, vsby, vsbw, vsbh;
 	int hsbx, hsby, hsbw, hsbh;
 	int scrolldiff;
+	int titlediff;
 
 private:
 	gFbo* boxfbo;
@@ -161,6 +163,7 @@ private:
 	int vsbmy;
 	int hsbmx;
 	bool isalpha;
+	float marginx, marginy;
 };
 
 #endif /* UI_GGUISCROLLABLE_H_ */


### PR DESCRIPTION
- Fixed the problem of not reaching the end of the grid even if scrolling is done to the end.
- Scrollbars align with the state of the title and by sending this if there is any extra space that needs to be left (marginx, marginy).
- The totalw variable is defined to work properly even if the screen size changes.