### PR TITLE
Fix gModel high memory usage for Windows

### DIFF
--- a/engine/graphics/gModel.cpp
+++ b/engine/graphics/gModel.cpp
@@ -727,7 +727,7 @@ float gModel::getAnimationPosition() const {
 
 void gModel::setAnimationFramerate(float animationFramerate) {
 	animationframerate = animationFramerate;
-#ifdef WIN32
+#if defined(WIN32) || defined(TARGET_OS_OSX)
 	setAnimationFrameNum(getAnimationDuration() * animationframerate / scene->mAnimations[0]->mTicksPerSecond);
 #else
 	setAnimationFrameNum(getAnimationDuration() * animationframerate);

--- a/engine/graphics/gVbo.cpp
+++ b/engine/graphics/gVbo.cpp
@@ -123,11 +123,11 @@ gIndex* gVbo::getIndices() const {
 }
 
 void gVbo::bind() const {
-	glBindVertexArray(vao);
+	G_CHECK_GL(glBindVertexArray(vao));
 }
 
 void gVbo::unbind() const {
-	glBindVertexArray(0);
+	G_CHECK_GL(glBindVertexArray(0));
 }
 
 void gVbo::draw() {


### PR DESCRIPTION
This PR fixes an issue when `model.makeVertexAnimated();` called, gModel uses too much memory to crash the program.