### PR TITLE
Set pack and unpack alignments to 1

### DIFF
--- a/engine/core/gRenderer.cpp
+++ b/engine/core/gRenderer.cpp
@@ -625,6 +625,11 @@ gRenderer::gRenderer() {
 	viewmatrixold = viewmatrix;
 	cameraposition = glm::vec3(0.0f);
 
+	// This changes pack and unpack alignments
+	// Fixes alignment issues with 3 channel images
+	glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+	glPixelStorei(GL_PACK_ALIGNMENT, 1);
+
 	colorshader = new gShader();
 	colorshader->loadProgram(getShaderSrcColorVertex(), getShaderSrcColorFragment());
 


### PR DESCRIPTION
This pull request fixes a problem with images appearing distorted. The issue occurs when displaying images with dimensions that aren't multiples of four. This can cause OpenGL to mishandle the images, leading to misaligned and improperly rendered visuals. Here's an example to help illustrate the problem:

**Issue Example:**
![Distorted Image](https://github.com/GlistEngine/GlistEngine/assets/23135761/1f941b7d-3df8-488d-a59f-918d386822ea)

**Original Image:**
![Original Image](https://github.com/GlistEngine/GlistEngine/assets/23135761/27c1c5c5-5aac-4ab2-8047-b9a3c302fb06)

To solve this problem, the pull request aims to correct the misalignment and rendering issues. It ensures that images with dimensions not divisible by four are handled correctly. By changing unpack and pack alignments, OpenGL will properly handle these.