### PR TITLE
Added function to select all cells and tweaks for better performance.

### DIFF
--- a/engine/ui/gGUIGrid.cpp
+++ b/engine/ui/gGUIGrid.cpp
@@ -963,9 +963,20 @@ void gGUIGrid::setSelectedCells(bool takeAll) {
 		}
 	}
 	else {
-		for(int i = 0; i < allcells.size(); i++) {
-			if(allcells[i].cellrowno >= r1 && allcells[i].cellrowno <= r2 && allcells[i].cellcolumnno >= c1 && allcells[i].cellcolumnno <= c2) {
-				selectedcells.push_back(i);
+		int rowamount = r2 - r1 + 1;
+		int columnamount = c2 - c1 + 1;
+		if(rowamount * columnamount > allcells.size()) {
+			for(int i = 0; i < allcells.size(); i++) {
+				if(allcells[i].cellrowno >= r1 && allcells[i].cellrowno <= r2 && allcells[i].cellcolumnno >= c1 && allcells[i].cellcolumnno <= c2)
+					selectedcells.push_back(i);
+			}
+		}
+		else {
+			for(int column = c1; column <= c2; column++) {
+				for(int row = r1; row <= r2; row++) {
+					int index = getCellNo(row, column);
+					if(index != -1) selectedcells.push_back(index);
+				}
 			}
 		}
 	}

--- a/engine/ui/gGUIGrid.h
+++ b/engine/ui/gGUIGrid.h
@@ -179,7 +179,7 @@ private:
 	void changeAllAffectedCellsYH(float diff);
 	void changeSelectedCell(int amount);
 	void changeCell(int cellNo);
-	void setSelectedCells();
+	void setSelectedCells(bool takeAll = false);
 	void resetSelectedIndexes();
 
 	void copyCells();


### PR DESCRIPTION
- All cells are selected if clicking the upper left corner.
- Edited unnecessary large background drawing.
- The loop is broken when it comes to undrawn values after the row/column that needs to be drawn.
- If no change will be made for all of the selected cells in the control, instead of controlling all of the area, it is preferred the more efficient way.