### PR TITLE
Frustum culling fixes and performance improvements

### DIFF
--- a/engine/core/gObject.cpp
+++ b/engine/core/gObject.cpp
@@ -42,83 +42,58 @@ inline bool endsWith(std::string const & value, std::string const & ending) {
 }
 
 gObject::gObject() {
-	if (!initializedpaths) {
-		char temp[256];
-		exepath = getcwd(temp, sizeof(temp));
-		if(!endsWith(exepath, "/")) {
-			exepath += "/";
-		}
-
-		for (int i = 0; i < exepath.size(); i++) {
-			if (exepath[i] == '\\') {
-				exepath[i] = '/';
-			}
-		}
-#if defined(ANDROID)
-		if(gAndroidUtil::datadirectory.empty()) {
-			assetsdir = "";
-		} else {
-			assetsdir = gAndroidUtil::datadirectory + "/";
-		}
-#elif TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
-		assetsdir = gGetIOSResourceDirectory() + "/";
-#else
-		if(assetsdir.empty()) {
-			assetsdir = exepath + "assets/";
-		}
-#endif
-		initializedpaths = true;
-	}
-
 }
 
 std::string gObject::gGetAppDir() {
+	initPaths();
 	return exepath;
 }
 
 std::string gObject::gGetAssetsDir() {
+	initPaths();
 	return assetsdir;
 }
 
 void gObject::gSetAssetsDir(std::string assetsDir) {
+	initPaths();
 	gObject::assetsdir = assetsDir;
 }
 
 std::string gObject::gGetFilesDir() {
-	return assetsdir + "files/";
+	return gGetAssetsDir() + "files/";
 }
 
 std::string gObject::gGetImagesDir() {
-	if (releasescaling == 1) return assetsdir + "mipmaps/" + resolutiondirs[releaseresolution];
-	return assetsdir + "images/";
+	if (releasescaling == 1) return gGetAssetsDir() + "mipmaps/" + resolutiondirs[releaseresolution];
+	return gGetAssetsDir() + "images/";
 }
 
 std::string gObject::gGetFontsDir() {
-	return assetsdir + "fonts/";
+	return gGetAssetsDir() + "fonts/";
 }
 
 std::string gObject::gGetModelsDir() {
-	return assetsdir + "models/";
+	return gGetAssetsDir() + "models/";
 }
 
 std::string gObject::gGetTexturesDir() {
-	return assetsdir + "textures/";
+	return gGetAssetsDir() + "textures/";
 }
 
 std::string gObject::gGetShadersDir() {
-	return assetsdir + "shaders/";
+	return gGetAssetsDir() + "shaders/";
 }
 
 std::string gObject::gGetSoundsDir() {
-	return assetsdir + "sounds/";
+	return gGetAssetsDir() + "sounds/";
 }
 
 std::string gObject::gGetDatabasesDir() {
-	return assetsdir + "databases/";
+	return gGetAssetsDir() + "databases/";
 }
 
 std::string gObject::gGetVideosDir() {
-	return assetsdir + "videos/";
+	return gGetAssetsDir() + "videos/";
 }
 
 void gObject::setCurrentResolution(int scalingNo, int currentResolutionNo) {
@@ -126,6 +101,36 @@ void gObject::setCurrentResolution(int scalingNo, int currentResolutionNo) {
 	releaseresolution = currentResolutionNo;
 }
 
+void gObject::initPaths() {
+	if (initializedpaths) {
+		return;
+	}
+	char temp[256];
+	exepath = getcwd(temp, sizeof(temp));
+	if(!endsWith(exepath, "/")) {
+		exepath += "/";
+	}
+
+	for (int i = 0; i < exepath.size(); i++) {
+		if (exepath[i] == '\\') {
+			exepath[i] = '/';
+		}
+	}
+#if defined(ANDROID)
+	if(gAndroidUtil::datadirectory.empty()) {
+			assetsdir = "";
+		} else {
+			assetsdir = gAndroidUtil::datadirectory + "/";
+		}
+#elif TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
+	assetsdir = gGetIOSResourceDirectory() + "/";
+#else
+	if(assetsdir.empty()) {
+		assetsdir = exepath + "assets/";
+	}
+#endif
+	initializedpaths = true;
+}
 
 void gObject::logi(std::string tag, std::string message) {
 	if(!gIsLoggingEnabled()) return;

--- a/engine/core/gObject.cpp
+++ b/engine/core/gObject.cpp
@@ -24,6 +24,7 @@ int gObject::releaseresolution;
 
 std::string gObject::exepath;
 std::string gObject::assetsdir;
+bool gObject::initializedpaths = false;
 
 
 static const std::string resolutiondirs[] = {
@@ -33,37 +34,42 @@ static const std::string resolutiondirs[] = {
 int gObject::renderpassnum = 1;
 int gObject::renderpassno = 0;
 
-inline bool endsWith(std::string const & value, std::string const & ending)
-{
-	if (ending.size() > value.size()) return false;
+inline bool endsWith(std::string const & value, std::string const & ending) {
+	if (ending.size() > value.size()) {
+		return false;
+	}
 	return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
 }
 
 gObject::gObject() {
-	char temp[256];
-	exepath = getcwd(temp, sizeof(temp));
-	if(!endsWith(exepath, "/")) {
-		exepath += "/";
+	if (!initializedpaths) {
+		char temp[256];
+		exepath = getcwd(temp, sizeof(temp));
+		if(!endsWith(exepath, "/")) {
+			exepath += "/";
+		}
+
+		for (int i = 0; i < exepath.size(); i++) {
+			if (exepath[i] == '\\') {
+				exepath[i] = '/';
+			}
+		}
+#if defined(ANDROID)
+		if(gAndroidUtil::datadirectory.empty()) {
+			assetsdir = "";
+		} else {
+			assetsdir = gAndroidUtil::datadirectory + "/";
+		}
+#elif TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
+		assetsdir = gGetIOSResourceDirectory() + "/";
+#else
+		if(assetsdir.empty()) {
+			assetsdir = exepath + "assets/";
+		}
+#endif
+		initializedpaths = true;
 	}
 
-	for (int i = 0; i < exepath.size(); i++) {
-	    if (exepath[i] == '\\') {
-	    	exepath[i] = '/';
-	    }
-	}
-#if defined(ANDROID)
-    if(gAndroidUtil::datadirectory.empty()) {
-        assetsdir = "";
-    } else {
-        assetsdir = gAndroidUtil::datadirectory + "/";
-    }
-#elif TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
-    assetsdir = gGetIOSResourceDirectory() + "/";
-#else
-    if(assetsdir == "") {
-        assetsdir = exepath + "assets/";
-    }
-#endif
 }
 
 std::string gObject::gGetAppDir() {

--- a/engine/core/gObject.h
+++ b/engine/core/gObject.h
@@ -193,10 +193,10 @@ public:
 protected:
 	static int renderpassnum, renderpassno;
 	static int releasescaling, releaseresolution;
-
 private:
 	static std::string exepath;
 	static std::string assetsdir;
+	static bool initializedpaths;
 };
 
 #endif /* ENGINE_BASE_GOBJECT_H_ */

--- a/engine/core/gObject.h
+++ b/engine/core/gObject.h
@@ -197,6 +197,8 @@ private:
 	static std::string exepath;
 	static std::string assetsdir;
 	static bool initializedpaths;
+
+	static void initPaths();
 };
 
 #endif /* ENGINE_BASE_GOBJECT_H_ */

--- a/engine/core/gRenderer.cpp
+++ b/engine/core/gRenderer.cpp
@@ -738,6 +738,7 @@ gRenderer::~gRenderer() {
 	delete brdfshader;
 	delete fboshader;
 	delete rendercolor;
+	delete lightsubo;
 }
 
 gShader* gRenderer::getColorShader() {

--- a/engine/graphics/gMesh.h
+++ b/engine/graphics/gMesh.h
@@ -41,7 +41,7 @@ public:
 	std::vector<gIndex>& getIndices();
 	int getVerticesNum() const;
 	int getIndicesNum() const;
-	gBoundingBox getBoundingBox();
+	const gBoundingBox& getBoundingBox();
 	gVbo* getVbo();
 	void clear();
 
@@ -60,7 +60,11 @@ public:
     bool intersectsTriangles(gRay* ray);
     float distanceTriangles(gRay* ray);
 
+	void recalculateBoundingBox();
+
 protected:
+	void processTransformationMatrix() override;
+
     void drawStart();
     void drawVbo();
     void drawEnd();
@@ -86,11 +90,9 @@ private:
     gShader* textureshader;
     gShader *pbrshader;
 
-    float bbminx, bbminy, bbminz, bbmaxx, bbmaxy, bbmaxz;
-    glm::vec3 bbvpos;
-    int bbi;
-
     gBoundingBox initialboundingbox;
+    gBoundingBox boundingbox;
+	bool needsboundingboxrecalculation;
 };
 
 #endif /* ENGINE_GRAPHICS_GMESH_H_ */

--- a/engine/graphics/gModel.h
+++ b/engine/graphics/gModel.h
@@ -51,7 +51,7 @@ public:
 	gSkinnedMesh& getMesh(int meshNo);
 	gSkinnedMesh* getMeshPtr(int meshNo);
 	const std::string getMeshName(int meshNo) const;
-	gBoundingBox getBoundingBox();
+	const gBoundingBox& getBoundingBox();
 
 	void move(float dx, float dy, float dz);
 	void move(const glm::vec3& dv);
@@ -110,7 +110,12 @@ public:
 
     gBoundingBox& getInitialBoundingBox();
 
+	void recalculateBoundingBox();
+
 	void setEnableFrustumCulling(bool enable);
+
+protected:
+	void processTransformationMatrix() override;
 
 private:
 	const aiScene* scene;
@@ -149,16 +154,14 @@ private:
 	bool isvertexanimated;
 	bool isvertexanimationstoredonvram;
 
-    float bbminx, bbminy, bbminz, bbmaxx, bbmaxy, bbmaxz;
-    std::vector<gVertex> bbvertices;
-    glm::vec3 bbvpos;
-    gVertex bbv;
 	// this is used to find the nodes fast because assimp code is slow, it might consume little more memory
 	std::unordered_map<std::string, aiNode*> nodemap;
 
     glm::mat4 convertMatrix(const aiMatrix4x4 &aiMat);
     gBoundingBox initialboundingbox;
+    gBoundingBox boundingbox;
 	bool isenablefrustumculling;
+	bool needsboundingboxrecalculation;
 
 };
 

--- a/engine/graphics/gNode.cpp
+++ b/engine/graphics/gNode.cpp
@@ -228,6 +228,9 @@ void gNode::processTransformationMatrix() {
 	localtransformationmatrix = glm::translate(glm::mat4(1.0f), position);
 	localtransformationmatrix = localtransformationmatrix * glm::toMat4((const glm::quat&)orientation);
 	localtransformationmatrix = glm::scale(localtransformationmatrix, scalevec);
+	prevposition = position;
+	prevorientation = orientation;
+	prevscalevec = scalevec;
 }
 
 void gNode::setEnabled(bool isEnabled) {

--- a/engine/graphics/gNode.h
+++ b/engine/graphics/gNode.h
@@ -144,6 +144,10 @@ protected:
 	glm::quat orientation;
 	glm::vec3 scalevec;
 
+	glm::vec3 prevposition;
+	glm::quat prevorientation;
+	glm::vec3 prevscalevec;
+
 	virtual void processTransformationMatrix();
 
 private:

--- a/engine/types/gColor.h
+++ b/engine/types/gColor.h
@@ -27,11 +27,11 @@ public:
 	void set(int r, int g, int b, int a = 255);
 	void set(gColor* color);
 
-	glm::vec4 asVec4() {
+	glm::vec4 asVec4() const {
 		return {r, g, b, a};
 	}
 
-	glm::vec3 asVec3() {
+	glm::vec3 asVec3() const {
 		return {r, g, b};
 	}
 


### PR DESCRIPTION
This PR optimizes bounding box generation, it's also updated when needed. Collision box updates are lazy evaluated, which means it will have no impact on performance if getBoundingBox is never called. With these changes frustum culling is now enabled by default. 


- Optimized bounding box generation, it can now be calculated hundreds of thousands of times per frame and have little to no impact on performance (depending on the vertex count and moved pieces).
- gObject now doesn't recalculate the exepath and assetsdir every time a new object is created. (This also includes gBoundingBox, which was a big performance hit because of the copying)
- Renderer now deletes lightsubo too.
- getBoundingBox now returns a const reference. 
- gColor asVec4 and asVec3 now const functions.
