### PR TITLE
Fix gRectangle opacity issue

### DIFF
--- a/engine/graphics/primitives/gRectangle.cpp
+++ b/engine/graphics/primitives/gRectangle.cpp
@@ -69,17 +69,21 @@ void gRectangle::setRectanglePoints(float x, float y, float w, float h, bool isF
 	vertex4.position.z = 0.0f;
 	verticessb.push_back(vertex4);
 
-	indicessb.push_back(0);
-	indicessb.push_back(1);
-	indicessb.push_back(2);
-	indicessb.push_back(3);
-	indicessb.push_back(0);
-
-
+	if (isFilled) {
+		indicessb.push_back(0);
+        indicessb.push_back(1);
+		indicessb.push_back(3);
+		indicessb.push_back(2);
+		setDrawMode(gMesh::DRAWMODE_TRIANGLESTRIP);
+	} else {
+		indicessb.push_back(0);
+		indicessb.push_back(1);
+		indicessb.push_back(2);
+		indicessb.push_back(3);
+		indicessb.push_back(0);
+		setDrawMode(gMesh::DRAWMODE_LINESTRIP);
+	}
 	setVertices(verticessb, indicessb);
-    if(!isFilled) setDrawMode(gMesh::DRAWMODE_LINESTRIP);
-    else setDrawMode(gMesh::DRAWMODE_TRIANGLESTRIP);
-
 }
 
 gRectangle::~gRectangle() {


### PR DESCRIPTION
The issue occurs while trying to draw a rectangle with lower opacity with alpha blending on.

Before the changes:
![Screenshot 2023-10-15 150301](https://github.com/GlistEngine/GlistEngine/assets/23135761/58ea6339-d80a-4e75-994e-5a273a9e2fb6)

After the changes:
![Screenshot 2023-10-15 150648](https://github.com/GlistEngine/GlistEngine/assets/23135761/48e6f60d-b4bf-42e2-9275-4b099594859f)