### PR TITLE
Move all openGL commands into gGLRenderEngine

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -131,6 +131,8 @@ set(SRC_FILES
 	${ENGINE_DIR}/graphics/gFog.cpp
 	${ENGINE_DIR}/core/gObject.cpp
 	${ENGINE_DIR}/core/gRenderer.cpp
+	${ENGINE_DIR}/core/gGLRenderEngine.cpp
+	${ENGINE_DIR}/core/gRenderer.cpp
 	${ENGINE_DIR}/core/gRenderObject.cpp
 	${ENGINE_DIR}/core/gGUIActionManager.cpp
 	${ENGINE_DIR}/graphics/gTexture.cpp

--- a/engine/core/gAppManager.cpp
+++ b/engine/core/gAppManager.cpp
@@ -259,7 +259,7 @@ void gAppManager::loop() {
     }
     //gLogi("gAppManager") << "stopping loop";
     app->stop();
-    gRenderObject::destroyRenderer();
+    //gRenderObject::destroyRenderer(); // Moved to destructor
     if(usewindow) {
         window->close();
     }

--- a/engine/core/gGLRenderEngine.cpp
+++ b/engine/core/gGLRenderEngine.cpp
@@ -1,0 +1,631 @@
+//
+// Created by sadettin on 23.08.2025.
+//
+
+#include "gGLRenderEngine.h"
+
+//screenShot Related includes
+#include "stb/stb_image_write.h"
+#include "gBaseApp.h"
+#include "gImage.h"
+
+void gGLRenderEngine::clear() {
+	G_CHECK_GL(glClearColor(0.0f, 0.0f, 0.0f, 1.0f));
+	G_CHECK_GL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+}
+
+void gGLRenderEngine::clearColor(int r, int g, int b, int a) {
+	//    glBindFramebuffer(GL_FRAMEBUFFER, gFbo::defaultfbo);
+	G_CHECK_GL(glClearColor((float)r / 255, (float)g / 255, (float)b / 255, (float)a / 255));
+	G_CHECK_GL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+}
+
+void gGLRenderEngine::clearColor(gColor color) {
+	G_CHECK_GL(glClearColor(color.r, color.g, color.b, color.a));
+	G_CHECK_GL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+}
+
+void gGLRenderEngine::enableDepthTest() {
+	enableDepthTest(DEPTHTESTTYPE_LESS);
+}
+
+void gGLRenderEngine::enableDepthTest(int depthTestType) {
+	G_CHECK_GL(glEnable(GL_DEPTH_TEST));
+	G_CHECK_GL(glDepthFunc(depthtesttypeid[depthTestType]));
+	isdepthtestenabled = true;
+	depthtesttype = depthTestType;
+}
+
+void gGLRenderEngine::setDepthTestFunc(int depthTestType) {
+	G_CHECK_GL(glDepthFunc(depthtesttypeid[depthTestType]));
+	depthtesttype = depthTestType;
+}
+
+void gGLRenderEngine::disableDepthTest() {
+	G_CHECK_GL(glDisable(GL_DEPTH_TEST));
+	isdepthtestenabled = false;
+}
+
+bool gGLRenderEngine::isDepthTestEnabled() {
+	return isdepthtestenabled;
+}
+
+int gGLRenderEngine::getDepthTestType() {
+	return depthtesttype;
+}
+
+void gGLRenderEngine::enableAlphaBlending() {
+	G_CHECK_GL(glEnable(GL_BLEND));
+	G_CHECK_GL(glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA));
+	isalphablendingenabled = true;
+}
+
+void gGLRenderEngine::disableAlphaBlending() {
+	G_CHECK_GL(glDisable(GL_BLEND));
+	isalphablendingenabled = false;
+}
+
+bool gGLRenderEngine::isAlphaBlendingEnabled() {
+	return isalphablendingenabled;
+}
+
+void gGLRenderEngine::enableAlphaTest() {
+#if defined(WIN32) || defined(LINUX)
+	glEnable(GL_ALPHA_TEST);
+	glAlphaFunc(GL_GREATER, 0.1);
+	isalphatestenabled = true;
+#endif
+}
+
+void gGLRenderEngine::disableAlphaTest() {
+#if defined(WIN32) || defined(LINUX)
+	glDisable(GL_ALPHA_TEST);
+	isalphatestenabled = false;
+#endif
+}
+
+bool gGLRenderEngine::isAlphaTestEnabled() {
+	return isalphatestenabled;
+}
+
+/*
+ * Rotates The Pixel Data upside down. Hence rotates flips the image upside down
+ */
+void flipVertically(unsigned char* pixelData, int width, int height, int numChannels) {
+	int rowsize = width * numChannels;
+	unsigned char* temprow = new unsigned char[rowsize];
+
+	for(int row = 0; row < height / 2; ++row) {
+		// Calculate the corresponding row from the bottom
+		int bottomrow = height - row - 1;
+
+		// Swap the rows
+		memcpy(temprow, pixelData + row * rowsize, rowsize);
+		memcpy(pixelData + row * rowsize, pixelData + bottomrow * rowsize, rowsize);
+		memcpy(pixelData + bottomrow * rowsize, temprow, rowsize);
+	}
+
+	delete[] temprow;
+}
+
+gImage gGLRenderEngine::takeScreenshot(int x, int y, int width, int height) {
+	unsigned char* pixeldata = new unsigned char[width * height * 4];
+	glReadPixels(x, getHeight() - y - height, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixeldata);
+	flipVertically(pixeldata, width, height, 4);
+	gImage screenshot;
+	screenshot.setImageData(pixeldata, width, height, 4);
+	//std::string imagePath = "output.png";   USE IT TO SAVE THE IMAGE
+	// screenShot->saveImage(imagePath);  USE IT TO SAVE THE IMAGE
+	return screenshot;
+}
+
+gImage gGLRenderEngine::takeScreenshot() {
+	int height = gBaseApp::getAppManager()->getWindow()->getHeight();
+	int width = gBaseApp::getAppManager()->getWindow()->getWidth();
+	unsigned char* pixeldata = new unsigned char[width * height * 4];
+	glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixeldata);
+	flipVertically(pixeldata, width, height, 4);
+	gImage screenshot;
+	screenshot.setImageData(pixeldata, width, height, 4);
+	//std::string imagePath = "output.png";   USE IT TO SAVE THE IMAGE
+	// screenShot->saveImage(imagePath);  USE IT TO SAVE THE IMAGE
+	return screenshot;
+}
+
+
+GLuint gGLRenderEngine::genBuffers() {
+	GLuint buffer;
+	glGenBuffers(1, &buffer);
+	return buffer;
+}
+
+void gGLRenderEngine::deleteBuffer(GLuint* buffer) {
+	if(buffer != 0) {
+		glDeleteBuffers(1, buffer);
+	}
+}
+
+
+void gGLRenderEngine::bindBuffer(GLenum target, GLuint buffer) {
+	G_CHECK_GL(glBindBuffer(target, buffer));
+}
+
+void gGLRenderEngine::unbindBuffer(GLenum target) {
+	G_CHECK_GL(glBindBuffer(target, 0));
+}
+
+void gGLRenderEngine::bufSubData(GLuint buffer, int offset, int size, const void* data) {
+	bindBuffer(GL_UNIFORM_BUFFER, buffer);
+	G_CHECK_GL(glBufferSubData(GL_UNIFORM_BUFFER, offset, size, data));
+	unbindBuffer(GL_UNIFORM_BUFFER);
+}
+
+void gGLRenderEngine::setBufferData(GLuint buffer, const void* data, size_t size, int usage) {
+	bindBuffer(GL_UNIFORM_BUFFER, buffer);
+	G_CHECK_GL(glBufferData(GL_UNIFORM_BUFFER, size, data, usage));
+	unbindBuffer(GL_UNIFORM_BUFFER);
+}
+
+void gGLRenderEngine::setBufferRange(int index, GLuint buffer, int offset, int size) {
+	G_CHECK_GL(glBindBufferRange(GL_UNIFORM_BUFFER, index, buffer, offset, size));
+}
+
+// ----- VAO -----l
+GLuint gGLRenderEngine::createVAO() {
+	GLuint vao;
+	glGenVertexArrays(1, &vao);
+	return vao;
+}
+
+void gGLRenderEngine::deleteVAO(GLuint* vao) {
+	if(vao != 0) {
+		glDeleteVertexArrays(1, vao);
+	}
+}
+
+void gGLRenderEngine::bindVAO(GLuint vao) {
+	assert(vao != 0);
+	G_CHECK_GL(glBindVertexArray(vao));
+}
+
+void gGLRenderEngine::unbindVAO() {
+	G_CHECK_GL(glBindVertexArray(0));
+}
+
+void gGLRenderEngine::setVertexBufferData(GLuint vbo, size_t size, const void* data, int usage) {
+	assert(vbo != 0);
+	glBindBuffer(GL_ARRAY_BUFFER, vbo);
+	glBufferData(GL_ARRAY_BUFFER, size, data, usage);
+}
+
+void gGLRenderEngine::setIndexBufferData(GLuint ebo, size_t size, const void* data, int usage) {
+	assert(ebo != 0);
+	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ebo);
+	glBufferData(GL_ELEMENT_ARRAY_BUFFER, size, data, usage);
+}
+
+// ----- Draw -----
+void gGLRenderEngine::drawArrays(int drawMode, int count) {
+	G_CHECK_GL(glDrawArrays(drawMode, 0, count));
+}
+
+void gGLRenderEngine::drawElements(int drawMode, int count) {
+	G_CHECK_GL(glDrawElements(drawMode, count, GL_UNSIGNED_INT, 0));
+}
+
+// ----- vertex attributes -----
+void gGLRenderEngine::enableVertexAttrib(int index) {
+	glEnableVertexAttribArray(index);
+}
+
+void gGLRenderEngine::disableVertexAttrib(int index) {
+	glDisableVertexAttribArray(index);
+}
+
+void gGLRenderEngine::setVertexAttribPointer(int index, int size, int type, bool normalized, int stride,
+                                             const void* pointer) {
+	glVertexAttribPointer(index, size, type, normalized ? GL_TRUE : GL_FALSE, stride, pointer);
+}
+
+// ----- Framebuffer -----
+GLuint gGLRenderEngine::createFramebuffer() {
+	GLuint fbo;
+	glGenFramebuffers(1, &fbo);
+	return fbo;
+}
+
+void gGLRenderEngine::deleteFramebuffer(GLuint* fbo) {
+	if(fbo != 0) {
+		glDeleteFramebuffers(1, fbo);
+	}
+}
+
+void gGLRenderEngine::bindFramebuffer(GLuint fbo) {
+	G_CHECK_GL(glBindFramebuffer(GL_FRAMEBUFFER, fbo));
+}
+
+void gGLRenderEngine::checkFramebufferStatus() {
+	// check if fbo complete
+	GLuint status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+	if(status != GL_FRAMEBUFFER_COMPLETE) {
+		gLogi("gFbo") << "Framebuffer is not complete! status:" << gToHex(status, 4);
+	}
+}
+
+// ----- Renderbuffer -----
+GLuint gGLRenderEngine::createRenderbuffer() {
+	GLuint rbo;
+	G_CHECK_GL(glGenRenderbuffers(1, &rbo));
+	return rbo;
+}
+
+void gGLRenderEngine::deleteRenderbuffer(GLuint* rbo) {
+	if(rbo != 0) {
+		glDeleteRenderbuffers(1, rbo);
+	}
+}
+
+void gGLRenderEngine::bindRenderbuffer(GLuint rbo) {
+	assert(rbo != 0);
+	glBindRenderbuffer(GL_RENDERBUFFER, rbo);
+}
+
+void gGLRenderEngine::setRenderbufferStorage(GLenum format, int width, int height) {
+	glRenderbufferStorage(GL_RENDERBUFFER, format, width, height);
+}
+
+// ----- Attachments -----
+void gGLRenderEngine::attachTextureToFramebuffer(GLenum attachment, GLenum textarget, GLuint texId, GLuint level) {
+	G_CHECK_GL(glFramebufferTexture2D(GL_FRAMEBUFFER, attachment, textarget, texId, level));
+}
+
+void gGLRenderEngine::attachRenderbufferToFramebuffer(GLenum attachment, GLuint rbo) {
+	G_CHECK_GL(glFramebufferRenderbuffer(GL_FRAMEBUFFER, attachment, GL_RENDERBUFFER, rbo));
+}
+
+// ----- Draw/Read buffers -----
+void gGLRenderEngine::setDrawBufferNone() {
+#if defined(GLIST_MOBILE)
+	G_CHECK_GL(glDrawBuffers(0, GL_NONE));
+#else
+	G_CHECK_GL(glDrawBuffer(GL_NONE));
+#endif
+}
+
+void gGLRenderEngine::setReadBufferNone() {
+	G_CHECK_GL(glReadBuffer(GL_NONE));
+}
+
+// ----- Fullscreen Quad -----
+void gGLRenderEngine::createFullscreenQuad(GLuint& vao, GLuint& vbo) {
+	float quadVertices[] = {
+		// positions   // texCoords
+		-1.0f, 1.0f, 0.0f, 1.0f,
+		-1.0f, -1.0f, 0.0f, 0.0f,
+		1.0f, -1.0f, 1.0f, 0.0f,
+
+		-1.0f, 1.0f, 0.0f, 1.0f,
+		1.0f, -1.0f, 1.0f, 0.0f,
+		1.0f, 1.0f, 1.0f, 1.0f
+	};
+
+	glGenVertexArrays(1, &vao);
+	glGenBuffers(1, &vbo);
+
+	glBindVertexArray(vao);
+	glBindBuffer(GL_ARRAY_BUFFER, vbo);
+	glBufferData(GL_ARRAY_BUFFER, sizeof(quadVertices), &quadVertices, GL_STATIC_DRAW);
+
+	glEnableVertexAttribArray(0);
+	glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)0);
+
+	glEnableVertexAttribArray(1);
+	glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)(2 * sizeof(float)));
+}
+
+void gGLRenderEngine::deleteFullscreenQuad(GLuint* vao, GLuint* vbo) {
+	if(vao != 0)
+		glDeleteVertexArrays(1, vao);
+	if(vbo != 0)
+		glDeleteBuffers(1, vbo);
+}
+
+GLuint gGLRenderEngine::loadProgram(const char* vertexSource, const char* fragmentSource, const char* geometrySource) {
+	unsigned int vertex = GL_NONE;
+	unsigned int fragment = GL_NONE;
+#if defined(WIN32) || defined(LINUX)
+	unsigned int geometry = GL_NONE;
+#endif
+	// vertex shader
+	G_CHECK_GL2(vertex, glCreateShader(GL_VERTEX_SHADER));
+	glShaderSource(vertex, 1, &vertexSource, nullptr);
+	glCompileShader(vertex);
+	checkCompileErrors(vertex, "VERTEX");
+
+	// fragment Shader
+	G_CHECK_GL2(fragment, glCreateShader(GL_FRAGMENT_SHADER));
+	glShaderSource(fragment, 1, &fragmentSource, nullptr);
+	glCompileShader(fragment);
+	checkCompileErrors(fragment, "FRAGMENT");
+
+	// if geometry shader is given, compile geometry shader
+#if defined(WIN32) || defined(LINUX)
+	if(geometrySource != nullptr) {
+		geometry = glCreateShader(GL_GEOMETRY_SHADER);
+		glShaderSource(geometry, 1, &geometrySource, nullptr);
+		glCompileShader(geometry);
+		checkCompileErrors(geometry, "GEOMETRY");
+	}
+#endif
+
+	// shader Program
+	GLuint id = glCreateProgram();
+	glAttachShader(id, vertex);
+	glAttachShader(id, fragment);
+#if defined(WIN32) || defined(LINUX)
+	if(geometrySource != nullptr)
+		glAttachShader(id, geometry);
+#endif
+	glLinkProgram(id);
+	checkCompileErrors(id, "PROGRAM");
+	// delete the shaders as they're linked into our program now and no longer necessery
+	glDeleteShader(vertex);
+	glDeleteShader(fragment);
+#if defined(WIN32) || defined(LINUX)
+	if(geometrySource != nullptr)
+		glDeleteShader(geometry);
+#endif
+
+	return id;
+}
+
+void gGLRenderEngine::checkCompileErrors(GLuint shader, const std::string& type) {
+	GLint success;
+	GLchar infoLog[1024];
+	if(type != "PROGRAM") {
+		G_CHECK_GL(glGetShaderiv(shader, GL_COMPILE_STATUS, &success));
+		if(!success) {
+			glGetShaderInfoLog(shader, 1024, nullptr, infoLog);
+			gLoge("gShader") << "ERROR::SHADER_COMPILATION_ERROR of type: " << type << "\n" << infoLog <<
+					"\n -- --------------------------------------------------- -- " << std::endl;
+		}
+	} else {
+		glGetProgramiv(shader, GL_LINK_STATUS, &success);
+		if(!success) {
+			glGetProgramInfoLog(shader, 1024, nullptr, infoLog);
+			gLoge("gShader") << "ERROR::PROGRAM_LINKING_ERROR of type: " << type << "\n" << infoLog <<
+					"\n -- --------------------------------------------------- -- " << std::endl;
+		}
+	}
+#ifdef DEBUG
+	assert(success);
+#endif
+}
+
+void gGLRenderEngine::setBool(GLuint id, const std::string& name, bool value) {
+	G_CHECK_GL(glUniform1i(getUniformLocation(id, name), (int)value));
+}
+
+void gGLRenderEngine::setInt(GLuint id, const std::string& name, int value) {
+	G_CHECK_GL(glUniform1i(getUniformLocation(id, name), value));
+}
+
+void gGLRenderEngine::setFloat(GLuint id, const std::string& name, float value) {
+	G_CHECK_GL(glUniform1f(getUniformLocation(id, name), value));
+}
+
+void gGLRenderEngine::setVec2(GLuint id, const std::string& name, const glm::vec2& value) {
+	G_CHECK_GL(glUniform2fv(getUniformLocation(id, name), 1, &value[0]));
+}
+
+void gGLRenderEngine::setVec2(GLuint id, const std::string& name, float x, float y) {
+	G_CHECK_GL(glUniform2f(getUniformLocation(id, name), x, y));
+}
+
+void gGLRenderEngine::setVec3(GLuint id, const std::string& name, const glm::vec3& value) {
+	G_CHECK_GL(glUniform3fv(getUniformLocation(id, name), 1, &value[0]));
+}
+
+void gGLRenderEngine::setVec3(GLuint id, const std::string& name, float x, float y, float z) {
+	G_CHECK_GL(glUniform3f(getUniformLocation(id, name), x, y, z));
+}
+
+void gGLRenderEngine::setVec4(GLuint id, const std::string& name, const glm::vec4& value) {
+	G_CHECK_GL(glUniform4fv(getUniformLocation(id, name), 1, &value[0]));
+}
+
+void gGLRenderEngine::setVec4(GLuint id, const std::string& name, float x, float y, float z, float w) {
+	G_CHECK_GL(glUniform4f(getUniformLocation(id, name), x, y, z, w));
+}
+
+void gGLRenderEngine::setMat2(GLuint id, const std::string& name, const glm::mat2& mat) {
+	G_CHECK_GL(glUniformMatrix2fv(getUniformLocation(id, name), 1, GL_FALSE, &mat[0][0]));
+}
+
+void gGLRenderEngine::setMat3(GLuint id, const std::string& name, const glm::mat3& mat) {
+	G_CHECK_GL(glUniformMatrix3fv(getUniformLocation(id, name), 1, GL_FALSE, &mat[0][0]));
+}
+
+void gGLRenderEngine::setMat4(GLuint id, const std::string& name, const glm::mat4& mat) {
+	G_CHECK_GL(glUniformMatrix4fv(getUniformLocation(id, name), 1, GL_FALSE, &mat[0][0]));
+}
+
+void gGLRenderEngine::useShader(GLuint id) const {
+	G_CHECK_GL(glUseProgram(id));
+}
+
+void gGLRenderEngine::resetShader(GLuint id, bool loaded) const {
+	if(loaded) {
+		glDeleteShader(id);
+	}
+}
+
+GLint gGLRenderEngine::getUniformLocation(GLuint id, const std::string& name) {
+	return glGetUniformLocation(id, name.c_str());
+}
+
+void gGLRenderEngine::clearScreen(bool color, bool depth) {
+	GLbitfield mask = 0;
+	if(color) mask |= GL_COLOR_BUFFER_BIT;
+	if(depth) mask |= GL_DEPTH_BUFFER_BIT;
+	glClear(mask);
+}
+
+void gGLRenderEngine::bindQuadVAO() {
+	G_CHECK_GL(glBindVertexArray(gFbo::getQuadVao()));
+}
+
+void gGLRenderEngine::drawFullscreenQuad() {
+	glDrawArrays(GL_TRIANGLES, 0, 6);
+}
+
+void gGLRenderEngine::bindDefaultFramebuffer() {
+	glBindFramebuffer(GL_FRAMEBUFFER, gFbo::defaultfbo);
+}
+
+void gGLRenderEngine::drawVbo(const gVbo& vbo) {
+	G_CHECK_GL(glDrawArrays(GL_TRIANGLES, 0, vbo.getVerticesNum()));
+}
+
+GLuint gGLRenderEngine::createTextures() {
+	GLuint id;
+	G_CHECK_GL(glGenTextures(1, &id));
+	return id;
+}
+
+void gGLRenderEngine::bindTexture(GLuint texId) {
+	G_CHECK_GL(glBindTexture(GL_TEXTURE_2D, texId));
+}
+
+void gGLRenderEngine::bindTexture(GLuint texId, int textureSlotNo) {
+	G_CHECK_GL(glActiveTexture(GL_TEXTURE0 + textureSlotNo));
+	G_CHECK_GL(glBindTexture(GL_TEXTURE_2D, texId));
+}
+
+void gGLRenderEngine::unbindTexture() {
+	G_CHECK_GL(glBindTexture(GL_TEXTURE_2D, 0));
+}
+
+void gGLRenderEngine::activateTexture(int textureSlotNo) {
+	G_CHECK_GL(glActiveTexture(GL_TEXTURE0 + textureSlotNo));
+}
+
+void gGLRenderEngine::resetTexture() {
+	G_CHECK_GL(glActiveTexture(GL_TEXTURE0));
+}
+
+void gGLRenderEngine::deleteTexture(GLuint* texId) {
+	G_CHECK_GL(glDeleteTextures(1, texId));
+}
+
+void gGLRenderEngine::texImage2D(GLenum target, GLint internalFormat, int width, int height, GLint format,
+                                 GLint type, void* data) {
+	G_CHECK_GL(glTexImage2D(target, 0, internalFormat, width, height, 0, format, type, data));
+}
+
+void gGLRenderEngine::setWrapping(GLenum target, GLint wrapS, GLint wrapT) {
+	G_CHECK_GL(glTexParameteri(target, GL_TEXTURE_WRAP_S, wrapS));
+	G_CHECK_GL(glTexParameteri(target, GL_TEXTURE_WRAP_T, wrapT));
+}
+
+void gGLRenderEngine::setWrapping(GLenum target, GLint wrapS, GLint wrapT, GLint wrapR) {
+	G_CHECK_GL(glTexParameteri(target, GL_TEXTURE_WRAP_S, wrapS));
+	G_CHECK_GL(glTexParameteri(target, GL_TEXTURE_WRAP_T, wrapT));
+	G_CHECK_GL(glTexParameteri(target, GL_TEXTURE_WRAP_R, wrapR));
+}
+
+void gGLRenderEngine::setFiltering(GLenum target, GLint minFilter, GLint magFilter) {
+	G_CHECK_GL(glTexParameteri(target, GL_TEXTURE_MIN_FILTER, minFilter));
+	G_CHECK_GL(glTexParameteri(target, GL_TEXTURE_MAG_FILTER, magFilter));
+}
+
+void gGLRenderEngine::setWrappingAndFiltering(GLenum target, GLint wrapS, GLint wrapT, GLint minFilter,
+                                              GLint magFilter) {
+	G_CHECK_GL(glTexParameteri(target, GL_TEXTURE_WRAP_S, wrapS));
+	G_CHECK_GL(glTexParameteri(target, GL_TEXTURE_WRAP_T, wrapT));
+	G_CHECK_GL(glTexParameteri(target, GL_TEXTURE_MIN_FILTER, minFilter));
+	G_CHECK_GL(glTexParameteri(target, GL_TEXTURE_MAG_FILTER, magFilter));
+}
+
+void gGLRenderEngine::setWrappingAndFiltering(GLenum target, GLint wrapS, GLint wrapT, GLint wrapR, GLint minFilter,
+                                              GLint magFilter) {
+	G_CHECK_GL(glTexParameteri(target, GL_TEXTURE_WRAP_S, wrapS));
+	G_CHECK_GL(glTexParameteri(target, GL_TEXTURE_WRAP_T, wrapT));
+	G_CHECK_GL(glTexParameteri(target, GL_TEXTURE_WRAP_R, wrapR));
+	G_CHECK_GL(glTexParameteri(target, GL_TEXTURE_MIN_FILTER, minFilter));
+	G_CHECK_GL(glTexParameteri(target, GL_TEXTURE_MAG_FILTER, magFilter));
+}
+
+void gGLRenderEngine::setSwizzleMask(GLint swizzleMask[4]) {
+#if defined(GLIST_MOBILE)
+	G_CHECK_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, swizzleMask[0]));
+	G_CHECK_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_G, swizzleMask[1]));
+	G_CHECK_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, swizzleMask[2]));
+	G_CHECK_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, swizzleMask[3]));
+#else
+	G_CHECK_GL(glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleMask));
+#endif
+}
+
+void gGLRenderEngine::readTexturePixels(unsigned char* inPixels, GLuint textureId, int width, int height,
+                                        GLenum format) {
+	GLuint fbo;
+	glGenFramebuffers(1, &fbo);
+	glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, textureId, 0);
+
+	glReadPixels(0, 0, width, height, format, GL_UNSIGNED_BYTE, inPixels);
+
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	glDeleteFramebuffers(1, &fbo);
+}
+
+void gGLRenderEngine::generateMipMap() {
+	G_CHECK_GL(glGenerateMipmap(GL_TEXTURE_2D));
+}
+
+void gGLRenderEngine::bindSkyTexture(GLuint texId) {
+	G_CHECK_GL(glBindTexture(GL_TEXTURE_CUBE_MAP, texId));
+}
+
+void gGLRenderEngine::bindSkyTexture(GLuint texId, int textureSlot) {
+	G_CHECK_GL(glActiveTexture(textureSlot));
+	G_CHECK_GL(glBindTexture(GL_TEXTURE_CUBE_MAP, texId));
+}
+
+void gGLRenderEngine::unbindSkyTexture() {
+	glBindTexture(GL_TEXTURE_CUBE_MAP, 0);
+}
+
+void gGLRenderEngine::unbindSkyTexture(int textureSlotNo) {
+	G_CHECK_GL(glActiveTexture(GL_TEXTURE0 + textureSlotNo));
+	G_CHECK_GL(glBindTexture(GL_TEXTURE_CUBE_MAP, 0));
+}
+
+void gGLRenderEngine::generateSkyMipMap() {
+	G_CHECK_GL(glGenerateMipmap(GL_TEXTURE_CUBE_MAP));
+}
+
+void gGLRenderEngine::enableDepthTestEqual() {
+	G_CHECK_GL(glDepthFunc(GL_LEQUAL));
+}
+
+void gGLRenderEngine::createQuad(GLuint& inQuadVAO, GLuint& inQuadVBO) {
+	float quadVertices[] = {
+		// positions        // texture Coords
+		-1.0f, 1.0f, 0.0f, 0.0f, 1.0f,
+		-1.0f, -1.0f, 0.0f, 0.0f, 0.0f,
+		1.0f, 1.0f, 0.0f, 1.0f, 1.0f,
+		1.0f, -1.0f, 0.0f, 1.0f, 0.0f,
+	};
+	// setup plane VAO
+	glGenVertexArrays(1, &inQuadVAO);
+	glGenBuffers(1, &inQuadVBO);
+	glBindVertexArray(inQuadVAO);
+	glBindBuffer(GL_ARRAY_BUFFER, inQuadVBO);
+	glBufferData(GL_ARRAY_BUFFER, sizeof(quadVertices), &quadVertices, GL_STATIC_DRAW);
+	glEnableVertexAttribArray(0);
+	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*)0);
+	glEnableVertexAttribArray(1);
+	glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*)(3 * sizeof(float)));
+}

--- a/engine/core/gGLRenderEngine.cpp
+++ b/engine/core/gGLRenderEngine.cpp
@@ -7,7 +7,66 @@
 //screenShot Related includes
 #include "stb/stb_image_write.h"
 #include "gBaseApp.h"
+#include "gGrid.h"
 #include "gImage.h"
+#include "gShader.h"
+
+void gCheckGLErrorAndPrint(const std::string& prefix, const std::string& func, int line) {
+	GLenum error = glGetError();
+	if (error != GL_NO_ERROR) {
+		gLogi("gGLRenderEngine") << prefix << "OpenGL ERROR at " << func << ", line " << line << ", error: " << gToHex(error, 4);
+	}
+}
+void gEnableCulling() {
+	glEnable(GL_CULL_FACE);
+}
+
+void gDisableCulling() {
+	glDisable(GL_CULL_FACE);
+}
+
+bool gIsCullingEnabled() {
+	return glIsEnabled(GL_CULL_FACE);
+}
+
+void gCullFace(int cullingFace) {
+	glCullFace(cullingFace);
+}
+
+int gGetCullFace() {
+	GLint i;
+	glGetIntegerv(GL_CULL_FACE_MODE, &i);
+	return i;
+}
+
+void gSetCullingDirection(int cullingDirection) {
+	glFrontFace(cullingDirection);
+}
+
+int gGetCullingDirection() {
+	GLint i;
+	glGetIntegerv(GL_FRONT_FACE, &i);
+	return i;
+}
+
+gGLRenderEngine::~gGLRenderEngine() {
+	delete colorshader;
+	delete textureshader;
+	delete imageshader;
+	delete fontshader;
+	delete skyboxshader;
+	delete shadowmapshader;
+	delete pbrshader;
+	delete equirectangularshader;
+	delete irradianceshader;
+	delete prefiltershader;
+	delete brdfshader;
+	delete fboshader;
+	delete rendercolor;
+	delete lightsubo;
+	delete gridshader;
+	if(!isdevelopergrid) delete originalgrid;
+}
 
 void gGLRenderEngine::clear() {
 	G_CHECK_GL(glClearColor(0.0f, 0.0f, 0.0f, 1.0f));

--- a/engine/core/gGLRenderEngine.cpp
+++ b/engine/core/gGLRenderEngine.cpp
@@ -682,6 +682,20 @@ void gGLRenderEngine::createQuad(GLuint& inQuadVAO, GLuint& inQuadVBO) {
 	glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*)(3 * sizeof(float)));
 }
 
+void gGLRenderEngine::enableCubeMapSeemless() {
+#if defined(GLIST_MOBILE)
+	glEnable(GL_TEXTURE_CUBE_MAP); // OpenGL ES does not support GL_TEXTURE_CUBE_MAP_SEAMLESS
+#else
+	glEnable(GL_TEXTURE_CUBE_MAP_SEAMLESS);
+#endif
+}
+
+void gGLRenderEngine::checkEnableCubeMap4Android() {
+#if defined(ANDROID)
+	G_CHECK_GL(glEnable(GL_TEXTURE_CUBE_MAP)); // OpenGL ES does not support GL_TEXTURE_CUBE_MAP_SEAMLESS
+#endif
+}
+
 void gGLRenderEngine::pushMatrix() {
 	G_CHECK_GL(glPushMatrix());
 }

--- a/engine/core/gGLRenderEngine.cpp
+++ b/engine/core/gGLRenderEngine.cpp
@@ -195,7 +195,9 @@ GLuint gGLRenderEngine::genBuffers() {
 }
 
 void gGLRenderEngine::deleteBuffer(GLuint& buffer) {
-	glDeleteBuffers(1, &buffer);
+	if (buffer != 0) {
+		glDeleteBuffers(1, &buffer);
+	}
 }
 
 void gGLRenderEngine::bindBuffer(GLenum target, GLuint buffer) {
@@ -567,7 +569,9 @@ void gGLRenderEngine::resetTexture() {
 }
 
 void gGLRenderEngine::deleteTexture(GLuint& texId) {
-	G_CHECK_GL(glDeleteTextures(1, &texId));
+	if (texId != 0) {
+		G_CHECK_GL(glDeleteTextures(1, &texId));
+	}
 }
 
 void gGLRenderEngine::texImage2D(GLenum target, GLint internalFormat, int width, int height, GLint format,

--- a/engine/core/gGLRenderEngine.cpp
+++ b/engine/core/gGLRenderEngine.cpp
@@ -167,28 +167,24 @@ void flipVertically(unsigned char* pixelData, int width, int height, int numChan
 	delete[] temprow;
 }
 
-gImage gGLRenderEngine::takeScreenshot(int x, int y, int width, int height) {
+void gGLRenderEngine::takeScreenshot(gImage& img, int x, int y, int width, int height) {
 	unsigned char* pixeldata = new unsigned char[width * height * 4];
 	glReadPixels(x, getHeight() - y - height, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixeldata);
 	flipVertically(pixeldata, width, height, 4);
-	gImage screenshot;
-	screenshot.setImageData(pixeldata, width, height, 4);
+	img.setImageData(pixeldata, width, height, 4);
 	//std::string imagePath = "output.png";   USE IT TO SAVE THE IMAGE
 	// screenShot->saveImage(imagePath);  USE IT TO SAVE THE IMAGE
-	return screenshot;
 }
 
-gImage gGLRenderEngine::takeScreenshot() {
+void gGLRenderEngine::takeScreenshot(gImage& img) {
 	int height = gBaseApp::getAppManager()->getWindow()->getHeight();
 	int width = gBaseApp::getAppManager()->getWindow()->getWidth();
 	unsigned char* pixeldata = new unsigned char[width * height * 4];
 	glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixeldata);
 	flipVertically(pixeldata, width, height, 4);
-	gImage screenshot;
-	screenshot.setImageData(pixeldata, width, height, 4);
+	img.setImageData(pixeldata, width, height, 4);
 	//std::string imagePath = "output.png";   USE IT TO SAVE THE IMAGE
 	// screenShot->saveImage(imagePath);  USE IT TO SAVE THE IMAGE
-	return screenshot;
 }
 
 
@@ -198,12 +194,9 @@ GLuint gGLRenderEngine::genBuffers() {
 	return buffer;
 }
 
-void gGLRenderEngine::deleteBuffer(GLuint* buffer) {
-	if(buffer != 0) {
-		glDeleteBuffers(1, buffer);
-	}
+void gGLRenderEngine::deleteBuffer(GLuint& buffer) {
+	glDeleteBuffers(1, &buffer);
 }
-
 
 void gGLRenderEngine::bindBuffer(GLenum target, GLuint buffer) {
 	G_CHECK_GL(glBindBuffer(target, buffer));
@@ -236,9 +229,9 @@ GLuint gGLRenderEngine::createVAO() {
 	return vao;
 }
 
-void gGLRenderEngine::deleteVAO(GLuint* vao) {
+void gGLRenderEngine::deleteVAO(GLuint& vao) {
 	if(vao != 0) {
-		glDeleteVertexArrays(1, vao);
+		glDeleteVertexArrays(1, &vao);
 	}
 }
 
@@ -293,9 +286,9 @@ GLuint gGLRenderEngine::createFramebuffer() {
 	return fbo;
 }
 
-void gGLRenderEngine::deleteFramebuffer(GLuint* fbo) {
+void gGLRenderEngine::deleteFramebuffer(GLuint& fbo) {
 	if(fbo != 0) {
-		glDeleteFramebuffers(1, fbo);
+		glDeleteFramebuffers(1, &fbo);
 	}
 }
 
@@ -318,9 +311,9 @@ GLuint gGLRenderEngine::createRenderbuffer() {
 	return rbo;
 }
 
-void gGLRenderEngine::deleteRenderbuffer(GLuint* rbo) {
+void gGLRenderEngine::deleteRenderbuffer(GLuint& rbo) {
 	if(rbo != 0) {
-		glDeleteRenderbuffers(1, rbo);
+		glDeleteRenderbuffers(1, &rbo);
 	}
 }
 
@@ -382,9 +375,9 @@ void gGLRenderEngine::createFullscreenQuad(GLuint& vao, GLuint& vbo) {
 	glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)(2 * sizeof(float)));
 }
 
-void gGLRenderEngine::deleteFullscreenQuad(GLuint* vao, GLuint* vbo) {
+void gGLRenderEngine::deleteFullscreenQuad(GLuint& vao, GLuint* vbo) {
 	if(vao != 0)
-		glDeleteVertexArrays(1, vao);
+		glDeleteVertexArrays(1, &vao);
 	if(vbo != 0)
 		glDeleteBuffers(1, vbo);
 }
@@ -573,8 +566,8 @@ void gGLRenderEngine::resetTexture() {
 	G_CHECK_GL(glActiveTexture(GL_TEXTURE0));
 }
 
-void gGLRenderEngine::deleteTexture(GLuint* texId) {
-	G_CHECK_GL(glDeleteTextures(1, texId));
+void gGLRenderEngine::deleteTexture(GLuint& texId) {
+	G_CHECK_GL(glDeleteTextures(1, &texId));
 }
 
 void gGLRenderEngine::texImage2D(GLenum target, GLint internalFormat, int width, int height, GLint format,

--- a/engine/core/gGLRenderEngine.cpp
+++ b/engine/core/gGLRenderEngine.cpp
@@ -681,3 +681,16 @@ void gGLRenderEngine::createQuad(GLuint& inQuadVAO, GLuint& inQuadVBO) {
 	glEnableVertexAttribArray(1);
 	glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*)(3 * sizeof(float)));
 }
+
+void gGLRenderEngine::pushMatrix() {
+	G_CHECK_GL(glPushMatrix());
+}
+
+void gGLRenderEngine::popMatrix() {
+	G_CHECK_GL(glPopMatrix());
+}
+
+void gGLRenderEngine::updatePackUnpackAlignment(int i) {
+	glPixelStorei(GL_UNPACK_ALIGNMENT, i);
+	glPixelStorei(GL_PACK_ALIGNMENT, i);
+}

--- a/engine/core/gGLRenderEngine.h
+++ b/engine/core/gGLRenderEngine.h
@@ -12,7 +12,7 @@
 class gGLRenderEngine : public gRenderer {
 public:
 	gGLRenderEngine() = default;
-	~gGLRenderEngine() = default;
+	~gGLRenderEngine();
 
 	void clear();
 	void clearColor(int r, int g, int b, int a = 255);

--- a/engine/core/gGLRenderEngine.h
+++ b/engine/core/gGLRenderEngine.h
@@ -1,0 +1,171 @@
+//
+// Created by sadettin on 13.08.2025.
+//
+
+#pragma once
+
+#ifndef CORE_GGLENGINERENDERER_H
+#define CORE_GGLENGINERENDERER_H
+#include "gRenderer.h"
+
+class gGLRenderEngine : public gRenderer {
+public:
+	gGLRenderEngine() = default;
+	~gGLRenderEngine() = default;
+
+	void clear();
+	void clearColor(int r, int g, int b, int a = 255);
+	void clearColor(gColor color);
+
+	gImage takeScreenshot(int x, int y, int width, int height);
+	gImage takeScreenshot();
+
+	void enableDepthTest();
+	void enableDepthTest(int depthTestType);
+	void setDepthTestFunc(int depthTestType);
+	void disableDepthTest();
+	bool isDepthTestEnabled();
+	int getDepthTestType();
+
+	void enableAlphaBlending();
+	void disableAlphaBlending();
+	bool isAlphaBlendingEnabled();
+	void enableAlphaTest();
+	void disableAlphaTest();
+	bool isAlphaTestEnabled();
+
+	/* -------------- gUbo ------------- */
+	GLuint genBuffers();
+	void deleteBuffer(GLuint* buffer);
+
+	void bindBuffer(GLenum target, GLuint buffer);
+	void unbindBuffer(GLenum target);
+
+	void bufSubData(GLuint buffer, int offset, int size, const void* data);
+	void setBufferData(GLuint buffer, const void* data, size_t size, int usage);
+	void setBufferRange(int index, GLuint buffer, int offset, int size);
+
+	/* -------------- gVbo --------------- */
+	GLuint createVAO();
+	void deleteVAO(GLuint* vao);
+
+	void bindVAO(GLuint vao);
+	void unbindVAO();
+
+	void setVertexBufferData(GLuint vbo, size_t size, const void* data, int usage);
+	void setIndexBufferData(GLuint ebo, size_t size, const void* data, int usage);
+
+	void drawArrays(int drawMode, int count);
+	void drawElements(int drawMode, int count);
+
+	void enableVertexAttrib(int index);
+	void disableVertexAttrib(int index);
+	void setVertexAttribPointer(int index, int size, int type, bool normalized, int stride, const void* pointer);
+
+	/* -------------- gFbo --------------- */
+	GLuint createFramebuffer();
+	void deleteFramebuffer(GLuint* fbo);
+	void bindFramebuffer(GLuint fbo);
+	void checkFramebufferStatus();
+
+	GLuint createRenderbuffer();
+	void deleteRenderbuffer(GLuint* rbo);
+	void bindRenderbuffer(GLuint rbo);
+	void setRenderbufferStorage(GLenum format, int width, int height);
+
+	void attachTextureToFramebuffer(GLenum attachment, GLenum textarget, GLuint texId, GLuint level = 0);
+	void attachRenderbufferToFramebuffer(GLenum attachment, GLuint rbo);
+
+	void setDrawBufferNone();
+	void setReadBufferNone();
+
+	void createFullscreenQuad(GLuint& vao, GLuint& vbo);
+	void deleteFullscreenQuad(GLuint* vao, GLuint* vbo);
+
+	/* -------------- gShader --------------- */
+	// This function loads shaders without preproccesing them. Geometry source can be nullptr.
+	GLuint loadProgram(const char* vertexSource, const char* fragmentSource, const char* geometrySource);
+	void checkCompileErrors(GLuint shader, const std::string& type);
+	void setBool(GLuint id, const std::string& name, bool value);
+	void setInt(GLuint id, const std::string& name, int value);
+	void setFloat(GLuint id, const std::string& name, float value);
+	void setVec2(GLuint id, const std::string& name, const glm::vec2& value);
+	void setVec2(GLuint id, const std::string& name, float x, float y);
+	void setVec3(GLuint id, const std::string& name, const glm::vec3& value);
+	void setVec3(GLuint id, const std::string& name, float x, float y, float z);
+	void setVec4(GLuint id, const std::string& name, const glm::vec4& value);
+	void setVec4(GLuint id, const std::string& name, float x, float y, float z, float w);
+	void setMat2(GLuint id, const std::string& name, const glm::mat2& mat);
+	void setMat3(GLuint id, const std::string& name, const glm::mat3& mat);
+	void setMat4(GLuint id, const std::string& name, const glm::mat4& mat);
+
+	void useShader(GLuint id) const;
+	void resetShader(GLuint id, bool loaded) const;
+	GLint getUniformLocation(GLuint id, const std::string& name);
+
+	template<typename T>
+	void attachUbo(GLuint id, const gUbo<T>* ubo, const std::string& uboName) {
+		unsigned int blockIndex;
+		G_CHECK_GL2(blockIndex, glGetUniformBlockIndex(id, uboName.c_str()));
+		G_CHECK_GL(glUniformBlockBinding(id, blockIndex, ubo->getBindingPoint()));
+		/*if (blockIndex != GL_INVALID_INDEX) {
+			GLint blockSize;
+			G_CHECK_GL(glGetActiveUniformBlockiv(id, blockIndex, GL_UNIFORM_BLOCK_DATA_SIZE, &blockSize));
+
+			GLint blockAlignment;
+			G_CHECK_GL(glGetIntegerv(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, &blockAlignment));
+
+			std::cout << "Uniform block alignment: " << blockAlignment << " bytes" << std::endl;
+
+			// Now 'blockSize' contains the size of the uniform block in bytes
+			std::cout << "Uniform block size: " << blockSize << " bytes" << std::endl;
+			if (ubo->getSize() != blockSize) {
+				std::cout << "Error: Uniform block size mismatch. actual size: " << ubo->getSize() << ", block size: " << blockSize << std::endl;
+			}
+		} else {
+			std::cerr << "Error: Unable to find uniform block index." << std::endl;
+		}*/
+	}
+
+	/* ------------ gPostProcessManager ------------- */
+	void clearScreen(bool color = true, bool depth = true);
+	void bindQuadVAO();
+	void drawFullscreenQuad();
+	void bindDefaultFramebuffer();
+
+	/* -------------- gGrid --------------- */
+	void drawVbo(const gVbo& vbo);
+
+	/* ---------------- gTexture ---------------- */
+	GLuint createTextures();
+	void bindTexture(GLuint texId);
+	void bindTexture(GLuint texId, int textureSlotNo);
+	void unbindTexture();
+	void activateTexture(int textureSlotNo = 0);
+	void resetTexture();
+	void deleteTexture(GLuint* texId);
+
+	void texImage2D(GLenum target, GLint internalFormat, int width, int height, GLint format, GLint type, void* data);
+	void setWrapping(GLenum target, GLint wrapS, GLint wrapT);
+	void setWrapping(GLenum target, GLint wrapS, GLint wrapT, GLint wrapR);
+
+	void setFiltering(GLenum target, GLint minFilter, GLint magFilter);
+	void setWrappingAndFiltering(GLenum target, GLint wrapS, GLint wrapT, GLint minFilter, GLint magFilter);
+	void setWrappingAndFiltering(GLenum target, GLint wrapS, GLint wrapT, GLint wrapR, GLint minFilter, GLint magFilter);
+	void setSwizzleMask(GLint swizzleMask[4]);
+
+	void readTexturePixels(unsigned char* inPixels, GLuint textureId, int width, int height, GLenum format);
+
+	void generateMipMap();
+
+	/* ---------------- gSkybox ---------------- */
+	void bindSkyTexture(GLuint texId);
+	void bindSkyTexture(GLuint texId, int textureSlot);
+	void unbindSkyTexture();
+	void unbindSkyTexture(int textureSlotNo);
+	void generateSkyMipMap();
+	void enableDepthTestEqual();
+	void createQuad(GLuint& inQuadVAO, GLuint& inQuadVBO);
+};
+
+#endif

--- a/engine/core/gGLRenderEngine.h
+++ b/engine/core/gGLRenderEngine.h
@@ -166,6 +166,12 @@ public:
 	void generateSkyMipMap();
 	void enableDepthTestEqual();
 	void createQuad(GLuint& inQuadVAO, GLuint& inQuadVBO);
+
+	/* ---------------- gRenderObject ---------------- */
+	void pushMatrix();
+	void popMatrix();
+private:
+	void updatePackUnpackAlignment(int i);
 };
 
 #endif

--- a/engine/core/gGLRenderEngine.h
+++ b/engine/core/gGLRenderEngine.h
@@ -166,6 +166,8 @@ public:
 	void generateSkyMipMap();
 	void enableDepthTestEqual();
 	void createQuad(GLuint& inQuadVAO, GLuint& inQuadVBO);
+	void enableCubeMapSeemless();
+	void checkEnableCubeMap4Android();
 
 	/* ---------------- gRenderObject ---------------- */
 	void pushMatrix();

--- a/engine/core/gGLRenderEngine.h
+++ b/engine/core/gGLRenderEngine.h
@@ -18,8 +18,8 @@ public:
 	void clearColor(int r, int g, int b, int a = 255);
 	void clearColor(gColor color);
 
-	gImage takeScreenshot(int x, int y, int width, int height);
-	gImage takeScreenshot();
+	void takeScreenshot(gImage& img, int x, int y, int width, int height);
+	void takeScreenshot(gImage& img);
 
 	void enableDepthTest();
 	void enableDepthTest(int depthTestType);
@@ -37,7 +37,7 @@ public:
 
 	/* -------------- gUbo ------------- */
 	GLuint genBuffers();
-	void deleteBuffer(GLuint* buffer);
+	void deleteBuffer(GLuint& buffer);
 
 	void bindBuffer(GLenum target, GLuint buffer);
 	void unbindBuffer(GLenum target);
@@ -48,7 +48,7 @@ public:
 
 	/* -------------- gVbo --------------- */
 	GLuint createVAO();
-	void deleteVAO(GLuint* vao);
+	void deleteVAO(GLuint& vao);
 
 	void bindVAO(GLuint vao);
 	void unbindVAO();
@@ -65,12 +65,12 @@ public:
 
 	/* -------------- gFbo --------------- */
 	GLuint createFramebuffer();
-	void deleteFramebuffer(GLuint* fbo);
+	void deleteFramebuffer(GLuint& fbo);
 	void bindFramebuffer(GLuint fbo);
 	void checkFramebufferStatus();
 
 	GLuint createRenderbuffer();
-	void deleteRenderbuffer(GLuint* rbo);
+	void deleteRenderbuffer(GLuint& rbo);
 	void bindRenderbuffer(GLuint rbo);
 	void setRenderbufferStorage(GLenum format, int width, int height);
 
@@ -81,7 +81,7 @@ public:
 	void setReadBufferNone();
 
 	void createFullscreenQuad(GLuint& vao, GLuint& vbo);
-	void deleteFullscreenQuad(GLuint* vao, GLuint* vbo);
+	void deleteFullscreenQuad(GLuint& vao, GLuint* vbo);
 
 	/* -------------- gShader --------------- */
 	// This function loads shaders without preproccesing them. Geometry source can be nullptr.
@@ -143,7 +143,7 @@ public:
 	void unbindTexture();
 	void activateTexture(int textureSlotNo = 0);
 	void resetTexture();
-	void deleteTexture(GLuint* texId);
+	void deleteTexture(GLuint& texId);
 
 	void texImage2D(GLenum target, GLint internalFormat, int width, int height, GLint format, GLint type, void* data);
 	void setWrapping(GLenum target, GLint wrapS, GLint wrapT);

--- a/engine/core/gGLRenderEngine.h
+++ b/engine/core/gGLRenderEngine.h
@@ -7,6 +7,7 @@
 #ifndef CORE_GGLENGINERENDERER_H
 #define CORE_GGLENGINERENDERER_H
 #include "gRenderer.h"
+#include "gUbo.h"
 
 class gGLRenderEngine : public gRenderer {
 public:
@@ -103,8 +104,7 @@ public:
 	void resetShader(GLuint id, bool loaded) const;
 	GLint getUniformLocation(GLuint id, const std::string& name);
 
-	template<typename T>
-	void attachUbo(GLuint id, const gUbo<T>* ubo, const std::string& uboName) {
+	void attachUbo(GLuint id, const gUbo<float>* ubo, const std::string& uboName) {
 		unsigned int blockIndex;
 		G_CHECK_GL2(blockIndex, glGetUniformBlockIndex(id, uboName.c_str()));
 		G_CHECK_GL(glUniformBlockBinding(id, blockIndex, ubo->getBindingPoint()));

--- a/engine/core/gGLRenderEngine.h
+++ b/engine/core/gGLRenderEngine.h
@@ -104,7 +104,7 @@ public:
 	void resetShader(GLuint id, bool loaded) const;
 	GLint getUniformLocation(GLuint id, const std::string& name);
 
-	void attachUbo(GLuint id, const gUbo<float>* ubo, const std::string& uboName) {
+	void attachUbo(GLuint id, const gUbo<gSceneLights>* ubo, const std::string& uboName) {
 		unsigned int blockIndex;
 		G_CHECK_GL2(blockIndex, glGetUniformBlockIndex(id, uboName.c_str()));
 		G_CHECK_GL(glUniformBlockBinding(id, blockIndex, ubo->getBindingPoint()));

--- a/engine/core/gPostProcessManager.cpp
+++ b/engine/core/gPostProcessManager.cpp
@@ -1,5 +1,5 @@
 /*
- * gPostProcessManager.cpp
+* gPostProcessManager.cpp
  *
  *  Created on: 29 Kas 2021
  *      Author: kayra
@@ -10,10 +10,10 @@
 const int gPostProcessManager::fbocount = 2;
 
 gPostProcessManager::gPostProcessManager() {
-    fbos = nullptr;
-    fbotoread = 0;
-    fbotowrite = 0;
-    lastwrittenfbo = 0;
+	fbos = nullptr;
+	fbotoread = 0;
+	fbotowrite = 0;
+	lastwrittenfbo = 0;
 }
 
 gPostProcessManager::~gPostProcessManager() {
@@ -33,21 +33,23 @@ void gPostProcessManager::addEffect(gBasePostProcess *effect) {
 
 void gPostProcessManager::enable() {
 	fbos[0].bind(); // this is where we will draw our affected objects.
-	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+	gRenderObject::getRenderer()->clearScreen(true, true);
 }
 
 void gPostProcessManager::disable() {
-	glDisable(GL_DEPTH_TEST);
+	gRenderer* renderer = gRenderObject::getRenderer();
+
+	renderer->disableDepthTest();
 	fbotoread = 0;
 	fbotowrite = 1;
 
 	for(int i = 0; i < effects.size(); i++) {
 		fbos[fbotowrite].bind();
-		glClear(GL_COLOR_BUFFER_BIT);
+		renderer->clearScreen(true, false);
 		effects[i]->use();
-		glBindVertexArray(gFbo::getQuadVao());
+		renderer->bindQuadVAO();
 		fbos[fbotoread].getTexture().bind();
-		glDrawArrays(GL_TRIANGLES, 0, 6);
+		renderer->drawFullscreenQuad();
 
 		lastwrittenfbo = fbotowrite;
 		int temp = fbotoread;
@@ -55,11 +57,11 @@ void gPostProcessManager::disable() {
 		fbotowrite = temp;
 	}
 
-	glBindFramebuffer(GL_FRAMEBUFFER, gFbo::defaultfbo);
-	glClear(GL_COLOR_BUFFER_BIT);
+	renderer->bindDefaultFramebuffer();
+	renderer->clearScreen(true, false);
 
-	gRenderObject::getRenderer()->getFboShader()->use();
-	glBindVertexArray(gFbo::getQuadVao());
+	renderer->getFboShader()->use();
+	renderer->bindQuadVAO();
 	fbos[lastwrittenfbo].getTexture().bind();
-	glDrawArrays(GL_TRIANGLES, 0, 6);
+	renderer->drawFullscreenQuad();
 }

--- a/engine/core/gPostProcessManager.h
+++ b/engine/core/gPostProcessManager.h
@@ -69,6 +69,7 @@ public:
 	 */
 	void disable();
 private:
+
 	static const int fbocount;
 	std::vector<gBasePostProcess*> effects;
 

--- a/engine/core/gRenderObject.cpp
+++ b/engine/core/gRenderObject.cpp
@@ -8,6 +8,8 @@
 #include "gRenderObject.h"
 #include <iostream>
 
+#include "gGLRenderEngine.h"
+
 
 gRenderer* gRenderObject::renderer = nullptr;
 
@@ -86,7 +88,7 @@ gRenderer* gRenderObject::getRenderer() {
 
 void gRenderObject::createRenderer() {
 	destroyRenderer(); // Delete the previous renderer if exists. If renderer is null, this will have no effect.
-	renderer = new gRenderer();
+	renderer = new gGLRenderEngine();
 	renderer->init();
 }
 

--- a/engine/core/gRenderObject.cpp
+++ b/engine/core/gRenderObject.cpp
@@ -57,13 +57,13 @@ int gRenderObject::getScreenHeight() {
 
 void gRenderObject::pushMatrix() {
 #if defined(WIN32) || defined(LINUX)
-	G_CHECK_GL(glPushMatrix());
+	renderer->pushMatrix();
 #endif
 }
 
 void gRenderObject::popMatrix() {
 #if defined(WIN32) || defined(LINUX)
-	G_CHECK_GL(glPopMatrix());
+	renderer->popMatrix();
 #endif
 }
 

--- a/engine/core/gRenderer.cpp
+++ b/engine/core/gRenderer.cpp
@@ -238,9 +238,6 @@ void gDrawTubeObliqueTrapezodial(float x, float y, float z, int topouterradius,
 	tubemesh.clear();
 }
 
-gRenderer::gRenderer() {
-}
-
 void gRenderer::init() {
 	width = gDefaultWidth();
 	height = gDefaultHeight();
@@ -338,25 +335,6 @@ void gRenderer::init() {
 	originalgrid = new gGrid();
 	grid = originalgrid;
 	isdevelopergrid = false;
-}
-
-gRenderer::~gRenderer() {
-	delete colorshader;
-	delete textureshader;
-	delete imageshader;
-	delete fontshader;
-	delete skyboxshader;
-	delete shadowmapshader;
-	delete pbrshader;
-	delete equirectangularshader;
-	delete irradianceshader;
-	delete prefiltershader;
-	delete brdfshader;
-	delete fboshader;
-	delete rendercolor;
-	delete lightsubo;
-	delete gridshader;
-	if(!isdevelopergrid) delete originalgrid;
 }
 
 gShader* gRenderer::getColorShader() {

--- a/engine/core/gRenderer.cpp
+++ b/engine/core/gRenderer.cpp
@@ -100,7 +100,7 @@ void gDrawArrow(float x1, float y1, float length, float angle, float tipLength, 
 }
 
 void gDrawRectangle(float x, float y, float w, float h, bool isFilled) {
-	static gRectangle rectanglemesh;
+	gRectangle rectanglemesh;
  	rectanglemesh.draw(x, y, w, h, isFilled);
 }
 

--- a/engine/core/gRenderer.cpp
+++ b/engine/core/gRenderer.cpp
@@ -256,8 +256,8 @@ void gRenderer::init() {
 
 	// This changes pack and unpack alignments
 	// Fixes alignment issues with 3 channel images
-	glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-	glPixelStorei(GL_PACK_ALIGNMENT, 1);
+	gRenderObject::getRenderer()->updatePackUnpackAlignment(1);
+
 
 	globalambientcolor.set(255, 255, 255, 255);
 	isglobalambientcolorchanged = true;

--- a/engine/core/gRenderer.h
+++ b/engine/core/gRenderer.h
@@ -388,6 +388,9 @@ public:
 	virtual void enableDepthTestEqual() = 0;
 	virtual void createQuad(GLuint& inQuadVAO, GLuint& inQuadVBO) = 0;
 
+	/* ---------------- gRenderObject ---------------- */
+	virtual void pushMatrix() = 0;
+	virtual void popMatrix() = 0;
 protected:
 	friend class gRenderObject; // this is where renderer->init() is called from
 
@@ -474,6 +477,8 @@ protected:
 	gGrid* grid;
 	gGrid* originalgrid;
 	bool isdevelopergrid;
+
+	virtual void updatePackUnpackAlignment(int i) = 0;
 
 	void init();
 

--- a/engine/core/gRenderer.h
+++ b/engine/core/gRenderer.h
@@ -83,6 +83,8 @@ void gDrawTubeOblique(float x, float y, float z, int outerradius,int innerradiou
 void gDrawTubeTrapezodial(float x, float y, float z, int topouterradius,int topinnerradious, int buttomouterradious, int buttominnerradious, int h, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int segmentnum = 32, bool isFilled = true);
 void gDrawTubeObliqueTrapezodial(float x, float y, float z, int topouterradius,int topinnerradious, int buttomouterradious, int buttominnerradious, int h, glm::vec2 shiftdistance, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int segmentnum = 32, bool isFilled = true);
 
+class gVbo;
+
 template<typename T>
 class gUbo;
 class gLight;
@@ -335,8 +337,7 @@ public:
 	virtual void resetShader(GLuint id, bool loaded) const = 0;
 	virtual GLint getUniformLocation(GLuint id, const std::string& name) = 0;
 
-	template<typename T>
-	virtual void attachUbo(GLuint id, const gUbo<T>* ubo, const std::string& uboName) = 0;
+	virtual void attachUbo(GLuint id, const gUbo<float>* ubo, const std::string& uboName) = 0;
 
 	/* ------------ gPostProcessManager ------------- */
 	virtual void clearScreen(bool color = true, bool depth = true) = 0;
@@ -370,13 +371,13 @@ public:
 	virtual void generateMipMap() = 0;
 
 	/* ---------------- gSkybox ---------------- */
-	virtual void bindSkyTexture(GLuint texId);
-	virtual void bindSkyTexture(GLuint texId, int textureSlot);
-	virtual void unbindSkyTexture();
-	virtual void unbindSkyTexture(int textureSlotNo);
-	virtual void generateSkyMipMap();
-	virtual void enableDepthTestEqual();
-	virtual void createQuad(GLuint& inQuadVAO, GLuint& inQuadVBO);
+	virtual void bindSkyTexture(GLuint texId) = 0;
+	virtual void bindSkyTexture(GLuint texId, int textureSlot) = 0;
+	virtual void unbindSkyTexture() = 0;
+	virtual void unbindSkyTexture(int textureSlotNo) = 0;
+	virtual void generateSkyMipMap() = 0;
+	virtual void enableDepthTestEqual() = 0;
+	virtual void createQuad(GLuint& inQuadVAO, GLuint& inQuadVBO) = 0;
 
 protected:
 	friend class gRenderObject; // this is where renderer->init() is called from

--- a/engine/core/gRenderer.h
+++ b/engine/core/gRenderer.h
@@ -387,6 +387,8 @@ public:
 	virtual void generateSkyMipMap() = 0;
 	virtual void enableDepthTestEqual() = 0;
 	virtual void createQuad(GLuint& inQuadVAO, GLuint& inQuadVBO) = 0;
+	virtual void enableCubeMapSeemless() = 0;
+	virtual void checkEnableCubeMap4Android() = 0;
 
 	/* ---------------- gRenderObject ---------------- */
 	virtual void pushMatrix() = 0;

--- a/engine/core/gRenderer.h
+++ b/engine/core/gRenderer.h
@@ -58,6 +58,16 @@
 #define G_CHECK_GL2(value, fn) value = fn
 #endif
 
+void gCheckGLErrorAndPrint(const std::string& prefix, const std::string& func, int line);
+
+void gEnableCulling();
+void gDisableCulling();
+bool gIsCullingEnabled();
+void gCullFace(int cullingFace);
+int gGetCullFace();
+void gSetCullingDirection(int cullingDirection);
+int gGetCullingDirection();
+
 void gDrawLine(float x1, float y1, float x2, float y2, float thickness = 1.0f);
 void gDrawLine(float x1, float y1, float z1, float x2, float y2, float z2, float thickness = 1.0f);
 void gDrawTriangle(float px, float py, float qx, float qy, float rx, float ry, bool is_filled = true);
@@ -99,8 +109,8 @@ public:
 	static const int DEPTHTESTTYPE_LESS, DEPTHTESTTYPE_ALWAYS;
 	static const int FOGMODE_LINEAR, FOGMODE_EXP;
 
-	gRenderer();
-	virtual ~gRenderer();
+	gRenderer() = default;
+	virtual ~gRenderer() = default;
 
 	static void setScreenSize(int screenWidth, int screenHeight);
 	static void setUnitScreenSize(int unitWidth, int unitHeight);

--- a/engine/core/gRenderer.h
+++ b/engine/core/gRenderer.h
@@ -272,16 +272,16 @@ public:
 	/*
 	 * Takes Screen Shot of the current Rendered Screen and returns it as an gImage class
 	 */
-	virtual gImage takeScreenshot() = 0;
+	virtual void takeScreenshot(gImage& img) = 0;
 
 	/*
 	 * Takes Screen Shot of the part of current Rendered Screen and returns it as an gImage class
 	 */
-	virtual gImage takeScreenshot(int x, int y, int width, int height) = 0;
+	virtual void takeScreenshot(gImage& img, int x, int y, int width, int height) = 0;
 
 	/* -------------- gUbo ------------- */
 	virtual GLuint genBuffers() = 0;
-	virtual void deleteBuffer(GLuint* buffer) = 0;
+	virtual void deleteBuffer(GLuint& buffer) = 0;
 
 	virtual void bindBuffer(GLenum target, GLuint buffer) = 0;
 	virtual void unbindBuffer(GLenum target) = 0;
@@ -292,7 +292,7 @@ public:
 
 	/* -------------- gVbo --------------- */
 	virtual GLuint createVAO() = 0;
-	virtual void deleteVAO(GLuint* vao) = 0;
+	virtual void deleteVAO(GLuint& vao) = 0;
 
 	virtual void bindVAO(GLuint vao) = 0;
 	virtual void unbindVAO() = 0;
@@ -309,12 +309,12 @@ public:
 
 	/* -------------- gFbo --------------- */
 	virtual GLuint createFramebuffer() = 0;
-	virtual void deleteFramebuffer(GLuint* fbo) = 0;
+	virtual void deleteFramebuffer(GLuint& fbo) = 0;
 	virtual void bindFramebuffer(GLuint fbo) = 0;
 	virtual void checkFramebufferStatus() = 0;
 
 	virtual GLuint createRenderbuffer() = 0;
-	virtual void deleteRenderbuffer(GLuint* rbo) = 0;
+	virtual void deleteRenderbuffer(GLuint& rbo) = 0;
 	virtual void bindRenderbuffer(GLuint rbo) = 0;
 	virtual void setRenderbufferStorage(GLenum format, int width, int height) = 0;
 
@@ -325,7 +325,7 @@ public:
 	virtual void setReadBufferNone() = 0;
 
 	virtual void createFullscreenQuad(GLuint& vao, GLuint& vbo) = 0;
-	virtual void deleteFullscreenQuad(GLuint* vao, GLuint* vbo) = 0;
+	virtual void deleteFullscreenQuad(GLuint& vao, GLuint* vbo) = 0;
 
 	/* -------------- gShader --------------- */
 	// This function loads shaders without preproccesing them. Geometry source can be nullptr.
@@ -364,7 +364,7 @@ public:
 	virtual void unbindTexture() = 0;
 	virtual void activateTexture(int textureSlotNo = 0) = 0;
 	virtual void resetTexture() = 0;
-	virtual void deleteTexture(GLuint* texId) = 0;
+	virtual void deleteTexture(GLuint& texId) = 0;
 
 	virtual void texImage2D(GLenum target, GLint internalFormat, int width, int height, GLint format, GLint type, void* data) = 0;
 	virtual void setWrapping(GLenum target, GLint wrapS, GLint wrapT) = 0;

--- a/engine/core/gRenderer.h
+++ b/engine/core/gRenderer.h
@@ -58,16 +58,6 @@
 #define G_CHECK_GL2(value, fn) value = fn
 #endif
 
-void gCheckGLErrorAndPrint(const std::string& prefix, const std::string& func, int line);
-
-void gEnableCulling();
-void gDisableCulling();
-bool gIsCullingEnabled();
-void gCullFace(int cullingFace);
-int gGetCullFace();
-void gSetCullingDirection(int cullingDirection);
-int gGetCullingDirection();
-
 void gDrawLine(float x1, float y1, float x2, float y2, float thickness = 1.0f);
 void gDrawLine(float x1, float y1, float z1, float x2, float y2, float z2, float thickness = 1.0f);
 void gDrawTriangle(float px, float py, float qx, float qy, float rx, float ry, bool is_filled = true);
@@ -173,9 +163,9 @@ public:
 	void setColor(gColor* color);
 	gColor* getColor();
 
-	void clear();
-	void clearColor(int r, int g, int b, int a = 255);
-	void clearColor(gColor color);
+	virtual void clear() = 0;
+	virtual void clearColor(int r, int g, int b, int a = 255) = 0;
+	virtual void clearColor(gColor color) = 0;
 
 	void enableLighting();
 	void disableLighting();
@@ -219,19 +209,19 @@ public:
 	void removeAllSceneLights();
 	void updateLights();
 
-	void enableDepthTest();
-	void enableDepthTest(int depthTestType);
-	void setDepthTestFunc(int depthTestType);
-	void disableDepthTest();
-	bool isDepthTestEnabled();
-	int getDepthTestType();
+	virtual void enableDepthTest() = 0;
+	virtual void enableDepthTest(int depthTestType) = 0;
+	virtual void setDepthTestFunc(int depthTestType) = 0;
+	virtual void disableDepthTest() = 0;
+	virtual bool isDepthTestEnabled() = 0;
+	virtual int getDepthTestType() = 0;
 
-	void enableAlphaBlending();
-	void disableAlphaBlending();
-	bool isAlphaBlendingEnabled();
-	void enableAlphaTest();
-	void disableAlphaTest();
-	bool isAlphaTestEnabled();
+	virtual void enableAlphaBlending() = 0;
+	virtual void disableAlphaBlending() = 0;
+	virtual bool isAlphaBlendingEnabled() = 0;
+	virtual void enableAlphaTest() = 0;
+	virtual void disableAlphaTest() = 0;
+	virtual bool isAlphaTestEnabled() = 0;
 
 	bool isSSAOEnabled();
 	void enableSSAO();
@@ -269,14 +259,126 @@ public:
 	/*
 	 * Takes Screen Shot of the current Rendered Screen and returns it as an gImage class
 	 */
-	gImage takeScreenshot();
+	virtual gImage takeScreenshot() = 0;
 
 	/*
 	 * Takes Screen Shot of the part of current Rendered Screen and returns it as an gImage class
 	 */
-	gImage takeScreenshot(int x, int y, int width, int height);
+	virtual gImage takeScreenshot(int x, int y, int width, int height) = 0;
 
-private:
+	/* -------------- gUbo ------------- */
+	virtual GLuint genBuffers() = 0;
+	virtual void deleteBuffer(GLuint* buffer) = 0;
+
+	virtual void bindBuffer(GLenum target, GLuint buffer) = 0;
+	virtual void unbindBuffer(GLenum target) = 0;
+
+	virtual void bufSubData(GLuint buffer, int offset, int size, const void* data) = 0;
+	virtual void setBufferData(GLuint buffer, const void* data, size_t size, int usage) = 0;
+	virtual void setBufferRange(int index, GLuint buffer, int offset, int size) = 0;
+
+	/* -------------- gVbo --------------- */
+	virtual GLuint createVAO() = 0;
+	virtual void deleteVAO(GLuint* vao) = 0;
+
+	virtual void bindVAO(GLuint vao) = 0;
+	virtual void unbindVAO() = 0;
+
+	virtual void setVertexBufferData(GLuint vbo, size_t size, const void* data, int usage) = 0;
+	virtual void setIndexBufferData(GLuint ebo, size_t size, const void* data, int usage) = 0;
+
+	virtual void drawArrays(int drawMode, int count) = 0;
+	virtual void drawElements(int drawMode, int count) = 0;
+
+	virtual void enableVertexAttrib(int index) = 0;
+	virtual void disableVertexAttrib(int index) = 0;
+	virtual void setVertexAttribPointer(int index, int size, int type, bool normalized, int stride, const void* pointer) = 0;
+
+	/* -------------- gFbo --------------- */
+	virtual GLuint createFramebuffer() = 0;
+	virtual void deleteFramebuffer(GLuint* fbo) = 0;
+	virtual void bindFramebuffer(GLuint fbo) = 0;
+	virtual void checkFramebufferStatus() = 0;
+
+	virtual GLuint createRenderbuffer() = 0;
+	virtual void deleteRenderbuffer(GLuint* rbo) = 0;
+	virtual void bindRenderbuffer(GLuint rbo) = 0;
+	virtual void setRenderbufferStorage(GLenum format, int width, int height) = 0;
+
+	virtual void attachTextureToFramebuffer(GLenum attachment, GLenum textarget, GLuint texId, GLuint level = 0) = 0;
+	virtual void attachRenderbufferToFramebuffer(GLenum attachment, GLuint rbo) = 0;
+
+	virtual void setDrawBufferNone() = 0;
+	virtual void setReadBufferNone() = 0;
+
+	virtual void createFullscreenQuad(GLuint& vao, GLuint& vbo) = 0;
+	virtual void deleteFullscreenQuad(GLuint* vao, GLuint* vbo) = 0;
+
+	/* -------------- gShader --------------- */
+	// This function loads shaders without preproccesing them. Geometry source can be nullptr.
+	virtual GLuint loadProgram(const char* vertexSource, const char* fragmentSource, const char* geometrySource) = 0;
+	virtual void checkCompileErrors(GLuint shader, const std::string& type) = 0;
+	virtual void setBool(GLuint id, const std::string& name, bool value) = 0;
+	virtual void setInt(GLuint id, const std::string& name, int value) = 0;
+	virtual void setFloat(GLuint id, const std::string& name, float value) = 0;
+	virtual void setVec2(GLuint id, const std::string& name, const glm::vec2& value) = 0;
+	virtual void setVec2(GLuint id, const std::string& name, float x, float y) = 0;
+	virtual void setVec3(GLuint id, const std::string& name, const glm::vec3& value) = 0;
+	virtual void setVec3(GLuint id, const std::string& name, float x, float y, float z) = 0;
+	virtual void setVec4(GLuint id, const std::string& name, const glm::vec4& value) = 0;
+	virtual void setVec4(GLuint id, const std::string& name, float x, float y, float z, float w) = 0;
+	virtual void setMat2(GLuint id, const std::string& name, const glm::mat2& mat) = 0;
+	virtual void setMat3(GLuint id, const std::string& name, const glm::mat3& mat) = 0;
+	virtual void setMat4(GLuint id, const std::string& name, const glm::mat4& mat) = 0;
+
+	virtual void useShader(GLuint id) const = 0;
+	virtual void resetShader(GLuint id, bool loaded) const = 0;
+	virtual GLint getUniformLocation(GLuint id, const std::string& name) = 0;
+
+	template<typename T>
+	virtual void attachUbo(GLuint id, const gUbo<T>* ubo, const std::string& uboName) = 0;
+
+	/* ------------ gPostProcessManager ------------- */
+	virtual void clearScreen(bool color = true, bool depth = true) = 0;
+	virtual void bindQuadVAO() = 0;
+	virtual void drawFullscreenQuad() = 0;
+	virtual void bindDefaultFramebuffer() = 0;
+
+	/* -------------- gGrid --------------- */
+	virtual void drawVbo(const gVbo& vbo) = 0;
+
+	/* ---------------- gTexture ---------------- */
+	virtual GLuint createTextures() = 0;
+	virtual void bindTexture(GLuint texId) = 0;
+	virtual void bindTexture(GLuint texId, int textureSlotNo) = 0;
+	virtual void unbindTexture() = 0;
+	virtual void activateTexture(int textureSlotNo = 0) = 0;
+	virtual void resetTexture() = 0;
+	virtual void deleteTexture(GLuint* texId) = 0;
+
+	virtual void texImage2D(GLenum target, GLint internalFormat, int width, int height, GLint format, GLint type, void* data) = 0;
+	virtual void setWrapping(GLenum target, GLint wrapS, GLint wrapT) = 0;
+	virtual void setWrapping(GLenum target, GLint wrapS, GLint wrapT, GLint wrapR) = 0;
+
+	virtual void setFiltering(GLenum target, GLint minFilter, GLint magFilter) = 0;
+	virtual void setWrappingAndFiltering(GLenum target, GLint wrapS, GLint wrapT, GLint minFilter, GLint magFilter) = 0;
+	virtual void setWrappingAndFiltering(GLenum target, GLint wrapS, GLint wrapT, GLint wrapR, GLint minFilter, GLint magFilter) = 0;
+	virtual void setSwizzleMask(GLint swizzleMask[4]) = 0;
+
+	virtual void readTexturePixels(unsigned char* inPixels, GLuint textureId, int width, int height, GLenum format) = 0;
+
+	virtual void generateMipMap() = 0;
+
+	/* ---------------- gSkybox ---------------- */
+	virtual void bindSkyTexture(GLuint texId);
+	virtual void bindSkyTexture(GLuint texId, int textureSlot);
+	virtual void unbindSkyTexture();
+	virtual void unbindSkyTexture(int textureSlotNo);
+	virtual void generateSkyMipMap();
+	virtual void enableDepthTestEqual();
+	virtual void createQuad(GLuint& inQuadVAO, GLuint& inQuadVBO);
+
+protected:
 	friend class gRenderObject; // this is where renderer->init() is called from
 
 	// this is an object that is sent to the gpu

--- a/engine/core/gRenderer.h
+++ b/engine/core/gRenderer.h
@@ -103,6 +103,7 @@ class gShader;
 class gCamera;
 class gGrid;
 
+
 class gRenderer: public gObject {
 public:
 	static const int SCREENSCALING_NONE, SCREENSCALING_MIPMAP, SCREENSCALING_AUTO;
@@ -347,8 +348,6 @@ public:
 	virtual void resetShader(GLuint id, bool loaded) const = 0;
 	virtual GLint getUniformLocation(GLuint id, const std::string& name) = 0;
 
-	virtual void attachUbo(GLuint id, const gUbo<float>* ubo, const std::string& uboName) = 0;
-
 	/* ------------ gPostProcessManager ------------- */
 	virtual void clearScreen(bool color = true, bool depth = true) = 0;
 	virtual void bindQuadVAO() = 0;
@@ -503,6 +502,10 @@ protected:
 	static const std::string& getShaderSrcBrdfFragment();
 	static const std::string& getShaderSrcFboVertex();
 	static const std::string& getShaderSrcFboFragment();
+
+public:
+	virtual void attachUbo(GLuint id, const gUbo<gSceneLights>* ubo, const std::string& uboName) = 0;
+
 };
 
 #endif /* CORE_GRENDERER_H_ */

--- a/engine/graphics/gFbo.cpp
+++ b/engine/graphics/gFbo.cpp
@@ -28,18 +28,18 @@ gFbo::gFbo() {
 
 gFbo::~gFbo() {
 	delete texture;
-	renderer->deleteRenderbuffer(&rbo);
-	renderer->deleteFramebuffer(&framebuffer);
-	renderer->deleteVAO(&gFbo::quadVAO);
-	renderer->deleteBuffer(&gFbo::quadVBO);
+	renderer->deleteRenderbuffer(rbo);
+	renderer->deleteFramebuffer(framebuffer);
+	renderer->deleteVAO(gFbo::quadVAO);
+	renderer->deleteBuffer(gFbo::quadVBO);
 }
 
 void gFbo::allocate(int width, int height, bool isDepthMap) {
 	// check if is not allocated
 	if(isallocated) {
 		delete texture;
-		renderer->deleteRenderbuffer(&rbo);
-		renderer->deleteFramebuffer(&framebuffer);
+		renderer->deleteRenderbuffer(rbo);
+		renderer->deleteFramebuffer(framebuffer);
 
 		texture = nullptr;
 		isallocated = false;

--- a/engine/graphics/gGrid.cpp
+++ b/engine/graphics/gGrid.cpp
@@ -127,7 +127,7 @@ void gGrid::drawVbo() {
 	if(isgridxzenabled){ //use "isgridxyenabled || isgridyzenabled ||" once they are implemented above
 		vbo.bind();
 //		gLogi("drawing")<<"";
-		G_CHECK_GL(glDrawArrays(GL_TRIANGLES, 0, vbo.getVerticesNum()));
+		renderer->drawArrays(GL_TRIANGLES, vbo.getVerticesNum());
 		vbo.unbind();
 	}
 }

--- a/engine/graphics/gImage.cpp
+++ b/engine/graphics/gImage.cpp
@@ -40,7 +40,7 @@ unsigned int gImage::load(const std::string& fullPath) {
 	if (gToLower(fullpath.substr(fullpath.length() - 3, 3)) == "hdr") ishdr = true;
 
 	if (!istextureallocated) {
-		glGenTextures(1, &id);
+		id = renderer->createTextures();
 		istextureallocated = true;
 	}
 
@@ -113,7 +113,7 @@ void gImage::loadImageData(const std::string& imagePath) {
 
 unsigned int gImage::useData() {
 	if (!istextureallocated) {
-		glGenTextures(1, &id);
+		id = renderer->createTextures();
 		istextureallocated = true;
 	}
 

--- a/engine/graphics/gMesh.cpp
+++ b/engine/graphics/gMesh.cpp
@@ -218,7 +218,7 @@ void gMesh::drawStart() {
 //		if(material.isDiffuseMapEnabled()) gLogi("gModel") << "diffuse texture name:" << material.getDiffuseMap()->getFilename();
 	    if (material.isDiffuseMapEnabled()) {
 			colorshader->setInt("material.diffusemap", 0); // Diffuse texture unit
-			G_CHECK_GL(glActiveTexture(GL_TEXTURE0));
+	    	renderer->activateTexture(0);
 		    material.bindDiffuseMap();
 	    }
 
@@ -226,7 +226,7 @@ void gMesh::drawStart() {
 	    colorshader->setInt("material.useSpecularMap", material.isDiffuseMapEnabled() && material.isSpecularMapEnabled());
 	    if (material.isDiffuseMapEnabled() && material.isSpecularMapEnabled()) {
 			colorshader->setInt("material.specularmap", 1); // Specular texture unit
-		    G_CHECK_GL(glActiveTexture(GL_TEXTURE1));
+	    	renderer->activateTexture(1);
 		    material.bindSpecularMap();
 	    }
 
@@ -234,7 +234,7 @@ void gMesh::drawStart() {
 	    colorshader->setInt("aUseNormalMap", material.isDiffuseMapEnabled() && material.isNormalMapEnabled());
 	    if (material.isDiffuseMapEnabled() && material.isNormalMapEnabled()) {
 			colorshader->setInt("material.normalmap", 2); // Normal texture unit
-		    G_CHECK_GL(glActiveTexture(GL_TEXTURE2));
+	    	renderer->activateTexture(2);
 		    material.bindNormalMap();
 	    }
 
@@ -288,7 +288,7 @@ void gMesh::drawStart() {
 	    normalNr   = 1;
 	    heightNr   = 1;
 	    for(ti = 0; ti < textures.size(); ti++) {
-	        G_CHECK_GL(glActiveTexture(GL_TEXTURE0 + ti)); // active proper texture unit before binding
+	    	renderer->activateTexture(ti); // active proper texture unit before binding
 
 	        // retrieve texture number (the N in diffuse_textureN)
 	        texnumber = "";
@@ -320,9 +320,9 @@ void gMesh::drawVbo() {
     // draw mesh
     vbo.bind();
     if (vbo.isIndexDataAllocated()) {
-		G_CHECK_GL(glDrawElements(drawmode, vbo.getIndicesNum(), G_INDEX_SIZE, nullptr));
+    	renderer->drawElements(drawmode, vbo.getIndicesNum());
     } else {
-		G_CHECK_GL(glDrawArrays(drawmode, 0, vbo.getVerticesNum()));
+    	renderer->drawElements(drawmode, vbo.getVerticesNum());
     }
     vbo.unbind();
 //    vbo.clear();
@@ -330,7 +330,7 @@ void gMesh::drawVbo() {
 
 void gMesh::drawEnd() {
 	// set everything back to defaults.
-	G_CHECK_GL(glActiveTexture(GL_TEXTURE0));
+	renderer->activateTexture(0);
 }
 
 int gMesh::getVerticesNum() const {

--- a/engine/graphics/gMorphingMesh.cpp
+++ b/engine/graphics/gMorphingMesh.cpp
@@ -251,9 +251,9 @@ void gMorphingMesh::draw() {
 void gMorphingMesh::drawVboFrames() {
 	vboframes[currenttargetmeshid][currentframeid].bind();
 	if (vboframes[currenttargetmeshid][currentframeid].isIndexDataAllocated()) {
-		glDrawElements(GL_TRIANGLES, vboframes[currenttargetmeshid][currentframeid].getIndicesNum(), GL_UNSIGNED_INT, 0);
+		renderer->drawElements(GL_TRIANGLES, vboframes[currenttargetmeshid][currentframeid].getIndicesNum());
 	} else {
-		glDrawArrays(GL_TRIANGLES, 0, vboframes[currenttargetmeshid][currentframeid].getVerticesNum());
+		renderer->drawArrays(GL_TRIANGLES, vboframes[currenttargetmeshid][currentframeid].getVerticesNum());
 	}
 	vboframes[currenttargetmeshid][currentframeid].unbind();
 }

--- a/engine/graphics/gNode.cpp
+++ b/engine/graphics/gNode.cpp
@@ -213,13 +213,13 @@ glm::vec3 gNode::getScalarDirectionZ() const {
 
 void gNode::pushMatrix() const {
 #if defined(WIN32) || defined(LINUX)
-	glPushMatrix();
+	renderer->pushMatrix();
 #endif
 }
 
 void gNode::popMatrix() const {
 #if defined(WIN32) || defined(LINUX)
-	glPushMatrix();
+	renderer->popMatrix();
 #endif
 }
 

--- a/engine/graphics/gShader.h
+++ b/engine/graphics/gShader.h
@@ -37,7 +37,7 @@ public:
 	void attachUbo(const std::string& uboName, const gUbo<T>* ubo) {
 		ubos[uboName] = ubo->getBindingPoint();
 		use();
-		gRenderObject::getRenderer()->attachUbo(uboName, ubo);
+		gRenderObject::getRenderer()->attachUbo(id, ubo, uboName);
 	}
 
 	bool loaded;

--- a/engine/graphics/gShader.h
+++ b/engine/graphics/gShader.h
@@ -12,6 +12,7 @@
 #include "gRenderer.h"
 #include <string>
 #include <unordered_map>
+#include "gRenderObject.h"
 
 template<typename T>
 class gUbo;
@@ -36,26 +37,7 @@ public:
 	void attachUbo(const std::string& uboName, const gUbo<T>* ubo) {
 		ubos[uboName] = ubo->getBindingPoint();
 		use();
-		unsigned int blockIndex;
-		G_CHECK_GL2(blockIndex, glGetUniformBlockIndex(id, uboName.c_str()));
-		G_CHECK_GL(glUniformBlockBinding(id, blockIndex, ubo->getBindingPoint()));
-		/*if (blockIndex != GL_INVALID_INDEX) {
-			GLint blockSize;
-			G_CHECK_GL(glGetActiveUniformBlockiv(id, blockIndex, GL_UNIFORM_BLOCK_DATA_SIZE, &blockSize));
-
-			GLint blockAlignment;
-			G_CHECK_GL(glGetIntegerv(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, &blockAlignment));
-
-			std::cout << "Uniform block alignment: " << blockAlignment << " bytes" << std::endl;
-
-			// Now 'blockSize' contains the size of the uniform block in bytes
-			std::cout << "Uniform block size: " << blockSize << " bytes" << std::endl;
-			if (ubo->getSize() != blockSize) {
-				std::cout << "Error: Uniform block size mismatch. actual size: " << ubo->getSize() << ", block size: " << blockSize << std::endl;
-			}
-		} else {
-			std::cerr << "Error: Unable to find uniform block index." << std::endl;
-		}*/
+		gRenderObject::getRenderer()->attachUbo(uboName, ubo);
 	}
 
 	bool loaded;

--- a/engine/graphics/gShadowMap.cpp
+++ b/engine/graphics/gShadowMap.cpp
@@ -103,7 +103,7 @@ void gShadowMap::enable() {
 		renderer->getShadowmapShader()->setMat4("lightMatrix", lightmatrix);
 		depthfbo.bind();
 	//	glViewport(0, 0, width, height);
-		glClear(GL_DEPTH_BUFFER_BIT);
+		renderer->clearScreen(false, true);
 	} else {
 		glViewport(0, 0, renderer->getScreenWidth(), renderer->getScreenHeight());
 		renderer->getColorShader()->use();
@@ -115,8 +115,7 @@ void gShadowMap::enable() {
 		renderer->getColorShader()->setVec3("viewPos", camera->getPosition());
 //		renderer->getColorShader()->setVec3("viewPos", glm::vec3(0, 1, 0));
 
-		glActiveTexture(GL_TEXTURE0 + shadowmaptextureslot);
-		glBindTexture(GL_TEXTURE_2D, depthfbo.getTextureId());
+		renderer->bindTexture(depthfbo.getTextureId(), shadowmaptextureslot);
 		renderpassno = 1;
 	}
 }

--- a/engine/graphics/gSkinnedMesh.cpp
+++ b/engine/graphics/gSkinnedMesh.cpp
@@ -54,15 +54,15 @@ void gSkinnedMesh::draw() {
 }
 
 void gSkinnedMesh::drawVboFrame() {
-    // draw mesh
-    vboframe[0][frameno].bind();
-    if (vboframe[0][frameno].isIndexDataAllocated()) {
-        glDrawElements(GL_TRIANGLES, vboframe[0][frameno].getIndicesNum(), GL_UNSIGNED_INT, 0);
-    } else {
-    	glDrawArrays(GL_TRIANGLES, 0, vboframe[0][frameno].getVerticesNum());
-    }
-    vboframe[0][frameno].unbind();
-    framenoold = frameno;
+	// draw mesh
+	vboframe[0][frameno].bind();
+	if (vboframe[0][frameno].isIndexDataAllocated()) {
+		renderer->drawElements(GL_TRIANGLES, vboframe[0][frameno].getIndicesNum());
+	} else {
+		renderer->drawArrays(GL_TRIANGLES, vboframe[0][frameno].getVerticesNum());
+	}
+	vboframe[0][frameno].unbind();
+	framenoold = frameno;
 }
 
 void gSkinnedMesh::resizeAnimation(int verticesNum) {

--- a/engine/graphics/gSkybox.cpp
+++ b/engine/graphics/gSkybox.cpp
@@ -45,9 +45,7 @@ unsigned int gSkybox::load(std::vector<std::string>& fullPaths) {
 	skymapslot = GL_TEXTURE0;
 	skymapint = 0;
 
-#if defined(ANDROID)
-    G_CHECK_GL(glEnable(GL_TEXTURE_CUBE_MAP)); // OpenGL ES does not support GL_TEXTURE_CUBE_MAP_SEAMLESS
-#endif
+	renderer->checkEnableCubeMap4Android();
 
 	id = renderer->createTextures();
 	renderer->bindSkyTexture(id, skymapslot);
@@ -77,11 +75,7 @@ void gSkybox::loadSkybox(gImage* images) {
 	skymapslot = GL_TEXTURE0;
 	skymapint = 0;
 
-#if defined(GLIST_MOBILE)
-	glEnable(GL_TEXTURE_CUBE_MAP); // OpenGL ES does not support GL_TEXTURE_CUBE_MAP_SEAMLESS
-#else
-	glEnable(GL_TEXTURE_CUBE_MAP_SEAMLESS);
-#endif
+	renderer->enableCubeMapSeemless();
 
 	id = renderer->createTextures();
 	renderer->bindSkyTexture(id, skymapslot);
@@ -106,11 +100,7 @@ void gSkybox::loadDataSkybox(std::string *data, int width, int height) {
 	skymapslot = GL_TEXTURE0;
 	skymapint = 0;
 
-#if defined(GLIST_MOBILE)
-	glEnable(GL_TEXTURE_CUBE_MAP); // OpenGL ES does not support GL_TEXTURE_CUBE_MAP_SEAMLESS
-#else
-	glEnable(GL_TEXTURE_CUBE_MAP_SEAMLESS);
-#endif
+	renderer->enableCubeMapSeemless();
 
 	id = renderer->createTextures();
 	renderer->bindSkyTexture(id, skymapslot);
@@ -143,11 +133,7 @@ unsigned int gSkybox::loadEquirectangular(const std::string& fullPath) {
 //	glGenTextures(1, &id);
 //	glBindTexture(GL_TEXTURE_CUBE_MAP, id);
 
-#if defined(GLIST_MOBILE)
-	glEnable(GL_TEXTURE_CUBE_MAP); // OpenGL ES does not support GL_TEXTURE_CUBE_MAP_SEAMLESS
-#else
-	glEnable(GL_TEXTURE_CUBE_MAP_SEAMLESS);
-#endif
+	renderer->enableCubeMapSeemless();
 
 	equirectangularToCubemapShader = renderer->getEquirectangularShader();
 

--- a/engine/graphics/gSkybox.cpp
+++ b/engine/graphics/gSkybox.cpp
@@ -49,34 +49,26 @@ unsigned int gSkybox::load(std::vector<std::string>& fullPaths) {
     G_CHECK_GL(glEnable(GL_TEXTURE_CUBE_MAP)); // OpenGL ES does not support GL_TEXTURE_CUBE_MAP_SEAMLESS
 #endif
 
-	G_CHECK_GL(glActiveTexture(skymapslot));
-	G_CHECK_GL(glGenTextures(1, &id));
-	G_CHECK_GL(glBindTexture(GL_TEXTURE_CUBE_MAP, id));
+	id = renderer->createTextures();
+	renderer->bindSkyTexture(id, skymapslot);
 
 	for (unsigned int i = 0; i < fullPaths.size(); i++) {
         unsigned char *data = stbi_load(fullPaths[i].c_str(), &width, &height, &nrChannels, 0);
         if (data) {
-            G_CHECK_GL(glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, data));
+        	renderer->texImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, GL_RGB, width, height, GL_RGB, GL_UNSIGNED_BYTE, data);
             stbi_image_free(data);
         } else {
             std::cout << "Cubemap tex failed to load at path: " << fullPaths[i] << std::endl;
             stbi_image_free(data);
         }
     }
-
-    G_CHECK_GL(glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
-    G_CHECK_GL(glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
-    G_CHECK_GL(glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
-    G_CHECK_GL(glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
-    G_CHECK_GL(glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE));
+	renderer->setWrappingAndFiltering(GL_TEXTURE_CUBE_MAP, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE, GL_LINEAR, GL_LINEAR);
 
 	renderer->getSkyboxShader()->use();
 	renderer->getSkyboxShader()->setInt("skymap", skymapint);
 
 	if(ispbr) generatePbrMaps();
-
-	G_CHECK_GL(glBindTexture(GL_TEXTURE_CUBE_MAP, 0));
-	G_CHECK_GL(glActiveTexture(GL_TEXTURE0));
+	renderer->unbindSkyTexture(0);
 
     return id;
 }
@@ -91,30 +83,23 @@ void gSkybox::loadSkybox(gImage* images) {
 	glEnable(GL_TEXTURE_CUBE_MAP_SEAMLESS);
 #endif
 
-	glActiveTexture(skymapslot);
-	glGenTextures(1, &id);
-	glBindTexture(GL_TEXTURE_CUBE_MAP, id);
+	id = renderer->createTextures();
+	renderer->bindSkyTexture(id, skymapslot);
 
 	for (unsigned int i = 0; i < 6; i++) {
-		glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL_RGB,
-				images[i].getWidth(), images[i].getHeight(), 0, GL_RGB,
-				GL_UNSIGNED_BYTE, images[i].getImageData());
+		renderer->texImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, GL_RGB,
+			images[i].getWidth(), images[i].getHeight(), GL_RGB,
+			GL_UNSIGNED_BYTE, images[i].getImageData());
     }
 
-    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+	renderer->setWrappingAndFiltering(GL_TEXTURE_CUBE_MAP, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE, GL_LINEAR, GL_LINEAR);
 
 	renderer->getSkyboxShader()->use();
 	renderer->getSkyboxShader()->setInt("skymap", skymapint);
 
 	if(ispbr) generatePbrMaps();
 
-	glBindTexture(GL_TEXTURE_CUBE_MAP, 0);
-	glActiveTexture(GL_TEXTURE0);
-
+	renderer->unbindSkyTexture(0);
 }
 
 void gSkybox::loadDataSkybox(std::string *data, int width, int height) {
@@ -127,30 +112,23 @@ void gSkybox::loadDataSkybox(std::string *data, int width, int height) {
 	glEnable(GL_TEXTURE_CUBE_MAP_SEAMLESS);
 #endif
 
-	glActiveTexture(skymapslot);
-	glGenTextures(1, &id);
-	glBindTexture(GL_TEXTURE_CUBE_MAP, id);
+	id = renderer->createTextures();
+	renderer->bindSkyTexture(id, skymapslot);
 
 	for (unsigned int i = 0; i < 6; i++) {
-		glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL_RGB,
-				width, height, 0, GL_RGB, GL_UNSIGNED_BYTE,
+		renderer->texImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, GL_RGB,
+				width, height, GL_RGB, GL_UNSIGNED_BYTE,
 				(unsigned char*)gDecodeBase64(data[i]).c_str());
     }
 
-    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+	renderer->setWrappingAndFiltering(GL_TEXTURE_CUBE_MAP, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE, GL_LINEAR, GL_LINEAR);
 
 	renderer->getSkyboxShader()->use();
 	renderer->getSkyboxShader()->setInt("skymap", skymapint);
 
 	if(ispbr) generatePbrMaps();
 
-	glBindTexture(GL_TEXTURE_CUBE_MAP, 0);
-	glActiveTexture(GL_TEXTURE0);
-
+	renderer->unbindSkyTexture(0);
 }
 
 unsigned int gSkybox::loadTextureEquirectangular(const std::string& texturePath) {
@@ -173,27 +151,20 @@ unsigned int gSkybox::loadEquirectangular(const std::string& fullPath) {
 
 	equirectangularToCubemapShader = renderer->getEquirectangularShader();
 
-
-	glGenFramebuffers(1, &captureFBO);
-	glGenRenderbuffers(1, &captureRBO);
-
-	glBindFramebuffer(GL_FRAMEBUFFER, captureFBO);
-	glBindRenderbuffer(GL_RENDERBUFFER, captureRBO);
-	glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, 512, 512);
-	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, captureRBO);
+	captureFBO = renderer->createFramebuffer();
+	captureRBO = renderer->createRenderbuffer();
+	renderer->bindFramebuffer(captureFBO);
+	renderer->bindRenderbuffer(captureRBO);
+	renderer->setRenderbufferStorage(GL_DEPTH_COMPONENT24, 512, 512);
+	renderer->attachRenderbufferToFramebuffer(GL_DEPTH_ATTACHMENT, captureRBO);
 
 	//***********************************************
-	glActiveTexture(skymapslot);
-	glGenTextures(1, &id);
-	glBindTexture(GL_TEXTURE_CUBE_MAP, id);
+	id = renderer->createTextures();
+	renderer->bindSkyTexture(id, skymapslot);
 	for (unsigned int i = 0; i < 6; ++i) {
-		glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL_RGB32F, 512, 512, 0, GL_RGB, GL_FLOAT, nullptr);
+		renderer->texImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, GL_RGB32F, 512, 512, GL_RGB, GL_FLOAT, nullptr);
 	}
-    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+	renderer->setWrappingAndFiltering(GL_TEXTURE_CUBE_MAP, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE, GL_LINEAR, GL_LINEAR);
 
 	equirectangularToCubemapShader->use();
 	equirectangularToCubemapShader->setInt("equirectangularMap", 0);
@@ -202,22 +173,21 @@ unsigned int gSkybox::loadEquirectangular(const std::string& fullPath) {
 	// pbr: load the HDR environment map
 	gTexture hdr;
 	hdr.load(fullPath);
-	hdr.bind(0);
+	renderer->bindTexture(hdr.getId(), 0);
 
 	glViewport(0, 0, 512, 512); // don't forget to configure the viewport to the capture dimensions.
-	glBindFramebuffer(GL_FRAMEBUFFER, captureFBO);
+	renderer->bindFramebuffer(captureFBO);
 	for (unsigned int i = 0; i < 6; ++i) {
 		equirectangularToCubemapShader->setMat4("view", captureViews[i]);
-		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, id, 0);
-		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-
+		renderer->attachTextureToFramebuffer(GL_COLOR_ATTACHMENT0, GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, id);
+		renderer->clearScreen(true, true);
 		renderCube();
 	}
-	glBindFramebuffer(GL_FRAMEBUFFER, gFbo::defaultfbo);
+	renderer->bindDefaultFramebuffer();
 
 	// then let OpenGL generate mipmaps from first mip face (combatting visible dots artifact)
-	glBindTexture(GL_TEXTURE_CUBE_MAP, id);
-	glGenerateMipmap(GL_TEXTURE_CUBE_MAP);
+	renderer->bindSkyTexture(id);
+	renderer->generateSkyMipMap();
 
 	if(ispbr) generatePbrMaps();
 	glViewport(0, 0, getScreenWidth(), getScreenHeight());
@@ -225,8 +195,7 @@ unsigned int gSkybox::loadEquirectangular(const std::string& fullPath) {
 }
 
 void gSkybox::generatePbrMaps() {
-	glActiveTexture(skymapslot);
-	glBindTexture(GL_TEXTURE_CUBE_MAP, id);
+	renderer->bindSkyTexture(id, skymapslot);
 
 	pbrShader = renderer->getPbrShader();
 	irradianceShader = renderer->getIrradianceShader();
@@ -236,112 +205,97 @@ void gSkybox::generatePbrMaps() {
 	// pbr: create an irradiance cubemap, and re-scale capture FBO to irradiance scale.
 	// --------------------------------------------------------------------------------
 
-	glGenTextures(1, &irradianceMap);
-	glBindTexture(GL_TEXTURE_CUBE_MAP, irradianceMap);
+	irradianceMap = renderer->createTextures();
+	renderer->bindSkyTexture(irradianceMap);
 	for (unsigned int i = 0; i < 6; ++i) {
-		glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL_RGB32F, 32, 32, 0, GL_RGB, GL_FLOAT, nullptr);
+		renderer->texImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, GL_RGB32F, 32, 32, GL_RGB, GL_FLOAT, nullptr);
 	}
-	glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	renderer->setWrappingAndFiltering(GL_TEXTURE_CUBE_MAP, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE, GL_LINEAR, GL_LINEAR);
 
-	glBindFramebuffer(GL_FRAMEBUFFER, captureFBO);
-	glBindRenderbuffer(GL_RENDERBUFFER, captureRBO);
-	glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, 32, 32);
+	renderer->bindFramebuffer(captureFBO);
+	renderer->bindRenderbuffer(captureRBO);
+	renderer->setRenderbufferStorage(GL_DEPTH_COMPONENT24, 32, 32);
 
 	// pbr: solve diffuse integral by convolution to create an irradiance (cube)map.
 	// -----------------------------------------------------------------------------
 	irradianceShader->use();
 	irradianceShader->setInt("environmentMap", 0);
 	irradianceShader->setMat4("projection", captureProjection);
-	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_CUBE_MAP, id);
+	renderer->bindSkyTexture(id, GL_TEXTURE0);
 
 	glViewport(0, 0, 32, 32); // don't forget to configure the viewport to the capture dimensions.
-	glBindFramebuffer(GL_FRAMEBUFFER, captureFBO);
+	renderer->bindFramebuffer(captureFBO);
 	for (unsigned int i = 0; i < 6; ++i) {
 		irradianceShader->setMat4("view", captureViews[i]);
-		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, irradianceMap, 0);
-		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-
+		renderer->attachTextureToFramebuffer(GL_COLOR_ATTACHMENT0, GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, irradianceMap);
+		renderer->clearScreen(true, true);
 		renderCube();
 	}
-	glBindFramebuffer(GL_FRAMEBUFFER, gFbo::defaultfbo);
+	renderer->bindDefaultFramebuffer();
 
 	// pbr: create a pre-filter cubemap, and re-scale capture FBO to pre-filter scale.
 	// --------------------------------------------------------------------------------
 
-	glGenTextures(1, &prefilterMap);
-	glBindTexture(GL_TEXTURE_CUBE_MAP, prefilterMap);
+	prefilterMap = renderer->createTextures();
+	renderer->bindSkyTexture(prefilterMap);
 	for (unsigned int i = 0; i < 6; ++i) {
-		glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL_RGB32F, 128, 128, 0, GL_RGB, GL_FLOAT, nullptr);
+		renderer->texImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, GL_RGB32F, 128, 128, GL_RGB, GL_FLOAT, nullptr);
 	}
-	glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR); // be sure to set minification filter to mip_linear
-	glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	renderer->setWrappingAndFiltering(GL_TEXTURE_CUBE_MAP, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE, GL_LINEAR_MIPMAP_LINEAR, GL_LINEAR);
 	// generate mipmaps for the cubemap so OpenGL automatically allocates the required memory.
-	glGenerateMipmap(GL_TEXTURE_CUBE_MAP);
-
+	renderer->generateSkyMipMap();
 	// pbr: run a quasi monte-carlo simulation on the environment lighting to create a prefilter (cube)map.
 	// ----------------------------------------------------------------------------------------------------
 	prefilterShader->use();
 	prefilterShader->setInt("environmentMap", 0);
 	prefilterShader->setMat4("projection", captureProjection);
-	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_CUBE_MAP, id);
+	renderer->bindSkyTexture(id, GL_TEXTURE0);
 
-	glBindFramebuffer(GL_FRAMEBUFFER, captureFBO);
+	renderer->bindFramebuffer(captureFBO);
 	unsigned int maxMipLevels = 5;
 	for (unsigned int mip = 0; mip < maxMipLevels; ++mip) {
 		// reisze framebuffer according to mip-level size.
 		unsigned int mipWidth = 128 * std::pow(0.5, mip);
 		unsigned int mipHeight = 128 * std::pow(0.5, mip);
-		glBindRenderbuffer(GL_RENDERBUFFER, captureRBO);
-		glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, mipWidth, mipHeight);
+		renderer->bindRenderbuffer(captureRBO);
+		renderer->setRenderbufferStorage(GL_DEPTH_COMPONENT24, mipWidth, mipHeight);
 		glViewport(0, 0, mipWidth, mipHeight);
 
 		float roughness = (float)mip / (float)(maxMipLevels - 1);
 		prefilterShader->setFloat("roughness", roughness);
 		for (unsigned int i = 0; i < 6; ++i) {
 			prefilterShader->setMat4("view", captureViews[i]);
-			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, prefilterMap, mip);
-
-			glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+			renderer->attachTextureToFramebuffer(GL_COLOR_ATTACHMENT0, GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, prefilterMap, mip);
+			renderer->clearScreen(true, true);
 			renderCube();
 		}
 	}
-	glBindFramebuffer(GL_FRAMEBUFFER, gFbo::defaultfbo);
+	renderer->bindDefaultFramebuffer();
 
 	// pbr: generate a 2D LUT from the BRDF equations used.
 	// ----------------------------------------------------
 
-	glGenTextures(1, &brdfLUTTexture);
+	brdfLUTTexture = renderer->createTextures();
 
 	// pre-allocate enough memory for the LUT texture.
-	glBindTexture(GL_TEXTURE_2D, brdfLUTTexture);
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_RG32F, 512, 512, 0, GL_RG, GL_FLOAT, 0);
+	renderer->bindTexture(brdfLUTTexture);
+	renderer->texImage2D(GL_TEXTURE_2D, GL_RG32F, 512, 512, GL_RG, GL_FLOAT, 0);
 	// be sure to set wrapping mode to GL_CLAMP_TO_EDGE
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	renderer->setWrappingAndFiltering(GL_TEXTURE_2D, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE,
+	                                      GL_LINEAR, GL_LINEAR);
 
 	// then re-configure capture framebuffer object and render screen-space quad with BRDF shader.
-	glBindFramebuffer(GL_FRAMEBUFFER, captureFBO);
-	glBindRenderbuffer(GL_RENDERBUFFER, captureRBO);
-	glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, 512, 512);
-	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, brdfLUTTexture, 0);
+	captureFBO = renderer->createFramebuffer();
+	captureRBO = renderer->createRenderbuffer();
+	renderer->setRenderbufferStorage(GL_DEPTH_COMPONENT24, 512, 512);
+	renderer->attachTextureToFramebuffer(GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, brdfLUTTexture);
 
-	glViewport(0, 0, renderer->getScreenWidth(),renderer->getScreenHeight());
+	glViewport(0, 0, renderer->getScreenWidth(), renderer->getScreenHeight());
 	brdfShader->use();
-	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+	renderer->clearScreen(true, true);
 	renderQuad();
 
-	glBindFramebuffer(GL_FRAMEBUFFER, gFbo::defaultfbo);
+	renderer->bindDefaultFramebuffer();
 
 	pbrShader->use();
 	pbrShader->setInt("irradianceMap", 0);
@@ -359,8 +313,7 @@ void gSkybox::generatePbrMaps() {
 	renderer->getSkyboxShader()->use();
 	renderer->getSkyboxShader()->setInt("skymap", skymapint);
 
-	glBindTexture(GL_TEXTURE_CUBE_MAP, 0);
-	glActiveTexture(GL_TEXTURE0);
+	renderer->unbindSkyTexture(0);
 	ispbr = true;
 }
 
@@ -368,17 +321,14 @@ void gSkybox::bindPbrMaps() {
 	pbrShader->use();
 	pbrShader->setMat4("view", renderer->getViewMatrix());
 	pbrShader->setVec3("camPos", renderer->getCameraPosition());
-	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_CUBE_MAP, irradianceMap);
-	glActiveTexture(GL_TEXTURE1);
-	glBindTexture(GL_TEXTURE_CUBE_MAP, prefilterMap);
-	glActiveTexture(GL_TEXTURE2);
-	glBindTexture(GL_TEXTURE_2D, brdfLUTTexture);
+	renderer->bindSkyTexture(irradianceMap, GL_TEXTURE0);
+	renderer->bindSkyTexture(prefilterMap, GL_TEXTURE1);
+	renderer->bindTexture(brdfLUTTexture, GL_TEXTURE2 - GL_TEXTURE0);
 }
 
 void gSkybox::draw() {
 	skyboxshader = renderer->getSkyboxShader();
-	G_CHECK_GL(glDepthFunc(GL_LEQUAL));  // change depth function so depth test passes when values are equal to depth buffer's content
+	renderer->enableDepthTestEqual(); // change depth function so depth test passes when values are equal to depth buffer's content
 	skyboxshader->use();
 	skyboxshader->setInt("aIsHDR", ishdr);
 	skyboxshader->setMat4("projection", renderer->getProjectionMatrix());
@@ -387,12 +337,11 @@ void gSkybox::draw() {
 
 //	skyboxshader->setInt("skymap", skymapint);
 
-	glActiveTexture(skymapslot);
-	glBindTexture(GL_TEXTURE_CUBE_MAP, id);
+	renderer->bindSkyTexture(id, skymapslot);
     vbo.bind();
-    glDrawElements(GL_TRIANGLES, vbo.getIndicesNum(), GL_UNSIGNED_INT, 0);
+	renderer->drawElements(GL_TRIANGLES, vbo.getIndicesNum());
     vbo.unbind();
-	glBindTexture(GL_TEXTURE_CUBE_MAP, 0);
+	renderer->unbindSkyTexture();
 }
 
 void gSkybox::setupRenderData() {
@@ -548,51 +497,34 @@ void gSkybox::renderCube() {
             -1.0f,  1.0f, -1.0f,  0.0f,  1.0f,  0.0f, 0.0f, 1.0f, // top-left
             -1.0f,  1.0f,  1.0f,  0.0f,  1.0f,  0.0f, 0.0f, 0.0f  // bottom-left
         };
-        glGenVertexArrays(1, &cubeVAO);
-        glGenBuffers(1, &cubeVBO);
+    	cubeVAO = renderer->createVAO();
+    	cubeVBO = renderer->genBuffers();
         // fill buffer
-        glBindBuffer(GL_ARRAY_BUFFER, cubeVBO);
-        glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
+    	renderer->setVertexBufferData(cubeVBO, sizeof(vertices), vertices, GL_STATIC_DRAW);
         // link vertex attributes
-        glBindVertexArray(cubeVAO);
-        glEnableVertexAttribArray(0);
-        glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void*)0);
-        glEnableVertexAttribArray(1);
-        glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void*)(3 * sizeof(float)));
-        glEnableVertexAttribArray(2);
-        glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void*)(6 * sizeof(float)));
-        glBindBuffer(GL_ARRAY_BUFFER, 0);
-        glBindVertexArray(0);
+    	renderer->bindVAO(cubeVAO);
+		renderer->enableVertexAttrib(0);
+    	renderer->setVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void*)0);
+    	renderer->enableVertexAttrib(1);
+    	renderer->setVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void*)(3 * sizeof(float)));
+    	renderer->enableVertexAttrib(2);
+    	renderer->setVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void*)(6 * sizeof(float)));
+		renderer->unbindBuffer(GL_ARRAY_BUFFER);
+    	renderer->unbindVAO();
     }
     // render Cube
-    glBindVertexArray(cubeVAO);
-    glDrawArrays(GL_TRIANGLES, 0, 36);
-    glBindVertexArray(0);
+	renderer->bindVAO(cubeVAO);
+	renderer->drawArrays(GL_TRIANGLES, 36);
+	renderer->unbindVAO();
 }
 
 void gSkybox::renderQuad() {
     if (quadVAO == 0) {
-        float quadVertices[] = {
-            // positions        // texture Coords
-            -1.0f,  1.0f, 0.0f, 0.0f, 1.0f,
-            -1.0f, -1.0f, 0.0f, 0.0f, 0.0f,
-             1.0f,  1.0f, 0.0f, 1.0f, 1.0f,
-             1.0f, -1.0f, 0.0f, 1.0f, 0.0f,
-        };
-        // setup plane VAO
-        glGenVertexArrays(1, &quadVAO);
-        glGenBuffers(1, &quadVBO);
-        glBindVertexArray(quadVAO);
-        glBindBuffer(GL_ARRAY_BUFFER, quadVBO);
-        glBufferData(GL_ARRAY_BUFFER, sizeof(quadVertices), &quadVertices, GL_STATIC_DRAW);
-        glEnableVertexAttribArray(0);
-        glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*)0);
-        glEnableVertexAttribArray(1);
-        glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*)(3 * sizeof(float)));
+    	renderer->createQuad(quadVAO, quadVBO);
     }
-    glBindVertexArray(quadVAO);
-    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-    glBindVertexArray(0);
+	renderer->bindVAO(quadVAO);
+	renderer->drawArrays(GL_TRIANGLES, 36);
+	renderer->unbindVAO();
 }
 
 

--- a/engine/graphics/gTexture.cpp
+++ b/engine/graphics/gTexture.cpp
@@ -122,17 +122,15 @@ gTexture::gTexture(int w, int h, int format, bool isFbo) {
 	else if (format == GL_RGBA) componentnum = 4;
     data = nullptr;
 	datahdr = nullptr;
-	glGenTextures(1, &id);
+	id = renderer->createTextures();
 	istextureallocated = true;
 	bind();
-    G_CHECK_GL(glTexImage2D(GL_TEXTURE_2D, 0, internalformat, width, height, 0, format, valuetype, nullptr));
+
+	renderer->texImage2D(GL_TEXTURE_2D, internalformat, width, height, format, valuetype, nullptr);
 
 	// TODO: BEFORE SHADOWMAP GL_REPEAT
-	G_CHECK_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
-	G_CHECK_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
-
-	G_CHECK_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, texturefilter[filtermin]));
-	G_CHECK_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, texturefilter[filtermag]));
+	renderer->setWrappingAndFiltering(GL_TEXTURE_2D, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE,
+	                                      texturefilter[filtermin], texturefilter[filtermag]);
 	setupRenderData();
 }
 
@@ -150,7 +148,7 @@ unsigned int gTexture::load(const std::string& fullPath) {
 	if (gToLower(fullpath.substr(fullpath.length() - 3, 3)) == "hdr") ishdr = true;
 
 	if (!istextureallocated) {
-		glGenTextures(1, &id);
+		id = renderer->createTextures();
 		istextureallocated = true;
 	}
 
@@ -189,7 +187,7 @@ unsigned int gTexture::loadData(unsigned char* textureData, int width, int heigh
 	this->componentnum = componentNum;
 
 	if (!istextureallocated) {
-		glGenTextures(1, &id);
+		id = renderer->createTextures();
 		istextureallocated = true;
 	}
 
@@ -215,26 +213,15 @@ void gTexture::setData(unsigned char* textureData, bool isMutable, bool isStbIma
 
 	if (data) {
 		bind();
-		G_CHECK_GL(glTexImage2D(GL_TEXTURE_2D, 0, format, width, height, 0, format, GL_UNSIGNED_BYTE, data));
-		G_CHECK_GL(glGenerateMipmap(GL_TEXTURE_2D));
-
-		G_CHECK_GL(glTexImage2D(GL_TEXTURE_2D, 0, format, getWidth(), getHeight(), 0, format, GL_UNSIGNED_BYTE, data));
-
-		G_CHECK_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT));
-		G_CHECK_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT));
-		G_CHECK_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, texturefilter[filtermin]));
-		G_CHECK_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, texturefilter[filtermag]));
+		renderer->texImage2D(GL_TEXTURE_2D, format, width, height, format, GL_UNSIGNED_BYTE, data);
+		renderer->generateMipMap();
+		renderer->texImage2D(GL_TEXTURE_2D, format, getWidth(), getHeight(), format, GL_UNSIGNED_BYTE, data);
+		renderer->setWrappingAndFiltering(GL_TEXTURE_2D, GL_REPEAT, GL_REPEAT,
+		                                     texturefilter[filtermin], texturefilter[filtermag]);
 
 		if (format == GL_RG) {
 			GLint swizzleMask[] = {GL_RED, GL_RED, GL_RED, GL_GREEN};
-#if defined(GLIST_MOBILE)
-			G_CHECK_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, swizzleMask[0]));
-			G_CHECK_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_G, swizzleMask[1]));
-			G_CHECK_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, swizzleMask[2]));
-			G_CHECK_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, swizzleMask[3]));
-#else
-			G_CHECK_GL(glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleMask));
-#endif
+			renderer->setSwizzleMask(swizzleMask);
 		}
 
 		if (isstbimage && !ismutable) {
@@ -260,13 +247,9 @@ void gTexture::setDataHDR(float* textureData, bool isMutable, bool isStbImage, b
 	datahdr = textureData;
 	if (datahdr) {
 		bind();
-		G_CHECK_GL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB32F, width, height, 0, GL_RGB, GL_FLOAT, datahdr)); // note how we specify the texture's data value to be float
-
-		G_CHECK_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
-		G_CHECK_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
-		G_CHECK_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, texturefilter[filtermin]));
-		G_CHECK_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, texturefilter[filtermag]));
-
+		renderer->texImage2D(GL_TEXTURE_2D, GL_RGB32F, width, height, GL_RGB, GL_FLOAT, datahdr); // note how we specify the texture's data value to be float
+		renderer->setWrappingAndFiltering(GL_TEXTURE_2D, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE,
+		                                     texturefilter[filtermin], texturefilter[filtermag]);
 		if (isstbimage && !ismutable) {
 			stbi_image_free(datahdr);
 			datahdr = nullptr;
@@ -292,16 +275,15 @@ bool gTexture::isMutable() {
 }
 
 void gTexture::bind() const {
-	G_CHECK_GL(glBindTexture(GL_TEXTURE_2D, id));
+	renderer->bindTexture(id);
 }
 
 void gTexture::bind(int textureSlotNo) const {
-	G_CHECK_GL(glActiveTexture(GL_TEXTURE0 + textureSlotNo));
-	G_CHECK_GL(glBindTexture(GL_TEXTURE_2D, id));
+	renderer->bindTexture(id, textureSlotNo);
 }
 
 void gTexture::unbind() const {
-	G_CHECK_GL(glBindTexture(GL_TEXTURE_2D, 0));
+	renderer->unbindTexture();
 }
 
 unsigned int gTexture::getId() const {
@@ -332,8 +314,7 @@ void gTexture::setWrapping(int wrapS, int wrapT) {
 	wraps = wrapS;
 	wrapt = wrapT;
 	bind();
-	G_CHECK_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, texturewrap[wraps]));
-	G_CHECK_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, texturewrap[wrapt]));
+	renderer->setWrapping(GL_TEXTURE_2D, texturewrap[wraps], texturewrap[wrapt]);
 	unbind();
 }
 
@@ -341,8 +322,7 @@ void gTexture::setFiltering(int minFilter, int magFilter) {
 	filtermin = minFilter;
 	filtermag = magFilter;
 	bind();
-	G_CHECK_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, texturefilter[filtermin]));
-	G_CHECK_GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, texturefilter[filtermag]));
+	renderer->setFiltering(GL_TEXTURE_2D, texturefilter[filtermin], texturefilter[filtermag]);
 	unbind();
 }
 
@@ -501,26 +481,25 @@ void gTexture::endDraw() {
 		renderer->getImageShader()->setVec2("subScale", subscale);
 	}
 
-	G_CHECK_GL(glActiveTexture(GL_TEXTURE0));
+	renderer->resetTexture();
 
 	bind();
 	renderer->getImageShader()->setBool("isAlphaMasking", ismaskloaded);
 	if(ismaskloaded) {
 		renderer->getImageShader()->setInt("maskimage", 1);
-		G_CHECK_GL(glActiveTexture(GL_TEXTURE0 + 1)); // GL_TEXTURE1
+		renderer->activateTexture(1); // GL_TEXTURE1
 		masktexture->bind(1);
 	}
 	if ((format == GL_RGBA || format == GL_RG || ismaskloaded) && !renderer->isAlphaBlendingEnabled()) {
-		G_CHECK_GL(glEnable(GL_BLEND));
-		G_CHECK_GL(glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA));
+		renderer->enableAlphaBlending();
 	}
 
-	G_CHECK_GL(glBindVertexArray(quadVAO));
-	G_CHECK_GL(glDrawArrays(GL_TRIANGLES, 0, 6));
-	G_CHECK_GL(glBindVertexArray(0));
+	renderer->bindVAO(quadVAO);
+	renderer->drawFullscreenQuad();
+	renderer->unbindVAO();
 
 	if (((format == GL_RGBA || format == GL_RG || format == GL_RGB) && !renderer->isAlphaBlendingEnabled()) || ismaskloaded) {
-		G_CHECK_GL(glDisable(GL_BLEND));
+		renderer->disableAlphaBlending();
 	}
 	unbind();
 }
@@ -531,12 +510,12 @@ void gTexture::setupRenderData() {
 
 void gTexture::cleanupAll() {
 	if(isloaded) {
-		G_CHECK_GL(glDeleteBuffers(1, &quadVBO));
-		G_CHECK_GL(glDeleteVertexArrays(1, &quadVAO));
+		renderer->deleteBuffer(&quadVBO);
+		renderer->deleteVAO(&quadVAO);
 		isloaded = false;
 	}
 	if(istextureallocated) {
-		G_CHECK_GL(glDeleteTextures(1, &id));
+		renderer->deleteTexture(&id);
 		istextureallocated = false;
 	}
 	cleanupData();
@@ -563,11 +542,10 @@ void gTexture::cleanupData() {
 
 void gTexture::setupRenderData(int sx, int sy, int sw, int sh) {
 	if(!isloaded) {
-		G_CHECK_GL(glGenVertexArrays(1, &quadVAO));
-		G_CHECK_GL(glGenBuffers(1, &quadVBO));
+		quadVAO = renderer->createVAO();
+		quadVBO = renderer->genBuffers();
 		isloaded = true;
 	}
-	G_CHECK_GL(glBindBuffer(GL_ARRAY_BUFFER, quadVBO));
 	if (isfbo || ishdr) {
 		float vertices[] = {
 				// pos      // tex
@@ -579,7 +557,7 @@ void gTexture::setupRenderData(int sx, int sy, int sw, int sh) {
 				1.0f, 1.0f, (float)(sx + sw) / width, (float)(sy) / height,
 				1.0f, 0.0f, (float)(sx + sw) / width, (float)(sy + sh) / height
 		};
-		G_CHECK_GL(glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW));
+		renderer->setVertexBufferData(quadVBO, sizeof(vertices), vertices, GL_STATIC_DRAW);
 	} else {
 		float vertices[] = {
 				// pos      // tex
@@ -591,14 +569,15 @@ void gTexture::setupRenderData(int sx, int sy, int sw, int sh) {
 				1.0f, 1.0f, (float)(sx + sw) / width, (float)(sy + sh) / height,
 				1.0f, 0.0f, (float)(sx + sw) / width, (float)sy / height
 		};
-		G_CHECK_GL(glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW));
+		renderer->setVertexBufferData(quadVBO, sizeof(vertices), vertices, GL_STATIC_DRAW);
 	}
 
-	G_CHECK_GL(glBindVertexArray(quadVAO));
-	G_CHECK_GL(glEnableVertexAttribArray(0));
-	G_CHECK_GL(glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)0));
-	G_CHECK_GL(glBindBuffer(GL_ARRAY_BUFFER, 0));
-	G_CHECK_GL(glBindVertexArray(0));
+	renderer->bindVAO(quadVAO);
+	renderer->enableVertexAttrib(0);
+	renderer->setVertexAttribPointer(0, 4, GL_FLOAT, false, 4 * sizeof(float), (void*)0);
+
+	renderer->unbindBuffer(GL_ARRAY_BUFFER);
+	renderer->unbindVAO();
 }
 
 std::string gTexture::getDirName(const std::string& fname) {
@@ -618,15 +597,7 @@ std::string gTexture::getFileName(const std::string& fname) {
 void gTexture::save(std::string fullpath) {
 	unsigned char* pixels = new unsigned char[width * height * componentnum];
 
-	GLuint fbo;
-	glGenFramebuffers(1, &fbo);
-	glBindFramebuffer(GL_FRAMEBUFFER, fbo);
-	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, id, 0);
-
-	glReadPixels(0, 0, width, height, format, GL_UNSIGNED_BYTE, pixels);
-
-	glBindFramebuffer(GL_FRAMEBUFFER, 0);
-	glDeleteFramebuffers(1, &fbo);
+	renderer->readTexturePixels(pixels, id, width, height, format);
 
 	// flip back vertically if fbo or hdr
 	if (isfbo || ishdr) {

--- a/engine/graphics/gTexture.cpp
+++ b/engine/graphics/gTexture.cpp
@@ -515,7 +515,7 @@ void gTexture::cleanupAll() {
 		isloaded = false;
 	}
 	if(istextureallocated) {
-		glDeleteTextures(1, &id);
+		renderer->deleteTexture(id);
 		istextureallocated = false;
 	}
 	cleanupData();

--- a/engine/graphics/gTexture.cpp
+++ b/engine/graphics/gTexture.cpp
@@ -510,12 +510,12 @@ void gTexture::setupRenderData() {
 
 void gTexture::cleanupAll() {
 	if(isloaded) {
-		renderer->deleteBuffer(&quadVBO);
-		renderer->deleteVAO(&quadVAO);
+		renderer->deleteBuffer(quadVBO);
+		renderer->deleteVAO(quadVAO);
 		isloaded = false;
 	}
 	if(istextureallocated) {
-		renderer->deleteTexture(&id);
+		glDeleteTextures(1, &id);
 		istextureallocated = false;
 	}
 	cleanupData();

--- a/engine/graphics/gUbo.h
+++ b/engine/graphics/gUbo.h
@@ -24,7 +24,7 @@ public:
 
 	~gUbo() {
 		if (id != GL_NONE) {
-			G_CHECK_GL(glDeleteBuffers(1, &id));
+			gRenderObject::getRenderer()->deleteBuffer(id);
 		}
 		delete data;
 	}

--- a/engine/graphics/gVbo.cpp
+++ b/engine/graphics/gVbo.cpp
@@ -155,15 +155,15 @@ void gVbo::setIndexData(gIndex* indices, int total) {
 
 void gVbo::clear() {
 	if(isvertexdataallocated) {
-		glDeleteBuffers(1, &vbo);
+		renderer->deleteBuffer(vbo);
 		isvertexdataallocated = false;
 	}
 	if(isindexdataallocated) {
-		glDeleteBuffers(1, &ebo);
+		renderer->deleteBuffer(ebo);
 		isvertexdataallocated = false;
     }
 	if (vao != GL_NONE) {
-		glDeleteVertexArrays(1, &vao);
+		renderer->deleteVAO(vao);
 		vao = GL_NONE;
 	}
 }


### PR DESCRIPTION
- I created a class named gGLRenderEngine inherits from gRenderer.
- I directly moved already existing functions inside gRenderer that are also using gl commands.
- Then I visited all other files and created necessary pure virtual functions inside gRenderer for missing gl commands.