### PR TITLE
Select multiple cells with shift+arrow and switch cells with enter.

### DIFF
--- a/engine/ui/gGUIGrid.cpp
+++ b/engine/ui/gGUIGrid.cpp
@@ -674,6 +674,7 @@ void gGUIGrid::changeCell() {
 void gGUIGrid::drawContent() {
 	gColor oldcolor = renderer->getColor();
 	drawCellBackground();
+	if(firstselectedcell != -1) drawSelectedArea();
 	if(isselected) drawSelectedBox();
 	else if(isrowselected) drawSelectedRow();
 	else if(iscolumnselected) drawSelectedColumn();
@@ -702,9 +703,9 @@ void gGUIGrid::drawSelectedBox() {
 	}
 	else {
 		int selectedx = calculateCurrentX(firstselectedcell % columnnum);
-		int selectedw = calculateCurrentX(lastselectedcell % columnnum) - selectedx + gridboxw;
+		int selectedw = calculateCurrentX(lastselectedcell % columnnum) - selectedx + gridboxesw[lastselectedcell % columnnum];
 		int selectedy = calculateCurrentY(int(firstselectedcell / columnnum));
-		int selectedh = calculateCurrentY(int(lastselectedcell / columnnum)) - selectedy + gridboxh;
+		int selectedh = calculateCurrentY(int(lastselectedcell / columnnum)) - selectedy + gridboxesh[int(lastselectedcell / columnnum)];
 		gDrawRectangle(selectedx + 1, selectedy + 1, selectedw - 2, selectedh - 2, false);
 		gDrawRectangle(selectedx + selectedw - 2 - 6, selectedy + selectedh - 2 - 4, 6, 6, true); // FLAG
 	}
@@ -719,7 +720,7 @@ void gGUIGrid::drawSelectedRow() {
 	else {
 		int selectedy = calculateCurrentY(int(firstselectedcell / columnnum));
 		int selectedw = calculateCurrentX(lastselectedcell % columnnum) + gridboxw / 2;
-		int selectedh = calculateCurrentY(int(lastselectedcell / columnnum)) - selectedy + gridboxh;
+		int selectedh = calculateCurrentY(int(lastselectedcell / columnnum)) - selectedy + gridboxesh[int(lastselectedcell / columnnum)];
 		gDrawRectangle(gridx + gridboxw / 2 + 1 - firstx, selectedy + 1, selectedw - 2 + firstx, selectedh - 2, false);
 		gDrawRectangle(gridx + gridboxw / 2 + selectedw - 2 - 6, selectedy + selectedh - 2 - 4, 6, 6, true); // FLAG
 	}
@@ -733,7 +734,7 @@ void gGUIGrid::drawSelectedColumn() {
 	}
 	else {
 		int selectedx = calculateCurrentX(firstselectedcell % columnnum);
-		int selectedw = calculateCurrentX(lastselectedcell % columnnum) - selectedx + gridboxw;
+		int selectedw = calculateCurrentX(lastselectedcell % columnnum) - selectedx + gridboxesw[lastselectedcell % columnnum];
 		int selectedh = calculateCurrentY(int(lastselectedcell / columnnum));
 		gDrawRectangle(selectedx + 1, gridy + gridboxh + 1 - firsty, selectedw - 2, selectedh - 2 + firsty, false);
 		gDrawRectangle(selectedx + selectedw - 2 - 6, gridboxh + selectedh - 2 - 4, 6, 6, true); // FLAG
@@ -834,6 +835,17 @@ void gGUIGrid::drawCellContents() {
 			}
 		}
 	}
+}
+
+void gGUIGrid::drawSelectedArea() {
+	renderer->setColor(*buttoncolor);
+	int sx = calculateCurrentX(firstselectedcell % columnnum);
+	int sy = calculateCurrentY(int(firstselectedcell / columnnum));
+	int sw = calculateCurrentX(lastselectedcell % columnnum) - sx + gridboxesw[lastselectedcell % columnnum];
+	int sh = calculateCurrentY(int(lastselectedcell / columnnum)) - sy + gridboxesh[int(lastselectedcell / columnnum)];
+	gDrawRectangle(sx, sy, sw, sh, true);
+	renderer->setColor(*textbackgroundcolor);
+	gDrawRectangle(allcells.at(selectedbox).cellx, allcells.at(selectedbox).celly, allcells.at(selectedbox).cellw, allcells.at(selectedbox).cellh, true);
 }
 
 void gGUIGrid::mousePressed(int x, int y, int button) {

--- a/engine/ui/gGUIGrid.cpp
+++ b/engine/ui/gGUIGrid.cpp
@@ -720,7 +720,7 @@ void gGUIGrid::drawSelectedRow() {
 		int selectedy = calculateCurrentY(int(firstselectedcell / columnnum));
 		int selectedw = calculateCurrentX(lastselectedcell % columnnum) + gridboxw / 2;
 		int selectedh = calculateCurrentY(int(lastselectedcell / columnnum)) - selectedy + gridboxh;
-		gDrawRectangle(gridx + gridboxw / 2 + 1 - firstx, selectedy + 1, selectedw - 2, selectedh - 2, false);
+		gDrawRectangle(gridx + gridboxw / 2 + 1 - firstx, selectedy + 1, selectedw - 2 + firstx, selectedh - 2, false);
 		gDrawRectangle(gridx + gridboxw / 2 + selectedw - 2 - 6, selectedy + selectedh - 2 - 4, 6, 6, true); // FLAG
 	}
 }
@@ -735,8 +735,8 @@ void gGUIGrid::drawSelectedColumn() {
 		int selectedx = calculateCurrentX(firstselectedcell % columnnum);
 		int selectedw = calculateCurrentX(lastselectedcell % columnnum) - selectedx + gridboxw;
 		int selectedh = calculateCurrentY(int(lastselectedcell / columnnum));
-		gDrawRectangle(selectedx + 1, gridy + gridboxh + 1 - firsty, selectedw - 2, selectedh - 2, false);
-		gDrawRectangle(selectedx + selectedw - 2 - 6, gridboxh + selectedh - 2 - 4 - firsty, 6, 6, true); // FLAG
+		gDrawRectangle(selectedx + 1, gridy + gridboxh + 1 - firsty, selectedw - 2, selectedh - 2 + firsty, false);
+		gDrawRectangle(selectedx + selectedw - 2 - 6, gridboxh + selectedh - 2 - 4, 6, 6, true); // FLAG
 	}
 }
 

--- a/engine/ui/gGUIGrid.h
+++ b/engine/ui/gGUIGrid.h
@@ -116,6 +116,7 @@ public:
 	void drawColumnContents();
 	void drawTitleLines();
 	void drawCellContents();
+	void drawSelectedArea();
 
 	void fillCell(int cellNo, std::string tempstr);
 	void createCell(int rowNo, int columnNo);

--- a/engine/ui/gGUIGrid.h
+++ b/engine/ui/gGUIGrid.h
@@ -154,6 +154,7 @@ private:
 	void makeDefaultCell();
 	void changeAllAffectedCellsXW(float diff);
 	void changeAllAffectedCellsYH(float diff);
+	void changeSelectedCell(int amount);
 
 	std::deque<Cell> allcells;
 	std::stack<Cell> undocellstack;
@@ -178,6 +179,7 @@ private:
 	int cursor;
 	int currentrow, currentcolumn;
 	int firstcursorposx, firstcursorposy;
+	int firstselectedcell, lastselectedcell;
 	float gridboxw, gridboxh;
 	float gridx, gridy, gridw, gridh;
 	long clicktime, previousclicktime, firstclicktime, clicktimediff;


### PR DESCRIPTION
- With enter, the grid is set to go down by the number of lines.
- If the current row is the last row and the enter key was pressed, it goes to the first row of the next column.
- If the cell is the last cell and the enter key was pressed, it goes to the first cell.
- After selecting a row, column or cell, multiple cell selection has been made by shift key + pressing any of the arrow keys.
- If multiple cells are selected, the transition between cells with enter is set to be inside the selected area.
- Clicking with the mouse or pressing one of the arrow keys while the shift key is not pressed will break the multi-selection.
- The green box representing the selected area is made to work properly according to multi-cell selection.