### PR TITLE
Click callback for gGUIButton and new title & dialogue types for gGUIDialogue

### DIFF
--- a/engine/ui/gGUIButton.cpp
+++ b/engine/ui/gGUIButton.cpp
@@ -118,6 +118,9 @@ void gGUIButton::mousePressed(int x, int y, int button) {
 			}
 		}
 		root->getCurrentCanvas()->onGuiEvent(id, G_GUIEVENT_BUTTONPRESSED);
+		if(callback) {
+			callback(true);
+		}
 	}
 }
 
@@ -131,6 +134,9 @@ void gGUIButton::mouseReleased(int x, int y, int button) {
 		}
 		root->getCurrentCanvas()->onGuiEvent(id, G_GUIEVENT_BUTTONRELEASED);
 		actionmanager.onGUIEvent(id, G_GUIEVENT_BUTTONRELEASED);
+		if(callback) {
+			callback(false);
+		}
 	} else {
 		if(!istoggle) ispressed = false;
 	}
@@ -228,4 +234,8 @@ void gGUIButton::setButtonh(int buttonh) {
 
 void gGUIButton::setButtonw(int buttonw) {
 	this->buttonw = buttonw;
+}
+
+void gGUIButton::setClickCallback(ClickCallback fn) {
+	callback = fn;
 }

--- a/engine/ui/gGUIButton.h
+++ b/engine/ui/gGUIButton.h
@@ -13,6 +13,8 @@
 
 class gGUIButton: public gGUIControl {
 public:
+	// void fn(bool isPressed)
+	using ClickCallback = std::function<void(bool)>;
 
 	gGUIButton();
 	virtual ~gGUIButton();
@@ -58,6 +60,7 @@ public:
 	void setButtonh(int buttonh);
 	void setButtonw(int buttonw);
 
+	void setClickCallback(ClickCallback fn);
 protected:
 	bool ispressed;
 	bool ishover;
@@ -71,6 +74,7 @@ protected:
 	gColor fcolor, pressedfcolor, disabledfcolor;
 	gColor hcolor;
 	bool fillbackground;
+	ClickCallback callback;
 
 	void resetTitlePosition();
 

--- a/engine/ui/gGUIDialogue.cpp
+++ b/engine/ui/gGUIDialogue.cpp
@@ -201,8 +201,12 @@ void gGUIDialogue::resetTitleBar() {
 		titlebarsizer.removeControl(0, 3);
 	}
 
-	titlebarsizer.setControl(0, 4, &exitbutton);
-	exitbutton.setSize(titlebar.height, titlebar.height);
+	if (titletype != TITLETYPE_NO_BUTTONS) {
+		titlebarsizer.setControl(0, 4, &exitbutton);
+		exitbutton.setSize(titlebar.height, titlebar.height);
+	} else {
+		titlebarsizer.removeControl(0, 4);
+	}
 }
 
 void gGUIDialogue::resetButtonsBar() {
@@ -210,9 +214,15 @@ void gGUIDialogue::resetButtonsBar() {
 	if(buttonsbar.height == 0) buttonsbar.height = buttonsbarh;
 	buttonsbar.set(root, this, this, 0, 0, left, top + height, buttonsbar.width, buttonsbar.height);
 
-	if(dialoguetype == DIALOGUETYPE_OK) buttonsbarsizer.setSize(1, 2);
-	if(dialoguetype == DIALOGUETYPE_YESNOCANCEL) buttonsbarsizer.setSize(1, 4);
-	if(dialoguetype == DIALOGUETYPE_OKCANCEL || dialoguetype == DIALOGUETYPE_YESNO) buttonsbarsizer.setSize(1, 3);
+	if(dialoguetype == DIALOGUETYPE_OK) {
+		buttonsbarsizer.setSize(1, 2);
+	} else if(dialoguetype == DIALOGUETYPE_YESNOCANCEL) {
+		buttonsbarsizer.setSize(1, 4);
+	} else if(dialoguetype == DIALOGUETYPE_OKCANCEL || dialoguetype == DIALOGUETYPE_YESNO) {
+		buttonsbarsizer.setSize(1, 3);
+	} else {
+		buttonsbarsizer.setSize(0, 0);
+	}
 
 	if(dialoguetype == DIALOGUETYPE_OK){
 		float bbbutp = ((float)buttonsbarbuttonw + 10) / (float)buttonsbar.width;
@@ -497,7 +507,7 @@ std::string gGUIDialogue::getMessageText() {
 	return defmessagetext.getText();
 }
 
-void gGUIDialogue::setIconType(int iconId) {
+void gGUIDialogue::setIconType(IconType iconId) {
 	if(iconId == ICONTYPE_NONE) {
 		isiconenabled = false;
 	}
@@ -507,16 +517,15 @@ void gGUIDialogue::setIconType(int iconId) {
 	}
 }
 
-void gGUIDialogue::setDialogueType(int typeId) {
+void gGUIDialogue::setDialogueType(DialogueType typeId) {
 	dialoguetype = typeId;
 	resetButtonsBar();
 }
 
-void gGUIDialogue::setTitleType(int typeId) {
+void gGUIDialogue::setTitleType(TitleType typeId) {
 	titletype = typeId;
 	resetTitleBar();
 }
-
 
 int gGUIDialogue::getOKButtonId() {
 	return buttonsbarokbutton.getId();

--- a/engine/ui/gGUIDialogue.h
+++ b/engine/ui/gGUIDialogue.h
@@ -34,19 +34,21 @@ class gGUIDialogue: public gGUIForm {
 public:
 	static const int EVENT_NONE = 0, EVENT_MINIMIZE = 1, EVENT_MAXIMIZE = 2, EVENT_RESTORE = 3, EVENT_EXIT = 4;
 	static const int RESIZE_NONE = 0, RESIZE_LEFT = 1, RESIZE_RIGHT = 2, RESIZE_TOP = 3, RESIZE_BOTTOM = 4;
-	enum {
+	enum DialogueType {
 		DIALOGUETYPE_OK,
 		DIALOGUETYPE_YESNOCANCEL,
 		DIALOGUETYPE_OKCANCEL,
-		DIALOGUETYPE_YESNO
+		DIALOGUETYPE_YESNO,
+		DIALOGUETYPE_NO_BUTTONS
 	};
-	enum {
+	enum TitleType {
 		TITLETYPE_EXITMINMAX,
 		TITLETYPE_EXITMAX,
 		TITLETYPE_EXITMIN,
-		TITLETYPE_EXIT
+		TITLETYPE_EXIT,
+		TITLETYPE_NO_BUTTONS
 	};
-	enum {
+	enum IconType {
 		ICONTYPE_NONE,
 		ICONTYPE_ERROR,
 		ICONTYPE_INFO,
@@ -86,9 +88,9 @@ public:
 
 	void setMessageText(std::string messageText);
 	std::string getMessageText();
-	void setIconType(int iconId);
-	void setDialogueType(int typeId);
-	void setTitleType(int typeId);
+	void setIconType(IconType iconId);
+	void setDialogueType(DialogueType typeId);
+	void setTitleType(TitleType typeId);
 
 	int getCursor(int x, int y);
 	void keyPressed(int key);
@@ -108,6 +110,22 @@ public:
 	gGUIButton* getCancelButton();
 	gGUIButton* getYesButton();
 	gGUIButton* getNoButton();
+
+	void setCallbackOK(gGUIButton::ClickCallback fn) {
+		buttonsbarokbutton.setClickCallback(fn);
+	}
+
+	void setCallbackCancel(gGUIButton::ClickCallback fn) {
+		buttonsbarcancelbutton.setClickCallback(fn);
+	}
+
+	void setCallbackYes(gGUIButton::ClickCallback fn) {
+		buttonsbaryesbutton.setClickCallback(fn);
+	}
+
+	void setCallbackNo(gGUIButton::ClickCallback fn) {
+		buttonsbarnobutton.setClickCallback(fn);
+	}
 
 private:
 	bool isdialogueshown;


### PR DESCRIPTION
This PR adds a new callback driven way to listen for clicks to a button, helps keep the code in one place and close to each other by giving it a click listener, this click listener can also be changed at any time allowing dynamic state to be preserved without if statements.

This PR also introduces new dialogue and title types for gGUIDialogue, allowing developers have a blank dialogue with only title and message. 