### PR TITLE
Fix gModel high memory usage for macOS

### DIFF
--- a/engine/graphics/gModel.cpp
+++ b/engine/graphics/gModel.cpp
@@ -732,7 +732,7 @@ float gModel::getAnimationPosition() const {
 
 void gModel::setAnimationFramerate(float animationFramerate) {
 	animationframerate = animationFramerate;
-#ifdef WIN32
+#if defined(WIN32) || defined(TARGET_OS_OSX)
 	setAnimationFrameNum(getAnimationDuration() * animationframerate / scene->mAnimations[0]->mTicksPerSecond);
 #else
 	setAnimationFrameNum(getAnimationDuration() * animationframerate);

--- a/engine/graphics/gVbo.cpp
+++ b/engine/graphics/gVbo.cpp
@@ -57,7 +57,7 @@ gVbo& gVbo::operator=(const gVbo& other) {
 	if (this == &other) {
 		return *this;
 	}
-	// clear current 
+	// clear current
 	clear();
 	verticesptr = nullptr;
 	vertexarrayptr = nullptr;
@@ -181,11 +181,11 @@ void gVbo::bind() const {
 #ifdef DEBUG
 	assert(vao != GL_NONE);
 #endif
-	glBindVertexArray(vao);
+	G_CHECK_GL(glBindVertexArray(vao));
 }
 
 void gVbo::unbind() const {
-	glBindVertexArray(0);
+	G_CHECK_GL(glBindVertexArray(0));
 }
 
 void gVbo::draw() {


### PR DESCRIPTION
This PR fixes an issue when `model.makeVertexAnimated();` called, gModel uses too much memory to crash the program.