### PR TITLE
Write text without double clicking on cells

### DIFF
--- a/engine/ui/gGUIGrid.cpp
+++ b/engine/ui/gGUIGrid.cpp
@@ -163,7 +163,7 @@ void gGUIGrid::showCell(int rowNo , int columnNo) {
 
 void gGUIGrid::checkCellType(int cellIndex) {
 	for(int i = 0; i < allcells.at(cellIndex).cellcontent.length(); i++) {
-		if(!isdigit(allcells.at(cellIndex).cellcontent.at(i))) {
+		if(!isdigit(allcells.at(cellIndex).cellcontent.at(i)) && allcells.at(cellIndex).cellcontent.at(i) != '.') {
 			if(allcells.at(cellIndex).celltype == "digit" && !allcells.at(cellIndex).iscellaligned) changeCellAlignment(gBaseGUIObject::TEXTALIGNMENT_LEFT, false);
 			allcells.at(cellIndex).celltype = "string";
 			break;

--- a/engine/ui/gGUIGrid.cpp
+++ b/engine/ui/gGUIGrid.cpp
@@ -462,6 +462,15 @@ void gGUIGrid::mouseDragged(int x, int y, int button) {
 
 void gGUIGrid::keyPressed(int key){
 	if(istextboxactive) textbox.keyPressed(key);
+	else if(isselected || isrowselected || iscolumnselected) {
+		textbox.cleanText();
+		allcells.at(selectedbox).cellcontent = "";
+		allcells.at(selectedbox).showncontent = "";
+		createTextBox();
+		textbox.mousePressed(allcells.at(selectedbox).cellx + textbox.getInitX(), allcells.at(selectedbox).celly + textbox.getInitX(), 0);
+		textbox.keyPressed(key);
+		istextboxactive = true;
+	}
 }
 
 void gGUIGrid::keyReleased(int key) {


### PR DESCRIPTION
- If the cell is selected and text is typed without double-clicking, text can be written to the clean textbox.