### PR TITLE
Removed unnecessary glfw include. 

### DIFF
--- a/engine/core/gRenderer.cpp
+++ b/engine/core/gRenderer.cpp
@@ -24,7 +24,6 @@
 //screenShot Related includes
 #include "stb/stb_image_write.h"
 #include "gBaseApp.h"
-#include <GLFW/glfw3.h>
 #include "gImage.h"
 
 const int gRenderer::SCREENSCALING_NONE = 0;


### PR DESCRIPTION
This commit removes unnecessary glfw inlcude which causes Android build to fail.