### PR TITLE
cmake: guard -stdlib=libc++ flag to Clang builds

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -9,7 +9,6 @@ endif()
 
 # Configure compiler and linker as you need
 set(GLIST_CXX_FLAGS_COMMON
-    -stdlib=libc++
     -Wuninitialized
     -Wmultichar
     -ffunction-sections
@@ -19,6 +18,12 @@ set(GLIST_CXX_FLAGS_COMMON
     -fpermissive
     -fPIC
 )
+
+# Only add libc++ if using Clang
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+	list(INSERT GLIST_CXX_FLAGS_COMMON 0 -stdlib=libc++)
+endif()
+
 list(APPEND GLIST_CXX_FLAGS_DEBUG -DDEBUG -O0 -g)
 list(APPEND GLIST_CXX_FLAGS_RELEASE -DEIGEN_NO_CUDA -DNDEBUG -O2)
 if(NOT APPLE)

--- a/engine/types/gColor.h
+++ b/engine/types/gColor.h
@@ -11,6 +11,7 @@
 
 #include <glm/vec3.hpp>
 #include <glm/vec4.hpp>
+#include <cmath>
 
 class gColor {
 public:

--- a/engine/ui/gGUINotebook.h
+++ b/engine/ui/gGUINotebook.h
@@ -200,6 +200,8 @@ private:
 				box.y = boxh - box.h;
 				return box;
 			}
+			default:
+				return *this;
 			}
 		}
 


### PR DESCRIPTION
During linux build, since linux might not use clang++ compiler but /usr/bin/c++ compiler instead, I let CMakeLists.txt to put -stdlib=libc++ is only for clang++.

Previously in CMakeLists.txt
```cmake
# Configure compiler and linker as you need
set(GLIST_CXX_FLAGS_COMMON
    -stdlib=libc++
    -Wuninitialized
    -Wmultichar
    -ffunction-sections
    -fdata-sections
    -fexceptions
    -frtti
    -fpermissive
    -fPIC
)
```

Now in CMakeLists.txt
```cmake
# Configure compiler and linker as you need
set(GLIST_CXX_FLAGS_COMMON
    -Wuninitialized
    -Wmultichar
    -ffunction-sections
    -fdata-sections
    -fexceptions
    -frtti
    -fpermissive
    -fPIC
)

# Only add libc++ if using Clang
if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
	list(INSERT GLIST_CXX_FLAGS_COMMON 0 -stdlib=libc++)
endif()
```

Additional:
- fmodf function was automatically detected with clang++ but not with c++ compiler, that's why I added ```#include <cmath>```