### PR TITLE
gAppManager error fix(stack trace)

### DIFF
--- a/engine/core/gAppManager.cpp
+++ b/engine/core/gAppManager.cpp
@@ -84,6 +84,7 @@ gAppManager::gAppManager(const std::string& appName, gBaseApp *baseApp, int widt
     iscanvasset = false;
     isrunning = false;
     setupcomplete = false;
+    guiappthread = nullptr;
 #ifdef ANDROID
 	isrendering = false;
 #else


### PR DESCRIPTION
Fix stack trace error message when you close a running project.