### PR TITLE
gGUITextbox incorrect cursor positioning has been fixed.

### DIFF
--- a/engine/ui/gGUITextbox.cpp
+++ b/engine/ui/gGUITextbox.cpp
@@ -118,6 +118,7 @@ void gGUITextbox::set(gBaseApp* root, gBaseGUIObject* topParentGUIObject, gBaseG
 	toplimit = top;
 	bottomlimit = bottom;
 	textfont = appmanager->getGUIManager()->getFont(gGUIManager::FONT_FREESANS);
+	cursoroffset = textfont->getStringWidth("a") * 0.2f;
 }
 
 void gGUITextbox::setText(const std::string& text) {
@@ -249,6 +250,7 @@ void gGUITextbox::update() {
 		}
 
 		handleKeys();
+		resetCursorPosition();
 	}
 	if(boxw - width > 0) boxshrinked = true;
 	else if(boxw - width < 0) boxexpanded = true;
@@ -1888,4 +1890,8 @@ void gGUITextbox::setEditMode(bool editMode) {
 
 int gGUITextbox::calculateContentHeight() {
 	return totalh;
+}
+
+void gGUITextbox::resetCursorPosition() {
+	cursorposx = cursoroffset + textfont->getStringWidth(lines[currentline - 1].substr(firstutf, cursorposutf - firstutf));
 }

--- a/engine/ui/gGUITextbox.cpp
+++ b/engine/ui/gGUITextbox.cpp
@@ -101,6 +101,7 @@ gGUITextbox::gGUITextbox() {
 	textcolor = fontcolor;
 	colorset = false;
 	isdisabled = false;
+	cursoroffset = 10.0f;
 	setTextAlignment(textalignment, boxw, initx);
 	
 	widthexceeded = false;

--- a/engine/ui/gGUITextbox.h
+++ b/engine/ui/gGUITextbox.h
@@ -299,7 +299,7 @@ private:
 	gColor* textcolor;
 	bool colorset;
 	bool isdisabled;
-    float cursoroffset = 0.0f; //Offset for cursor position to prevent blending with last character
+    float cursoroffset;
 
 	bool widthexceeded;
 	int widthAdjusmentDelay;

--- a/engine/ui/gGUITextbox.h
+++ b/engine/ui/gGUITextbox.h
@@ -260,6 +260,7 @@ private:
 	void findCursorPosition();
 	void findCursorPositionPassword();
 	void calculateLineCount();
+	void resetCursorPosition();
 	bool selectionmode;
 	int selectionposchar1, selectionposchar2;
 	int selectionposx1, selectionposx2;
@@ -298,6 +299,7 @@ private:
 	gColor* textcolor;
 	bool colorset;
 	bool isdisabled;
+    float cursoroffset = 0.0f; //Offset for cursor position to prevent blending with last character
 
 	bool widthexceeded;
 	int widthAdjusmentDelay;


### PR DESCRIPTION
Added resetCursorPosition function to fix cursor position, with a offset. But still need to clean up the orijinal codebase.