### PR TITLE
Add mobile GUI support: scrollable pages, touch gestures and virtual keyboard

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -360,6 +360,12 @@ if(NOT (ANDROID OR IOS OR EMSCRIPTEN))
 	)
 endif()
 
+if(IOS)
+	# miniaudio's implementation talks to AVFoundation on iOS, so the
+	# translation unit carrying it must be compiled as Objective-C++.
+	set_source_files_properties(${ENGINE_DIR}/media/gSound.cpp PROPERTIES LANGUAGE OBJCXX)
+endif()
+
 set(SHADERS_DIR "${ENGINE_DIR}/graphics/shaders" CACHE STRING "Engine shaders directory")
 set(GENERATED_SHADERS_DIR "${GENERATED_HEADERS_DIR}/graphics/shaders" CACHE STRING "Generated shaders directory")
 file(MAKE_DIRECTORY ${GENERATED_SHADERS_DIR})

--- a/engine/core/gAppManager.cpp
+++ b/engine/core/gAppManager.cpp
@@ -387,11 +387,12 @@ void gAppManager::loop() {
 #endif
     //gLogi("gAppManager") << "starting loop";
     isrunning = true;
-#ifdef ANDROID
-	// Android drives the app through initialize()/setup()/loop() directly instead
-	// of runApp(), so the GUI app thread must also be started here. Every other
-	// platform reaches this function through runApp(), which has already started
-	// it, so the call is confined here rather than changing their startup path.
+#if defined(ANDROID) || TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
+	// Android and iOS drive the app through initialize()/setup()/loop() directly
+	// instead of runApp(), so the GUI app thread must also be started here. The
+	// desktop platforms reach this function through runApp(), which has already
+	// started it, so the call is confined here rather than changing their
+	// startup path. (On iOS this function runs once, from setup().)
 	if(isguiapp && guiappthread) guiappthread->start();
 #endif
 	starttime = AppClock::now();
@@ -933,7 +934,7 @@ bool gAppManager::onWindowResizedEvent(gWindowResizeEvent& event) {
     if(!canvasmanager || !initialized || (!isguiapp && !getCurrentCanvas() && !canvasmanager->getTempCanvas())) {
         return true;
     }
-#ifdef ANDROID
+#if GLIST_ANDROID || GLIST_IOS
     delayedresize = false;
     bool swapdimensions = false;
     // The scrollable layout derives the whole unit space from the screen and

--- a/engine/core/gAppManager.cpp
+++ b/engine/core/gAppManager.cpp
@@ -13,7 +13,9 @@
 #include "gBaseApp.h"
 #include "gCanvasManager.h"
 #include "gGUIFrame.h"
+#include "gGUIScrollable.h"
 
+#include <cmath>
 #include <thread>
 #include "gGUIAppThread.h"
 #include "gTracy.h"
@@ -35,6 +37,86 @@
 #include "gWebCanvas.h"
 #include "gWebApp.h"
 #include "emscripten.h"
+#endif
+
+#if GLIST_ANDROID || GLIST_IOS
+namespace {
+
+// Tuning for the mobile page gestures. All distances are in unit space, so they
+// keep the same physical size across screens: the layout scale is what maps unit
+// space onto pixels and it is held fixed by design.
+
+// Exponential decay rate of the fling, per second: the speed is multiplied by
+// e^(-rate * dt) each frame. A flick therefore covers speed/rate units in all,
+// which at this value puts an ordinary flick at about half a screen and a hard
+// one at rather more than a screen, over one to one and a half seconds.
+constexpr float flingdecayrate = 3.0f;
+// Below this release speed the gesture was a drag, not a flick, and the page
+// stops where the finger left it.
+constexpr float flingminstartspeed = 60.0f;
+// The fling ends here rather than crawling towards zero forever.
+constexpr float flingstopspeed = 20.0f;
+// A frame longer than this is a stall or a return from the background, and
+// integrating it whole would teleport the page.
+constexpr float flingmaxstep = 0.1f;
+// Velocity samples closer together than this cannot be timed reliably, and ones
+// further apart are stale by the time the finger is released.
+constexpr float velocitymininterval = 0.001f;
+constexpr float velocitymaxinterval = 0.2f;
+// Weight of the newest sample. Smoothing keeps a single stuttered frame from
+// deciding the flick, while still following the finger closely.
+constexpr float velocitysmoothing = 0.7f;
+
+// How far past its end the page may be pulled, in units. The pull resists as it
+// nears this, so it is a limit approached rather than a distance reached.
+constexpr float overscrollmax = 90.0f;
+// Exponential rate at which the page springs back once nothing holds it out.
+// Much faster than the fling decay: the bounce should read as the page refusing
+// to go further, not as a movement of its own.
+constexpr float overscrollreturnrate = 12.0f;
+// Under this the spring is done and the offset is dropped to zero outright.
+constexpr float overscrollstopdistance = 0.5f;
+// Seconds of the leftover fling speed that go into the bounce when a throw
+// reaches the end. Small, because a hard fling carries a lot of speed and the
+// bounce should stay a hint rather than becoming a second scroll.
+constexpr float overscrollbouncetime = 0.12f;
+
+// How long the indicator stays fully opaque after the last movement, and how
+// long it then takes to fade out.
+constexpr float scrollindicatorholdtime = 0.15f;
+constexpr float scrollindicatorfadetime = 0.15f;
+constexpr int scrollindicatorthickness = 12;
+constexpr int scrollindicatormargin = 4;
+// Keeps the thumb grabbable-looking on very long pages.
+constexpr int scrollindicatorminlength = 24;
+constexpr int scrollindicatoralpha = 110;
+// While the page is stretched past its end, the thumb's tip on the side being
+// pulled darkens. This is how black that tip gets at full stretch; its length
+// grows with the stretch, see overscrollTipLength().
+constexpr int scrollindicatordarktipalpha = 145;
+
+// How long the darkened tip is for a given stretch: proportional to how far past
+// the end the finger is, the whole thumb at full stretch, nothing when not
+// stretched. Sign of overscroll is dropped here - which end it applies to is the
+// caller's business.
+int overscrollTipLength(int overscroll, int thumblength) {
+	int stretch = overscroll < 0 ? -overscroll : overscroll;
+	if(stretch <= 0) return 0;
+	float ratio = (float)stretch / overscrollmax;
+	if(ratio > 1.0f) ratio = 1.0f;
+	int length = (int)(thumblength * ratio);
+	if(length > thumblength) length = thumblength;
+	return length;
+}
+
+// A release has to be delivered to end a press that the control is holding, but
+// delivering it where the finger actually is would land inside the control and
+// count as a click on it: gGUIButton fires G_GUIEVENT_BUTTONRELEASED whenever the
+// release point falls within its bounds. Sending the release from a point no
+// control can occupy takes the press back instead of completing it.
+constexpr int cancelledreleaseposition = -100000;
+
+}
 #endif
 
 void gStartEngine(gBaseApp* baseApp, const std::string& appName, int windowMode, int width, int height, bool isResizable) {
@@ -152,6 +234,49 @@ gAppManager::gAppManager(const std::string& appName, gBaseApp *baseApp, int widt
 	isguiapp = false;
 	if(windowMode == G_WINDOWMODE_GUIAPP || windowMode == G_WINDOWMODE_FULLSCREENGUIAPP) isguiapp = true;
 	if(isguiapp) guiappthread = new gGUIAppThread(baseApp);
+
+	// The fixed scale plus scrolling model targets phone screens, where a
+	// rotation reshapes the screen underneath a layout the user cannot resize.
+	// Desktop windows are resized freely and keep the older proportional
+	// behaviour, so the model stays off there. Among the mobile window modes the
+	// GUI app ones are the ones that lay out a page of controls.
+#if GLIST_ANDROID || GLIST_IOS
+	scrollablelayout = isguiapp;
+#else
+	scrollablelayout = false;
+#endif
+	layoutscale = 0.0f;
+	layoutreferencewidth = 0;
+	layoutreferenceheight = 0;
+	istouchpressed = false;
+	istouchscrolling = false;
+	istouchrebaseneeded = false;
+	istouchownedbycontrol = false;
+	touchstartx = 0;
+	touchstarty = 0;
+	touchstartscrollx = 0;
+	touchstartscrolly = 0;
+	desiredscrollx = 0;
+	desiredscrolly = 0;
+#if GLIST_ANDROID || GLIST_IOS
+	isflinging = false;
+	flingvelocityx = 0.0f;
+	flingvelocityy = 0.0f;
+	flingpositionx = 0.0f;
+	flingpositiony = 0.0f;
+	hastouchvelocity = false;
+	lasttouchmovetime = AppClock::now();
+	lasttouchscrollx = 0;
+	lasttouchscrolly = 0;
+	iscontentdrivenheight = true;
+	lastcontentheight = -1;
+	ungrownlayoutheight = 0;
+	overscrollx = 0.0f;
+	overscrolly = 0.0f;
+	scrollindicatortimer = 0.0f;
+	scrollindicatorlastscrollx = 0;
+	scrollindicatorlastscrolly = 0;
+#endif
 }
 
 gAppManager::~gAppManager() {
@@ -194,6 +319,14 @@ void gAppManager::initialize() {
     }
 	deltatime = AppClockDuration(0);
 
+#if GLIST_ANDROID || GLIST_IOS
+	// A gesture cannot span a trip through the background: the touches that
+	// would have ended it went to a window that no longer exists. onAppPauseEvent
+	// already clears it, but that runs off a queue which a stopping loop may
+	// never drain, so this is where the guarantee actually holds.
+	resetTouchGesture();
+#endif
+
 	if(usewindow) {
 		window->initialize(width, height, windowmode, isresizable);
 		window->setTitle(appname);
@@ -213,6 +346,22 @@ void gAppManager::initialize() {
 		renderer->setScreenSize(width, height);
 		renderer->setUnitScreenSize(unitwidth, unitheight);
 		renderer->setScreenScaling(screenscaling);
+
+		// The scale the app was designed with is captured once and every later
+		// layout is derived from it, so that no rotation can redefine what the
+		// app considers its own scale.
+		if(!initializedbefore) {
+			layoutreferencewidth = unitwidth;
+			layoutreferenceheight = unitheight;
+			layoutscale = computeLayoutScale(width, height);
+		}
+		// On Android this whole function runs again every time the app returns
+		// from the background, because stop() clears the initialized flag and
+		// onStart calls initialize() afresh. updateScrollableLayout() re-applies
+		// the remembered scroll position, so the user keeps their place in the
+		// page across that - and equally if the surface size arrives late and
+		// this first layout turns out to be the wrong one.
+		if(isScrollableLayoutActive()) updateScrollableLayout(width, height);
 
 		// Create managers if not created
 		if(!guimanager) {
@@ -238,6 +387,13 @@ void gAppManager::loop() {
 #endif
     //gLogi("gAppManager") << "starting loop";
     isrunning = true;
+#ifdef ANDROID
+	// Android drives the app through initialize()/setup()/loop() directly instead
+	// of runApp(), so the GUI app thread must also be started here. Every other
+	// platform reaches this function through runApp(), which has already started
+	// it, so the call is confined here rather than changing their startup path.
+	if(isguiapp && guiappthread) guiappthread->start();
+#endif
 	starttime = AppClock::now();
 
 #ifdef ANDROID
@@ -277,6 +433,17 @@ void gAppManager::loop() {
         }
     }
     //gLogi("gAppManager") << "stopping loop";
+#ifdef ANDROID
+	// The thread must be joined before this function returns, because loop() can
+	// be entered again on the next onStart and gThread::start() cannot safely
+	// reassign a still-joinable std::thread. Only Android re-enters loop(); the
+	// other platforms keep joining it in the destructor as they always have, so
+	// their shutdown order is left untouched.
+	if(isguiapp && guiappthread) {
+		guiappthread->stop();
+		guiappthread->wait();
+	}
+#endif
     app->stop();
     if(usewindow) {
         window->close();
@@ -363,10 +530,141 @@ void gAppManager::setWindowSizeLimits(int minWidth, int minHeight, int maxWidth,
 	window->setWindowSizeLimits(minWidth, minHeight, maxWidth, maxHeight);
 }
 
+void gAppManager::enableScrollableLayout(bool enable) {
+#if GLIST_ANDROID || GLIST_IOS
+	if(scrollablelayout == enable) return;
+	scrollablelayout = enable;
+	if(!initialized) return;
+	if(enable) {
+		updateScrollableLayout(renderer->getScreenWidth(), renderer->getScreenHeight());
+	} else {
+		gRenderer::setUnitViewportWidth(0);
+		gRenderer::setUnitViewportHeight(0);
+		// There is no page to be anywhere in once the model is off, so the
+		// remembered position must not survive to be re-applied if it is
+		// switched back on later.
+		desiredscrollx = 0;
+		desiredscrolly = 0;
+		// The model derived the unit size from the screen, so switching it off
+		// has to hand the design size back. setScreenSize() alone would not:
+		// its proportional branch recalculates the unit size from itself and
+		// would simply keep whatever the model last derived.
+		if(layoutreferencewidth > 0 && layoutreferenceheight > 0) {
+			gRenderer::setUnitScreenSize(layoutreferencewidth, layoutreferenceheight);
+		}
+		setScreenSize(renderer->getScreenWidth(), renderer->getScreenHeight());
+	}
+#else
+	// Mobile only, so there is nothing to switch here. See the constructor.
+	(void)enable;
+#endif
+}
+
+float gAppManager::computeLayoutScale(int screenWidth, int screenHeight) const {
+	if(unitwidth <= 0) return 1.0f;
+	// The orientation the app happens to be launched in must not decide its
+	// scale, otherwise starting a phone in landscape renders it differently
+	// from starting it upright and turning it. The design size is therefore
+	// matched against a physical side of the screen rather than a screen axis:
+	// a portrait design spans the short side and a landscape one the long side,
+	// and neither side changes identity when the device rotates.
+	int shortside = screenWidth < screenHeight ? screenWidth : screenHeight;
+	int longside = screenWidth < screenHeight ? screenHeight : screenWidth;
+	int designside = unitheight > unitwidth ? shortside : longside;
+	if(designside < 1) return 1.0f;
+	return (float)designside / (float)unitwidth;
+}
+
+bool gAppManager::isScrollableLayoutActive() const {
+	return scrollablelayout && layoutscale > 0.0f && screenscaling >= G_SCREENSCALING_AUTO;
+}
+
+void gAppManager::updateScrollableLayout(int screenWidth, int screenHeight) {
+	// Everything follows from holding the scale still: the unit space is simply
+	// however much of it the screen can show at that scale. A rotation widens
+	// the layout and shortens the visible band instead of restretching both,
+	// which is why controls keep their size and proportions across it.
+	int unitw = (int)std::lround(screenWidth / layoutscale);
+	int viewportheight = (int)std::lround(screenHeight / layoutscale);
+	if(unitw < 1) unitw = 1;
+	if(viewportheight < 1) viewportheight = 1;
+
+	// The layout keeps the size it was designed for even when the screen is
+	// smaller than that; the remainder becomes scrollable rather than squeezed
+	// or, on the horizontal axis, cut off with no way to reach it. A portrait
+	// design only ever overflows vertically and a landscape one horizontally,
+	// so in practice at most one of the two axes actually scrolls.
+	int layoutwidth = unitw > layoutreferencewidth ? unitw : layoutreferencewidth;
+	int layoutheight = viewportheight > layoutreferenceheight ? viewportheight : layoutreferenceheight;
+#if GLIST_ANDROID || GLIST_IOS
+	// A third candidate: what the content itself needs. The design size says how
+	// tall the page was drawn for, not how much has since been put on it, and a
+	// page with more rows than it was designed for used to squash them all rather
+	// than grow. Measured against the previous pass, which is enough because the
+	// width - and so every wrap and every content height that follows from it -
+	// is settled before the height is ever asked about.
+	// Kept so that a later measurement outside this function asks the same
+	// question this one did. Measuring against the grown height instead would let
+	// each answer raise the next one.
+	ungrownlayoutheight = layoutheight;
+	if(iscontentdrivenheight) {
+		int contentheight = measureLayoutContentHeight(layoutheight);
+		if(contentheight > layoutheight) layoutheight = contentheight;
+	}
+#endif
+
+	gRenderer::setUnitScreenSize(layoutwidth, layoutheight);
+	gRenderer::setUnitViewportWidth(unitw);
+	gRenderer::setUnitViewportHeight(viewportheight);
+	gRenderer::setScreenSize(screenWidth, screenHeight);
+	// Each setter above clamps the position against the sizes known at that
+	// moment, so it is re-applied here, once they all agree on the new layout.
+	// The remembered position is the source rather than the renderer's own:
+	// reading that back would return whatever the intermediate steps clamped it
+	// to, which is how a rotation or a return from the background used to lose
+	// the user's place. Deliberately not written back - a layout too short to
+	// hold the position must not shorten the memory of it, or rotating away and
+	// back would not return to where the user was.
+	gRenderer::setScrollX(desiredscrollx);
+	gRenderer::setScrollY(desiredscrolly);
+
+#if GLIST_ANDROID || GLIST_IOS
+	// The indicator otherwise only appears once the page has already moved,
+	// which leaves the user no way to tell there is anything below the fold.
+	// Showing it briefly whenever the layout is (re)built - at launch and after
+	// every rotation - is what makes the overflow discoverable.
+	if(gRenderer::getMaxScrollX() > 0 || gRenderer::getMaxScrollY() > 0) {
+		scrollindicatortimer = scrollindicatorholdtime + scrollindicatorfadetime;
+	}
+	scrollindicatorlastscrollx = gRenderer::getScrollX();
+	scrollindicatorlastscrolly = gRenderer::getScrollY();
+#endif
+
+	if(iscanvasset && canvasmanager && canvasmanager->getCurrentCanvas()) {
+		canvasmanager->getCurrentCanvas()->windowResized(renderer->getWidth(), renderer->getHeight());
+	}
+	if(guimanager && guimanager->isframeset) {
+		guimanager->windowResized(renderer->getWidth(), renderer->getHeight());
+	}
+}
+
+void gAppManager::setScrollPosition(int scrollX, int scrollY) {
+	gRenderer::setScrollX(scrollX);
+	gRenderer::setScrollY(scrollY);
+	// Stored after the setters, so the memory holds a position that was actually
+	// reachable rather than however far past the end the gesture asked for.
+	desiredscrollx = gRenderer::getScrollX();
+	desiredscrolly = gRenderer::getScrollY();
+}
+
 void gAppManager::setScreenSize(int width, int height) {
 	G_PROFILE_ZONE_SCOPED_N("gAppManager::setScreenSize()");
 	G_PROFILE_ZONE_VALUE(width);
 	G_PROFILE_ZONE_VALUE(height);
+	if(isScrollableLayoutActive()) {
+		updateScrollableLayout(width, height);
+		return;
+	}
 	if(screenscaling == G_SCREENSCALING_AUTO_ONCE) {
 		// We don't want to update the unitresolution, that's why its setting directly. gAppManager needs to be a friend of gRenderer to do this.
 		renderer->unitwidth = renderer->scaleX(width);
@@ -376,7 +674,7 @@ void gAppManager::setScreenSize(int width, int height) {
     if(iscanvasset && canvasmanager->getCurrentCanvas()) {
 	    canvasmanager->getCurrentCanvas()->windowResized(renderer->getWidth(), renderer->getHeight());
     }
-    if(iscanvasset && guimanager->isframeset) {
+    if(guimanager && guimanager->isframeset) {
 	    guimanager->windowResized(renderer->getWidth(), renderer->getHeight());
     }
 }
@@ -501,6 +799,46 @@ void gAppManager::tick() {
         return;
     }
 
+#ifdef ANDROID
+	// The Java-side resize notification travels through two queues before it
+	// reaches the engine; it can be dropped when the queue is full and it can
+	// observe a stale surface size mid-rotation, in which case no corrective
+	// notification ever follows and the screen stays stuck in the old
+	// orientation. The real surface size is therefore polled every frame and a
+	// mismatch is fed into the normal resize path, which makes missed or stale
+	// notifications self-healing on the next frame.
+	if(window->isRendering()) {
+		EGLDisplay currentdisplay = eglGetCurrentDisplay();
+		EGLSurface currentsurface = eglGetCurrentSurface(EGL_DRAW);
+		EGLint surfacewidth, surfaceheight;
+		if(currentdisplay != EGL_NO_DISPLAY && currentsurface != EGL_NO_SURFACE &&
+				eglQuerySurface(currentdisplay, currentsurface, EGL_WIDTH, &surfacewidth) &&
+				eglQuerySurface(currentdisplay, currentsurface, EGL_HEIGHT, &surfaceheight) &&
+				(surfacewidth != renderer->getScreenWidth() || surfaceheight != renderer->getScreenHeight())) {
+			renderer->setViewport(0, 0, surfacewidth, surfaceheight);
+			window->setSize(surfacewidth, surfaceheight);
+		}
+	}
+#endif
+
+#if GLIST_ANDROID || GLIST_IOS
+	// Ahead of the managers, so that the controls are updated against the scroll
+	// position this frame will actually be drawn at.
+	// Before the fling and the layout work below, so that everything this frame
+	// sees the same page height.
+	updateLayoutContentHeight();
+	if(isScrollableLayoutActive()) {
+		updateFling();
+		// After the fling, so a throw that reaches the end this frame starts
+		// springing back on the next one rather than being cut short here.
+		updateOverscroll();
+		updateScrollIndicator();
+	}
+	// Outside the layout check: a control's own content scrolls whether or not
+	// the page around it does.
+	if(isguiapp) gGUIScrollable::updateContentFling();
+#endif
+
     if(canvasmanager) canvasmanager->update();
     if(guimanager) guimanager->update();
     if(!isguiapp) {
@@ -543,6 +881,10 @@ void gAppManager::tick() {
 			}
     	}
 		if(guimanager) guimanager->draw();
+#if GLIST_ANDROID || GLIST_IOS
+		// Last, so that it sits above the page rather than under its controls.
+		if(isScrollableLayoutActive()) drawScrollIndicator();
+#endif
         totaldraws++;
     }
 	if(inputmanager) inputmanager->update();
@@ -588,44 +930,47 @@ void gAppManager::onEvent(gEvent& event) {
 }
 
 bool gAppManager::onWindowResizedEvent(gWindowResizeEvent& event) {
-    if(!canvasmanager || !initialized || (!getCurrentCanvas() && !canvasmanager->getTempCanvas())) {
+    if(!canvasmanager || !initialized || (!isguiapp && !getCurrentCanvas() && !canvasmanager->getTempCanvas())) {
         return true;
     }
-    setScreenSize(event.getWidth(), event.getHeight());
 #ifdef ANDROID
     delayedresize = false;
-    if(gRenderer::getScreenScaling() >= G_SCREENSCALING_AUTO && olddeviceorientation != deviceorientation) {
-		DeviceOrientation orientation = deviceorientation;
-		DeviceOrientation oldorientation = olddeviceorientation;
-		// Normalize values
-		if(orientation == DEVICEORIENTATION_REVERSE_PORTRAIT) {
-			orientation = DEVICEORIENTATION_PORTRAIT;
-		} else if(orientation == DEVICEORIENTATION_REVERSE_LANDSCAPE) {
-			orientation = DEVICEORIENTATION_LANDSCAPE;
-		}
-		if(oldorientation == DEVICEORIENTATION_REVERSE_PORTRAIT) {
-			oldorientation = DEVICEORIENTATION_PORTRAIT;
-		} else if(oldorientation == DEVICEORIENTATION_REVERSE_LANDSCAPE) {
-			oldorientation = DEVICEORIENTATION_LANDSCAPE;
-		}
-
-		bool swapdimensions = oldorientation != orientation;
-		if((orientation != DEVICEORIENTATION_PORTRAIT && orientation != DEVICEORIENTATION_LANDSCAPE) ||
-			(oldorientation != DEVICEORIENTATION_PORTRAIT && oldorientation != DEVICEORIENTATION_LANDSCAPE)) {
-			// If this orientation is not known, we should not do anything
-			swapdimensions = false;
-		}
-
-		// Orientation changed, we should swap height and width
-		if(swapdimensions) {
-			int unitwidth = gBaseCanvas::getRenderer()->getUnitWidth();
-			int unitheight = gBaseCanvas::getRenderer()->getUnitHeight();
-			// Swap width and height values
-			gRenderer::setUnitScreenSize(unitheight, unitwidth);
-		}
+    bool swapdimensions = false;
+    // The scrollable layout derives the whole unit space from the screen and
+    // the fixed scale, so it already produces the rotated layout on its own and
+    // the swap below would only fight it.
+    if(!isScrollableLayoutActive() && gRenderer::getScreenScaling() >= G_SCREENSCALING_AUTO) {
+		// Rotation is detected from the surface dimensions carried by the event
+		// itself instead of the device orientation events: those are dispatched
+		// from the Java UI thread and can reach the engine after this resize
+		// event, in which case an orientation-based check misses the rotation,
+		// the unit swap never happens and the proportional rescale below
+		// corrupts the unit sizes. The surface shape flipping between
+		// portrait-like and landscape-like is a race-free rotation signal.
+		int oldwidth = renderer->getScreenWidth();
+		int oldheight = renderer->getScreenHeight();
+		swapdimensions = oldwidth != oldheight && event.getWidth() != event.getHeight() &&
+				(oldwidth > oldheight) != (event.getWidth() > event.getHeight());
     }
     olddeviceorientation = deviceorientation;
+	if(swapdimensions) {
+		// Device rotated: the unit space rotates with it (e.g. 720x1280 becomes
+		// 1280x720). The proportional AUTO_ONCE recalculation in setScreenSize()
+		// assumes a same-orientation resize and would corrupt the unit values
+		// here, so screen and unit sizes are set directly and the canvas/GUI are
+		// notified only once both hold their final values.
+		gRenderer::setUnitScreenSize(renderer->getUnitHeight(), renderer->getUnitWidth());
+		gRenderer::setScreenSize(event.getWidth(), event.getHeight());
+		if(iscanvasset && canvasmanager->getCurrentCanvas()) {
+			canvasmanager->getCurrentCanvas()->windowResized(renderer->getWidth(), renderer->getHeight());
+		}
+		if(guimanager && guimanager->isframeset) {
+			guimanager->windowResized(renderer->getWidth(), renderer->getHeight());
+		}
+		return false;
+	}
 #endif
+    setScreenSize(event.getWidth(), event.getHeight());
     return false;
 }
 
@@ -639,12 +984,29 @@ bool gAppManager::onWindowScaleChangedEvent(gWindowScaleChangedEvent& event) {
 		renderer->unitwidth = renderer->width / event.getScaleX();
 		renderer->unitheight = renderer->height / event.getScaleY();
 	}
+	gRenderer::updateProjectionMatrix2d();
 	return false;
 }
 
 bool gAppManager::onCharTypedEvent(gCharTypedEvent& event) {
 //	if (!canvasmanager || !getCurrentCanvas()) return true;
+#if GLIST_ANDROID || GLIST_IOS
+    // In a GUI app the soft keyboard delivers this on the platform UI thread while
+    // the loop draws the GUI on its own thread; driving the widget tree from here
+    // would race that drawing. The GUI part is queued to the loop, exactly as touch
+    // is in handleGUITouch(). Off the GUI-app path the loop runs on this thread, so
+    // the old direct call stands.
+    if(isguiapp) {
+        unsigned int character = event.getCharacter();
+        submitToMainThread([this, character]() {
+            if(guimanager && guimanager->isframeset) guimanager->charPressed(character);
+        });
+    } else if(guimanager->isframeset) {
+        guimanager->charPressed(event.getCharacter());
+    }
+#else
     if(guimanager->isframeset) guimanager->charPressed(event.getCharacter());
+#endif
     for (gBasePlugin*& plugin : gBasePlugin::usedplugins) plugin->charPressed(event.getCharacter());
     if(canvasmanager && getCurrentCanvas()) getCurrentCanvas()->charPressed(event.getCharacter());
     return false;
@@ -652,7 +1014,18 @@ bool gAppManager::onCharTypedEvent(gCharTypedEvent& event) {
 
 bool gAppManager::onKeyPressedEvent(gKeyPressedEvent& event) {
 //    if (!canvasmanager || !getCurrentCanvas()) return true;
+#if GLIST_ANDROID || GLIST_IOS
+    if(isguiapp) {
+        int keycode = event.getKeyCode();
+        submitToMainThread([this, keycode]() {
+            if(guimanager && guimanager->isframeset) guimanager->keyPressed(keycode);
+        });
+    } else if(guimanager->isframeset) {
+        guimanager->keyPressed(event.getKeyCode());
+    }
+#else
     if(guimanager->isframeset) guimanager->keyPressed(event.getKeyCode());
+#endif
     for (gBasePlugin*& plugin : gBasePlugin::usedplugins) plugin->keyPressed(event.getKeyCode());
     if(canvasmanager && getCurrentCanvas()) getCurrentCanvas()->keyPressed(event.getKeyCode());
     return false;
@@ -660,7 +1033,18 @@ bool gAppManager::onKeyPressedEvent(gKeyPressedEvent& event) {
 
 bool gAppManager::onKeyReleasedEvent(gKeyReleasedEvent& event) {
 //    if (!canvasmanager || !getCurrentCanvas()) return true;
+#if GLIST_ANDROID || GLIST_IOS
+    if(isguiapp) {
+        int keycode = event.getKeyCode();
+        submitToMainThread([this, keycode]() {
+            if(guimanager && guimanager->isframeset) guimanager->keyReleased(keycode);
+        });
+    } else if(guimanager->isframeset) {
+        guimanager->keyReleased(event.getKeyCode());
+    }
+#else
     if(guimanager->isframeset) guimanager->keyReleased(event.getKeyCode());
+#endif
     for (gBasePlugin*& plugin : gBasePlugin::usedplugins) plugin->keyReleased(event.getKeyCode());
     if(canvasmanager && getCurrentCanvas()) canvasmanager->getCurrentCanvas()->keyReleased(event.getKeyCode());
     return false;
@@ -736,7 +1120,23 @@ bool gAppManager::onWindowMouseExitEvent(gWindowMouseExitEvent& event) {
 
 bool gAppManager::onMouseScrolledEvent(gMouseScrolledEvent& event) {
 //    if (!canvasmanager || !getCurrentCanvas()) return true;
-    if(guimanager->isframeset) guimanager->mouseScrolled(event.getOffsetX(), event.getOffsetY());
+#if GLIST_ANDROID || GLIST_IOS
+    // Page scrolling with the wheel belongs to the scrollable layout, which is a
+    // mobile only feature. On desktop the wheel keeps its original meaning and
+    // is delivered to the controls, so this branch is compiled out there.
+    if(gRenderer::getMaxScrollX() > 0 || gRenderer::getMaxScrollY() > 0) {
+        // The layout does not fit on screen, so the wheel moves the page itself
+        // rather than reaching the controls on it.
+        setScrollPosition(gRenderer::getScrollX() - event.getOffsetX() * wheelscrollstep,
+                gRenderer::getScrollY() - event.getOffsetY() * wheelscrollstep);
+    } else if(guimanager && guimanager->isframeset) {
+        guimanager->mouseScrolled(event.getOffsetX(), event.getOffsetY());
+    }
+#else
+    if(guimanager && guimanager->isframeset) {
+        guimanager->mouseScrolled(event.getOffsetX(), event.getOffsetY());
+    }
+#endif
     for (gBasePlugin*& plugin : gBasePlugin::usedplugins) plugin->mouseScrolled(event.getOffsetX(), event.getOffsetY());
     if(canvasmanager && getCurrentCanvas()) canvasmanager->getCurrentCanvas()->mouseScrolled(event.getOffsetX(), event.getOffsetY());
     return false;
@@ -820,6 +1220,15 @@ void gAppManager::iosLoop()
 
 bool gAppManager::onAppPauseEvent(gAppPauseEvent& event) {
     submitToMainThread([this]() {
+#if GLIST_ANDROID || GLIST_IOS
+		// The app can be sent to the background with a finger still on the glass
+		// and the platform is not obliged to deliver the matching cancel. The
+		// gesture would then stay half open: its anchor belongs to a touch that
+		// no longer exists, and a fling would resume on return as if no time had
+		// passed. Cancelled rather than merely dropped, so that the part of the
+		// swipe that sent the app away does not stay on the page as scroll.
+		cancelTouchGesture();
+#endif
 		if (app) {
 			app->pause();
 		}
@@ -861,7 +1270,481 @@ bool gAppManager::onDeviceOrientationChangedEvent(gDeviceOrientationChangedEvent
     return false;
 }
 
+void gAppManager::handleGUITouch(gTouchEvent& event) {
+	if(event.getInputCount() < 1) return;
+	int inputindex = gClamp(event.getActionIndex(), 0, event.getInputCount() - 1);
+	// Touch events are delivered on the platform UI thread while the loop is
+	// drawing the GUI on its own thread, and driving the controls from here
+	// would mutate the widget tree underneath that drawing. The position is
+	// copied out of the event, whose input array belongs to the caller's stack
+	// and does not outlive this call, and the gesture is processed in the loop.
+	int touchx = event.getInputs()[inputindex].x;
+	int touchy = event.getInputs()[inputindex].y;
+	ActionType action = event.getAction();
+	submitToMainThread([this, touchx, touchy, action]() {
+		processGUITouch(touchx, touchy, action);
+	});
+}
+
+void gAppManager::processGUITouch(int touchX, int touchY, ActionType action) {
+	int x = touchX;
+	int y = touchY;
+	// Converted here rather than on arrival so that the position is measured
+	// against the screen size the loop currently holds.
+	if(gRenderer::getScreenScaling() > G_SCREENSCALING_NONE) {
+		x = gRenderer::scaleX(x);
+		y = gRenderer::scaleY(y);
+	}
+	bool isframeset = guimanager && guimanager->isframeset;
+
+	switch(action) {
+	case ACTIONTYPE_DOWN:
+		anchorTouchGesture(x, y);
+		istouchpressed = true;
+		istouchscrolling = false;
+		istouchrebaseneeded = false;
+		istouchownedbycontrol = false;
+		// Any coasting content stops the moment a finger lands, wherever it lands.
+		gGUIScrollable::cancelContentFling();
+		if(isframeset) {
+			// The GUI routes presses and drags only to the control it considers
+			// the cursor to be on (gGUISizer::mousePressed and mouseDragged both
+			// test iscursoron), and that flag is set nowhere but mouseMoved. A
+			// mouse sets it by hovering on the way to the click; a finger arrives
+			// with no hover at all, so without this the whole GUI is deaf to
+			// touch. The hover is therefore synthesised at the touch point.
+			guimanager->mouseMoved(x, y);
+			guimanager->mousePressed(x, y, 0);
+		}
+		break;
+	case ACTIONTYPE_POINTER_DOWN:
+	case ACTIONTYPE_POINTER_UP:
+		// A finger joined or left the gesture, so the index the positions are
+		// read from can start referring to a different finger. Measuring that
+		// finger against the anchor of the one that is gone would jump the page,
+		// so the gesture is re-anchored on the next move instead, which carries
+		// it on smoothly from whichever finger remains.
+		istouchrebaseneeded = true;
+		break;
+	case ACTIONTYPE_MOVE: {
+		if(!istouchpressed) break;
+		if(istouchrebaseneeded) {
+			// Deliberately keeps istouchscrolling as it is: re-anchoring moves
+			// the origin of the gesture, it does not start a new one.
+			anchorTouchGesture(x, y);
+			istouchrebaseneeded = false;
+			break;
+		}
+		if(!istouchscrolling) {
+			// The controls see the drag before the page does. A scrollable one
+			// claims it as soon as it starts moving its own content, and while it
+			// holds the claim the page stays still - otherwise a list inside a
+			// scrolling page could never be scrolled, because the page would take
+			// every gesture that began on it.
+			if(isframeset) guimanager->mouseDragged(x, y, 0);
+			if(gGUIScrollable::isContentDragActive()) {
+				istouchownedbycontrol = true;
+				break;
+			}
+			// The finger position is measured against the visible band, which does
+			// not move while scrolling, so the distance stays a plain drag distance
+			// and cannot feed back into itself.
+			int draggedx = touchstartx - x;
+			int draggedy = touchstarty - y;
+			if((gRenderer::getMaxScrollX() > 0 &&
+							(draggedx >= touchscrollthreshold || draggedx <= -touchscrollthreshold)) ||
+					(gRenderer::getMaxScrollY() > 0 &&
+							(draggedy >= touchscrollthreshold || draggedy <= -touchscrollthreshold))) {
+				if(istouchownedbycontrol) {
+					// A control had the gesture and has just run out of content, so
+					// the page picks it up from where the finger is now. Without
+					// this the page would jump by everything the control already
+					// scrolled, since that distance is still in the drag total.
+					anchorTouchGesture(x, y);
+					istouchownedbycontrol = false;
+					break;
+				}
+				istouchscrolling = true;
+				// The gesture turned out to be a scroll, so the press the control is
+				// holding is taken back rather than completed. The threshold is only
+				// 12 units, so the finger is almost certainly still inside the
+				// control it started on and a release at its position would fire it.
+				if(isframeset) guimanager->mouseReleased(cancelledreleaseposition, cancelledreleaseposition, 0);
+			}
+		}
+		if(istouchscrolling) {
+			// At most one of the two axes can overflow for a given design, and
+			// the setters clamp to a range of zero on the other one, so both are
+			// applied without needing to pick an axis first.
+			int targetx = touchstartscrollx + (touchstartx - x);
+			int targety = touchstartscrolly + (touchstarty - y);
+			setScrollPosition(targetx, targety);
+			// Whatever the setters refused to take is how far the finger has
+			// pulled past the end, and that becomes the rubber band.
+			applyDragOverscroll(targetx, targety);
+			// Measured from the scroll that actually took effect rather than from
+			// the finger, so a drag that is already pinned against an edge builds
+			// up no speed and cannot fling away from it on release.
+			trackTouchVelocity();
+		}
+		break;
+	}
+	case ACTIONTYPE_UP:
+		if(istouchpressed && !istouchscrolling && isframeset) {
+			// A drag a control consumed is not a tap on it either: releasing at
+			// the finger's position would select whatever list row it happens to
+			// end on. Only a gesture that never became a drag is a real release.
+			if(istouchownedbycontrol) {
+				guimanager->mouseReleased(cancelledreleaseposition, cancelledreleaseposition, 0);
+			} else {
+				guimanager->mouseReleased(x, y, 0);
+			}
+		}
+		// The finger has left, so the hover synthesised on the way in is taken
+		// back. Left standing it would keep the control looking hovered and, worse,
+		// keep it receiving drags belonging to gestures elsewhere on the page.
+		if(isframeset) guimanager->mouseMoved(cancelledreleaseposition, cancelledreleaseposition);
+		// A flick hands its speed over to the page; a slow drag just stops where
+		// it was let go. Only a real release does this, never a cancel: there the
+		// system took the gesture away and the user did not throw anything.
+		if(istouchscrolling &&
+				(std::fabs(flingvelocityx) >= flingminstartspeed ||
+				 std::fabs(flingvelocityy) >= flingminstartspeed)) {
+			isflinging = true;
+			flingpositionx = (float)gRenderer::getScrollX();
+			flingpositiony = (float)gRenderer::getScrollY();
+		} else {
+			flingvelocityx = 0.0f;
+			flingvelocityy = 0.0f;
+		}
+		istouchpressed = false;
+		istouchscrolling = false;
+		istouchrebaseneeded = false;
+		break;
+	case ACTIONTYPE_CANCEL:
+		// Released so the control does not stay stuck pressed, but from outside
+		// itself: the system withdrew the gesture, so this is not a click.
+		if(istouchpressed && !istouchscrolling && isframeset) {
+			guimanager->mouseReleased(cancelledreleaseposition, cancelledreleaseposition, 0);
+		}
+		if(isframeset) guimanager->mouseMoved(cancelledreleaseposition, cancelledreleaseposition);
+		cancelTouchGesture();
+		break;
+	default:
+		break;
+	}
+}
+
+void gAppManager::anchorTouchGesture(int touchX, int touchY) {
+	touchstartx = touchX;
+	touchstarty = touchY;
+	touchstartscrollx = gRenderer::getScrollX();
+	touchstartscrolly = gRenderer::getScrollY();
+	// A finger is on the glass, so it owns the page from here on. Catching a
+	// running fling this way is what lets the user stop a long page mid flight.
+	isflinging = false;
+	flingvelocityx = 0.0f;
+	flingvelocityy = 0.0f;
+	// The measurement restarts with the gesture: the interval across a re-anchor
+	// spans two different fingers and would read as a jump.
+	hastouchvelocity = false;
+}
+
+void gAppManager::cancelTouchGesture() {
+	// The gesture was withdrawn rather than finished: the system claimed it, or
+	// the app was sent away in the middle of it. The user never asked for the
+	// distance travelled so far, so the page goes back to where the gesture
+	// found it. Without this, every trip through the recents switcher leaves the
+	// page a notch further down, because the swipe that opens it is delivered
+	// here before the system takes it over.
+	if(istouchscrolling) {
+		setScrollPosition(touchstartscrollx, touchstartscrolly);
+	}
+	// A withdrawn gesture throws nothing, so any fling it just started is dropped.
+	gGUIScrollable::cancelContentFling();
+	resetTouchGesture();
+}
+
+int gAppManager::measureLayoutContentHeight(int referenceHeight) {
+	if(!guimanager || !guimanager->isframeset) return 0;
+	gGUIFrame* frame = guimanager->getCurrentFrame();
+	if(!frame) return 0;
+	gGUISizer* sizer = frame->getSizer();
+	if(!sizer) return 0;
+	// The reference is handed over rather than left to the sizer to remember. It
+	// is what the page would be tall without any growing, so it is also what a row
+	// with nothing to say about itself is entitled to - and it is recomputed here
+	// on every rotation, which a remembered one never would be.
+	sizer->setReferenceHeight(referenceHeight);
+	return sizer->getNaturalHeight();
+}
+
+void gAppManager::updateLayoutContentHeight() {
+	if(!iscontentdrivenheight || !isScrollableLayoutActive()) return;
+	if(ungrownlayoutheight <= 0) return;
+	// Nothing announces that a row has been added, so the measurement is repeated
+	// every frame - a walk of a few dozen slots adding integers. What is expensive
+	// is rebuilding the layout, and that only happens when the answer has actually
+	// changed.
+	int contentheight = measureLayoutContentHeight(ungrownlayoutheight);
+	if(contentheight == lastcontentheight) return;
+	lastcontentheight = contentheight;
+	updateScrollableLayout(renderer->getScreenWidth(), renderer->getScreenHeight());
+	if(guimanager && guimanager->isframeset) {
+		guimanager->windowResized(renderer->getWidth(), renderer->getHeight());
+	}
+}
+
+void gAppManager::enableContentDrivenHeight(bool isEnabled) {
+	if(iscontentdrivenheight == isEnabled) return;
+	iscontentdrivenheight = isEnabled;
+	lastcontentheight = -1;
+	if(isScrollableLayoutActive()) {
+		updateScrollableLayout(renderer->getScreenWidth(), renderer->getScreenHeight());
+		if(guimanager && guimanager->isframeset) {
+			guimanager->windowResized(renderer->getWidth(), renderer->getHeight());
+		}
+	}
+}
+
+bool gAppManager::isContentDrivenHeightEnabled() const {
+	return iscontentdrivenheight;
+}
+
+void gAppManager::setOverscroll(float overscrollX, float overscrollY) {
+	overscrollx = overscrollX;
+	overscrolly = overscrollY;
+	// Kept in floats here and handed over rounded, so a slow spring is not
+	// rounded away frame after frame and left stuck a unit short of home.
+	gRenderer::setOverscroll((int)std::lround(overscrollx), (int)std::lround(overscrolly));
+}
+
+float gAppManager::resistOverscroll(float distance) {
+	// The further the page is pulled past its end, the less of the finger's
+	// movement it gives up: the offset approaches overscrollmax without ever
+	// reaching it. Following the finger one to one out here would let the page be
+	// dragged clean off the screen and would give nothing to push back against.
+	float magnitude = std::fabs(distance);
+	float resisted = overscrollmax * magnitude / (magnitude + overscrollmax);
+	return distance < 0.0f ? -resisted : resisted;
+}
+
+void gAppManager::applyDragOverscroll(int targetX, int targetY) {
+	// Only an axis that scrolls at all can be pulled past its end. On one that
+	// fits, the whole page would otherwise slide about under any stray drag.
+	float overx = 0.0f;
+	float overy = 0.0f;
+	if(gRenderer::getMaxScrollX() > 0) {
+		overx = resistOverscroll((float)(targetX - gRenderer::getScrollX()));
+	}
+	if(gRenderer::getMaxScrollY() > 0) {
+		overy = resistOverscroll((float)(targetY - gRenderer::getScrollY()));
+	}
+	setOverscroll(overx, overy);
+}
+
+void gAppManager::updateOverscroll() {
+	// A finger still on the glass is holding the page out on purpose.
+	if(istouchpressed && istouchscrolling) return;
+	if(overscrollx == 0.0f && overscrolly == 0.0f) return;
+	float step = (float)getElapsedTime();
+	if(step <= 0.0f) return;
+	if(step > flingmaxstep) step = flingmaxstep;
+
+	float decay = std::exp(-overscrollreturnrate * step);
+	float newx = overscrollx * decay;
+	float newy = overscrolly * decay;
+	if(std::fabs(newx) < overscrollstopdistance) newx = 0.0f;
+	if(std::fabs(newy) < overscrollstopdistance) newy = 0.0f;
+	setOverscroll(newx, newy);
+}
+
+void gAppManager::resetTouchGesture() {
+	istouchpressed = false;
+	istouchscrolling = false;
+	istouchrebaseneeded = false;
+	istouchownedbycontrol = false;
+	isflinging = false;
+	flingvelocityx = 0.0f;
+	flingvelocityy = 0.0f;
+	hastouchvelocity = false;
+	// Dropped rather than sprung back: the gesture is gone, and so is any reason
+	// to animate the page returning from where it had pulled it.
+	setOverscroll(0.0f, 0.0f);
+}
+
+void gAppManager::trackTouchVelocity() {
+	AppClockTimePoint now = AppClock::now();
+	int scrollx = gRenderer::getScrollX();
+	int scrolly = gRenderer::getScrollY();
+	if(hastouchvelocity) {
+		float interval = std::chrono::duration<float>(now - lasttouchmovetime).count();
+		if(interval > velocitymininterval && interval < velocitymaxinterval) {
+			float instantx = (float)(scrollx - lasttouchscrollx) / interval;
+			float instanty = (float)(scrolly - lasttouchscrolly) / interval;
+			flingvelocityx = flingvelocityx * (1.0f - velocitysmoothing) + instantx * velocitysmoothing;
+			flingvelocityy = flingvelocityy * (1.0f - velocitysmoothing) + instanty * velocitysmoothing;
+		}
+	}
+	lasttouchmovetime = now;
+	lasttouchscrollx = scrollx;
+	lasttouchscrolly = scrolly;
+	hastouchvelocity = true;
+}
+
+void gAppManager::updateFling() {
+	if(!isflinging) return;
+	float step = (float)getElapsedTime();
+	if(step <= 0.0f) return;
+	if(step > flingmaxstep) step = flingmaxstep;
+
+	flingpositionx += flingvelocityx * step;
+	flingpositiony += flingvelocityy * step;
+	float decay = std::exp(-flingdecayrate * step);
+	flingvelocityx *= decay;
+	flingvelocityy *= decay;
+
+	int targetx = (int)std::lround(flingpositionx);
+	int targety = (int)std::lround(flingpositiony);
+	setScrollPosition(targetx, targety);
+	// The setters clamp, so a target beyond the end means that axis has hit the
+	// edge. Its speed is dropped and the float position pulled back onto the
+	// clamped value; otherwise speed would keep accumulating out of view and the
+	// page would sit still for a while before moving again.
+	if(gRenderer::getScrollX() != targetx) {
+		// What is left of the throw is turned into the bounce instead of being
+		// dropped, so arriving at the end fast looks different from arriving slow.
+		// Only when nothing is bouncing yet, or a fling grinding along the end
+		// would keep topping the offset up and never let the spring finish.
+		if(overscrollx == 0.0f) setOverscroll(resistOverscroll(flingvelocityx * overscrollbouncetime), overscrolly);
+		flingvelocityx = 0.0f;
+		flingpositionx = (float)gRenderer::getScrollX();
+	}
+	if(gRenderer::getScrollY() != targety) {
+		if(overscrolly == 0.0f) setOverscroll(overscrollx, resistOverscroll(flingvelocityy * overscrollbouncetime));
+		flingvelocityy = 0.0f;
+		flingpositiony = (float)gRenderer::getScrollY();
+	}
+
+	if(std::fabs(flingvelocityx) < flingstopspeed && std::fabs(flingvelocityy) < flingstopspeed) {
+		isflinging = false;
+	}
+}
+
+void gAppManager::updateScrollIndicator() {
+	int scrollx = gRenderer::getScrollX();
+	int scrolly = gRenderer::getScrollY();
+	// Shown while the page is moving and while a finger is holding it, so that
+	// it is already on screen the moment the drag begins.
+	// A stretch counts as movement: the scroll position stops changing the moment
+	// the end is reached, and without this the indicator would start fading out in
+	// the middle of the bounce.
+	bool isstretched = overscrollx != 0.0f || overscrolly != 0.0f;
+	if(scrollx != scrollindicatorlastscrollx || scrolly != scrollindicatorlastscrolly ||
+			istouchscrolling || isstretched) {
+		scrollindicatorlastscrollx = scrollx;
+		scrollindicatorlastscrolly = scrolly;
+		scrollindicatortimer = scrollindicatorholdtime + scrollindicatorfadetime;
+		return;
+	}
+	if(scrollindicatortimer > 0.0f) {
+		scrollindicatortimer -= (float)getElapsedTime();
+		if(scrollindicatortimer < 0.0f) scrollindicatortimer = 0.0f;
+	}
+}
+
+void gAppManager::drawScrollIndicator() {
+	if(scrollindicatortimer <= 0.0f) return;
+	int maxscrollx = gRenderer::getMaxScrollX();
+	int maxscrolly = gRenderer::getMaxScrollY();
+	if(maxscrollx <= 0 && maxscrolly <= 0) return;
+
+	float opacity = 1.0f;
+	if(scrollindicatortimer < scrollindicatorfadetime) {
+		opacity = scrollindicatortimer / scrollindicatorfadetime;
+	}
+
+	// The projection maps the visible band, so the band's own coordinates are
+	// what keeps the indicator pinned to the screen instead of scrolling away
+	// with the page. The rubber band offset is part of where the band actually
+	// is, so it has to be included: leaving it out slides the indicator off the
+	// edge exactly when the stretch is happening.
+	int bandleft = gRenderer::getScrollX() + gRenderer::getOverscrollX();
+	int bandtop = gRenderer::getScrollY() + gRenderer::getOverscrollY();
+	int bandwidth = gRenderer::getUnitViewportWidth();
+	int bandheight = gRenderer::getUnitViewportHeight();
+
+	bool isalpha = renderer->isAlphaBlendingEnabled();
+	if(!isalpha) renderer->enableAlphaBlending();
+	// Copied by value: getColor() hands out the renderer's own color object, so
+	// holding the pointer would restore whatever the indicator just set.
+	gColor oldcolor = *renderer->getColor();
+	renderer->setColor(0, 0, 0, (int)(scrollindicatoralpha * opacity));
+
+	// When both axes show an indicator they share the bottom-right corner: the
+	// vertical bar runs the full right edge and the horizontal one the full bottom
+	// edge, so scrolled to the end they cross there. Each bar gives up the other's
+	// thickness at that corner, so the two stop short of it instead of overlapping.
+	int cornergap = (maxscrollx > 0 && maxscrolly > 0) ? scrollindicatorthickness + scrollindicatormargin : 0;
+
+	if(maxscrolly > 0) {
+		int tracklength = bandheight - scrollindicatormargin * 2 - cornergap;
+		// getUnitHeight() > 0 is implied by maxscrolly > 0 today, but it is the
+		// divisor below and guarding it keeps a future change to the scroll model
+		// from turning this into a divide-by-zero.
+		if(tracklength > scrollindicatorminlength && renderer->getUnitHeight() > 0) {
+			int thumblength = (int)((float)tracklength * bandheight / (float)renderer->getUnitHeight());
+			if(thumblength < scrollindicatorminlength) thumblength = scrollindicatorminlength;
+			if(thumblength > tracklength) thumblength = tracklength;
+			int offset = (int)((tracklength - thumblength) * ((float)gRenderer::getScrollY() / maxscrolly));
+			int thumbx = bandleft + bandwidth - scrollindicatormargin - scrollindicatorthickness;
+			int thumby = bandtop + scrollindicatormargin + offset;
+			renderer->setColor(0, 0, 0, (int)(scrollindicatoralpha * opacity));
+			gDrawRectangle(thumbx, thumby, scrollindicatorthickness, thumblength, true);
+			// While the page is stretched, the tip on the pulled side darkens over a
+			// length that grows with the stretch: it reads as the bar pressing against
+			// the end rather than sitting frozen there. Positive overscroll is past the
+			// bottom, so it is the bottom tip; negative is the top.
+			int overscroll = gRenderer::getOverscrollY();
+			int darktip = overscrollTipLength(overscroll, thumblength);
+			if(darktip > 0) {
+				renderer->setColor(0, 0, 0, (int)(scrollindicatordarktipalpha * opacity));
+				int darky = overscroll > 0 ? thumby + thumblength - darktip : thumby;
+				gDrawRectangle(thumbx, darky, scrollindicatorthickness, darktip, true);
+			}
+		}
+	}
+	if(maxscrollx > 0) {
+		int tracklength = bandwidth - scrollindicatormargin * 2 - cornergap;
+		// Same guard as the vertical bar: getUnitWidth() is the divisor below.
+		if(tracklength > scrollindicatorminlength && renderer->getUnitWidth() > 0) {
+			int thumblength = (int)((float)tracklength * bandwidth / (float)renderer->getUnitWidth());
+			if(thumblength < scrollindicatorminlength) thumblength = scrollindicatorminlength;
+			if(thumblength > tracklength) thumblength = tracklength;
+			int offset = (int)((tracklength - thumblength) * ((float)gRenderer::getScrollX() / maxscrollx));
+			int thumbx = bandleft + scrollindicatormargin + offset;
+			int thumby = bandtop + bandheight - scrollindicatormargin - scrollindicatorthickness;
+			renderer->setColor(0, 0, 0, (int)(scrollindicatoralpha * opacity));
+			gDrawRectangle(thumbx, thumby, thumblength, scrollindicatorthickness, true);
+			// The right/left tip darkens the same way the vertical bar's does.
+			int overscroll = gRenderer::getOverscrollX();
+			int darktip = overscrollTipLength(overscroll, thumblength);
+			if(darktip > 0) {
+				renderer->setColor(0, 0, 0, (int)(scrollindicatordarktipalpha * opacity));
+				int darkx = overscroll > 0 ? thumbx + thumblength - darktip : thumbx;
+				gDrawRectangle(darkx, thumby, darktip, scrollindicatorthickness, true);
+			}
+		}
+	}
+
+	renderer->setColor(oldcolor);
+	if(!isalpha) renderer->disableAlphaBlending();
+}
+
 bool gAppManager::onTouchEvent(gTouchEvent& event) {
+	// Touches never reached the GUI otherwise, so in the GUI app modes they are
+	// what drives both the controls and the scrolling of the page they sit on.
+	if(isguiapp) handleGUITouch(event);
 	if(canvasmanager && getCurrentCanvas()) {
 		if (
 #if GLIST_ANDROID
@@ -872,8 +1755,13 @@ bool gAppManager::onTouchEvent(gTouchEvent& event) {
 			auto* target = static_cast<gWebCanvas*>(getCurrentCanvas())
 #endif
         ) {
+			// The action index comes from the platform and could point past the input
+			// list on a malformed event; clamp it and skip when there is nothing to
+			// read, so getInputs()[inputindex] is never out of bounds. Same guard the
+			// GUI touch path uses in handleGUITouch().
+			if (event.getInputCount() < 1) return false;
 			if (event.getAction() == ACTIONTYPE_POINTER_DOWN || (event.getInputCount() == 1 && event.getAction() == ACTIONTYPE_DOWN)) {
-				int inputindex = event.getActionIndex();
+				int inputindex = gClamp(event.getActionIndex(), 0, event.getInputCount() - 1);
 				TouchInput& input = event.getInputs()[inputindex];
 				int x = input.x;
 				int y = input.y;
@@ -883,7 +1771,7 @@ bool gAppManager::onTouchEvent(gTouchEvent& event) {
 				}
 				target->touchPressed(x, y, input.fingerid);
 			} else if (event.getAction() == ACTIONTYPE_POINTER_UP || (event.getInputCount() == 1 && event.getAction() == ACTIONTYPE_UP)) {
-				int inputindex = event.getActionIndex();
+				int inputindex = gClamp(event.getActionIndex(), 0, event.getInputCount() - 1);
 				TouchInput& input = event.getInputs()[inputindex];
 				int x = input.x;
 				int y = input.y;
@@ -893,7 +1781,7 @@ bool gAppManager::onTouchEvent(gTouchEvent& event) {
 				}
 				target->touchReleased(x, y, input.fingerid);
 			} else if (event.getAction() == ACTIONTYPE_MOVE) {
-				int inputindex = event.getActionIndex();
+				int inputindex = gClamp(event.getActionIndex(), 0, event.getInputCount() - 1);
 				TouchInput& input = event.getInputs()[inputindex];
 				int x = input.x;
 				int y = input.y;
@@ -921,11 +1809,19 @@ void gAppManager::submitToMainThread(std::function<void()> fn) {
 
 void gAppManager::executeQueue() {
 	G_PROFILE_ZONE_SCOPED_N("gAppManager::executeQueue()");
-    std::unique_lock<std::mutex> lock(mainthreadqueuemutex);
-    for (auto& func : mainthreadqueue) {
-        func();
-    }
-    mainthreadqueue.clear();
+	// The queue is taken over before anything runs, so that the callbacks run
+	// without the lock held. Holding it across them would block whoever submits
+	// next - on Android that is the UI thread, which must not wait on a frame's
+	// worth of GUI callbacks - and would deadlock outright if a callback
+	// submitted work of its own.
+	std::vector<std::function<void()>> queue;
+	{
+		std::unique_lock<std::mutex> lock(mainthreadqueuemutex);
+		queue.swap(mainthreadqueue);
+	}
+	for (auto& func : queue) {
+		func();
+	}
 }
 
 void gAppManager::preciseSleep(double seconds) {

--- a/engine/core/gAppManager.h
+++ b/engine/core/gAppManager.h
@@ -291,6 +291,43 @@ public:
 	void setScreenSize(int width, int height);
 
 	/**
+	 * Enables the mobile style layout, in which the drawing scale stays fixed
+	 * across rotations instead of the unit space being stretched to fit.
+	 *
+	 * The width of the layout always spans the screen, while its height keeps
+	 * the value the app was designed for. A landscape screen is shorter than
+	 * that height, so the part that no longer fits is reached by scrolling
+	 * down, the way phone apps behave.
+	 *
+	 * Android and iOS only: it is on by default in the GUI app window modes
+	 * there and this call does nothing on other platforms, where windows are
+	 * resized freely by the user and the older proportional behaviour is kept.
+	 * It also has no effect unless screen scaling is enabled.
+	 *
+	 * Switching it off hands the design unit size back, so the app returns to
+	 * the layout it would have had without the model.
+	 *
+	 * @param enable true to keep the scale fixed and scroll the overflow.
+	 */
+	void enableScrollableLayout(bool enable);
+
+	/*
+	 * Lets the page grow past its design height so that whatever is on it fits.
+	 *
+	 * Off, a page with more rows than it was designed for squashes them all: the
+	 * sizer divides a fixed height and never measures what is in it. On, the page
+	 * gets as tall as its content needs and the extra becomes scrollable - which
+	 * is only meaningful where scrolling exists, so this follows the scrollable
+	 * layout model and is mobile only.
+	 *
+	 * On by default. Turn it off for a page meant to fill exactly one screen
+	 * whatever that costs its contents.
+	 */
+	void enableContentDrivenHeight(bool isEnabled);
+	bool isContentDrivenHeightEnabled() const;
+	bool isScrollableLayoutEnabled() const { return scrollablelayout; }
+
+	/**
 	 * Completely replace the current gBaseCanvas with the specified gBaseCanvas.
 	 *
 	 * @param baseCanvas new gBaseCanvas to replace.
@@ -372,6 +409,106 @@ private:
     bool ismouseentered;
     bool mousebuttonpressed[maxmousebuttonnum];
     int mousebuttonstate;
+
+    static const int wheelscrollstep = 48;
+    // How far a finger has to travel, in unit space, before the gesture counts
+    // as a scroll rather than a tap on the control underneath it.
+    static const int touchscrollthreshold = 12;
+
+    bool scrollablelayout;
+    float layoutscale;
+    int layoutreferencewidth;
+    int layoutreferenceheight;
+    bool istouchpressed;
+    bool istouchscrolling;
+    // Set when a finger joins or leaves, so that the next move re-anchors the
+    // gesture instead of measuring a different finger against a stale origin.
+    bool istouchrebaseneeded;
+    // Set while a scrollable control under the finger is consuming the drag, and
+    // kept set after it lets go, so the hand over to the page can re-anchor.
+    bool istouchownedbycontrol;
+    int touchstartx;
+    int touchstarty;
+    int touchstartscrollx;
+    int touchstartscrolly;
+    // Where the user last asked the page to be. The renderer holds the position
+    // actually in force, which any rebuild of the layout clamps to whatever fits
+    // at that instant; this one is never clamped, so a layout that is briefly
+    // wrong - a rotation, or the surface size arriving late after the app
+    // returns from the background - cannot erase where the user was.
+    int desiredscrollx;
+    int desiredscrolly;
+
+#if GLIST_ANDROID || GLIST_IOS
+    // Set while the page keeps scrolling on its own after the finger has left.
+    bool isflinging;
+    // Unit space per second. Measured from the finger while it drags and then
+    // decayed by updateFling() once it is released.
+    float flingvelocityx;
+    float flingvelocityy;
+    // The scroll position carried at sub unit precision, so that a slow glide
+    // is not rounded away frame after frame.
+    float flingpositionx;
+    float flingpositiony;
+    // False until a drag has produced one measurable interval; without it the
+    // first sample would be timed against an unrelated moment.
+    bool hastouchvelocity;
+    AppClockTimePoint lasttouchmovetime;
+    int lasttouchscrollx;
+    int lasttouchscrolly;
+
+    // Whether the page may grow past its design height to fit what is on it.
+    bool iscontentdrivenheight;
+    // The content height the layout was last built for. -1 means "not measured
+    // yet", which forces the next frame to build rather than compare.
+    int lastcontentheight;
+    // The height the page would have without growing: the taller of the design
+    // height and the visible band. Every measurement is taken against this same
+    // number, so that growing the page can never raise the next answer.
+    int ungrownlayoutheight;
+
+    // How far the page is currently drawn past its end, in unit space, either
+    // sign. Purely a drawing offset: the scroll position stays clamped, so
+    // nothing that reads it ever sees a value outside the range. Kept in floats
+    // because the spring back is a decay and would otherwise round to a halt.
+    float overscrollx;
+    float overscrolly;
+
+    // Counts down while the indicator is on screen; it holds at full opacity
+    // first and fades over the last part of the countdown.
+    float scrollindicatortimer;
+    int scrollindicatorlastscrollx;
+    int scrollindicatorlastscrolly;
+#endif
+
+    float computeLayoutScale(int screenWidth, int screenHeight) const;
+    bool isScrollableLayoutActive() const;
+    void updateScrollableLayout(int screenWidth, int screenHeight);
+    // The one way the page is scrolled in response to input. Keeps the remembered
+    // position in step with the renderer, which nothing else does.
+    void setScrollPosition(int scrollX, int scrollY);
+#if GLIST_ANDROID || GLIST_IOS
+    void handleGUITouch(gTouchEvent& event);
+    void processGUITouch(int touchX, int touchY, ActionType action);
+    void anchorTouchGesture(int touchX, int touchY);
+    void cancelTouchGesture();
+    void resetTouchGesture();
+    void trackTouchVelocity();
+    void updateFling();
+    // Asks the current frame's root sizer how tall its content needs to be.
+    int measureLayoutContentHeight(int referenceHeight);
+    // Rebuilds the layout when that answer has changed since the last frame.
+    void updateLayoutContentHeight();
+    // Writes both the float state here and the rounded offset the renderer draws
+    // with, which is the only place either of them is set.
+    void setOverscroll(float overscrollX, float overscrollY);
+    // Turns a distance asked for past the end into the distance actually given.
+    float resistOverscroll(float distance);
+    void applyDragOverscroll(int targetX, int targetY);
+    void updateOverscroll();
+    void updateScrollIndicator();
+    void drawScrollIndicator();
+#endif
 
     AppClockTimePoint starttime, endtime;
     AppClockDuration deltatime;

--- a/engine/core/gBaseWindow.h
+++ b/engine/core/gBaseWindow.h
@@ -75,6 +75,16 @@ public:
 	virtual std::string getClipboardString();
 
 	/**
+	 * Shows or hides the on-screen (soft) keyboard on platforms that have one.
+	 * Text controls (gGUITextbox and, through it, gGUINumberBox / gGUITimebox)
+	 * call these when they gain or lose edit focus. The base does nothing: on
+	 * desktop there is a physical keyboard and no soft one to raise. Android
+	 * overrides them; an iOS window can do the same later.
+	 */
+	virtual void showKeyboard() {}
+	virtual void hideKeyboard() {}
+
+	/**
 	 * Sets game window size.
 	 *
 	 * @param width Size of game screen width.

--- a/engine/core/gGUIManager.cpp
+++ b/engine/core/gGUIManager.cpp
@@ -158,6 +158,11 @@ void gGUIManager::charPressed(unsigned int key) {
 }
 
 void gGUIManager::mouseMoved(int x, int y) {
+	// Pointer positions arrive relative to the visible band, while the controls
+	// were laid out in the full layout area, so the scroll distance is what
+	// bridges the two. It is 0 whenever the layout fits on screen.
+	x += gRenderer::getScrollX();
+	y += gRenderer::getScrollY();
 	if(!dialoguesshown.empty()) {
 		appmanager->setCursor(dialoguesshown[dialoguesshown.size() - 1]->getCursor(x, y));
 		dialoguesshown[dialoguesshown.size() - 1]->mouseMoved(x, y);
@@ -168,6 +173,8 @@ void gGUIManager::mouseMoved(int x, int y) {
 }
 
 void gGUIManager::mousePressed(int x, int y, int button) {
+	x += gRenderer::getScrollX();
+	y += gRenderer::getScrollY();
 	if(!dialoguesshown.empty()) {
 		dialoguesshown[dialoguesshown.size() - 1]->mousePressed(x, y, button);
 		return;
@@ -176,6 +183,8 @@ void gGUIManager::mousePressed(int x, int y, int button) {
 }
 
 void gGUIManager::mouseDragged(int x, int y, int button) {
+	x += gRenderer::getScrollX();
+	y += gRenderer::getScrollY();
 	if(!dialoguesshown.empty()) {
 		dialoguesshown[dialoguesshown.size() - 1]->mouseDragged(x, y, button);
 		return;
@@ -184,6 +193,8 @@ void gGUIManager::mouseDragged(int x, int y, int button) {
 }
 
 void gGUIManager::mouseReleased(int x, int y, int button) {
+	x += gRenderer::getScrollX();
+	y += gRenderer::getScrollY();
 	if(!dialoguesshown.empty()) {
 		dialoguesshown[dialoguesshown.size() - 1]->mouseReleased(x, y, button);
 		return;

--- a/engine/core/gRenderer.cpp
+++ b/engine/core/gRenderer.cpp
@@ -51,6 +51,17 @@ int gRenderer::unitheight;
 int gRenderer::screenscaling;
 int gRenderer::currentresolution;
 int gRenderer::unitresolution;
+int gRenderer::unitviewportwidth = 0;
+int gRenderer::unitviewportheight = 0;
+int gRenderer::scrollx = 0;
+int gRenderer::scrolly = 0;
+int gRenderer::overscrollx = 0;
+int gRenderer::overscrolly = 0;
+#if GLIST_ANDROID || GLIST_IOS
+bool gRenderer::contentprojectionactive = false;
+int gRenderer::contentprojectionwidth = 0;
+int gRenderer::contentprojectionheight = 0;
+#endif
 
 void gDrawLine(float x1, float y1, float x2, float y2, float thickness) {
 	G_PROFILE_ZONE_SCOPED_N("gDrawLine()");
@@ -477,17 +488,159 @@ void gRenderer::setScreenSize(int screenWidth, int screenHeight) {
 	width = screenWidth;
 	height = screenHeight;
 	setCurrentResolution(getResolution(screenWidth, screenHeight));
+	updateProjectionMatrix2d();
 }
 
 void gRenderer::setUnitScreenSize(int unitWidth, int unitHeight) {
 	unitwidth = unitWidth;
 	unitheight = unitHeight;
 	setUnitResolution(getResolution(unitWidth, unitHeight));
+	// A smaller layout area can leave the scroll position past its new end.
+	scrollx = gClamp(scrollx, 0, getMaxScrollX());
+	scrolly = gClamp(scrolly, 0, getMaxScrollY());
+	updateProjectionMatrix2d();
 }
 
 void gRenderer::setScreenScaling(int screenScaling) {
 	screenscaling = screenScaling;
 	gObject::setCurrentResolution(screenscaling, currentresolution);
+	updateProjectionMatrix2d();
+}
+
+void gRenderer::updateProjectionMatrix2d() {
+	// 2D primitives (gDrawRectangle etc.) read projectionmatrix2d directly, so it
+	// must be rebuilt whenever the screen/unit size or scaling mode changes.
+	// Otherwise it keeps the default 1280x720 ortho from init() until a texture
+	// draw happens to refresh it, which shifts/stretches all primitive drawings.
+	gRenderer* r = gRenderObject::getRenderer();
+	if(!r) return;
+#if GLIST_ANDROID || GLIST_IOS
+	if(contentprojectionactive) {
+		// A control's content buffer maps the control's whole box onto the buffer,
+		// so nothing wider or taller than the on-screen band is clipped away. The
+		// page scroll is left out on purpose - the content is drawn in its own
+		// local space - while the overscroll stays in, which is the control's own
+		// rubber band shifting the band it is drawn through.
+		float contentleft = (float)overscrollx;
+		float contenttop = (float)overscrolly;
+		r->projectionmatrix2d = glm::ortho(contentleft, contentleft + (float)contentprojectionwidth, contenttop + (float)contentprojectionheight, contenttop, -1.0f, 1.0f);
+		return;
+	}
+#endif
+	// The visible band of the layout area is what gets mapped onto the screen.
+	// Scrolling therefore costs nothing at draw time: shifting the band moves
+	// every 2D drawing at once and whatever falls outside is clipped by the
+	// projection itself.
+	float visibleleft = 0.0f;
+	float visiblewidth = (float)r->getWidth();
+	if(isHorizontalScrollingEnabled()) {
+		visibleleft = (float)(scrollx + overscrollx);
+		visiblewidth = (float)unitviewportwidth;
+	}
+	float visibletop = 0.0f;
+	float visibleheight = (float)r->getHeight();
+	if(isVerticalScrollingEnabled()) {
+		visibletop = (float)(scrolly + overscrolly);
+		visibleheight = (float)unitviewportheight;
+	}
+	r->projectionmatrix2d = glm::ortho(visibleleft, visibleleft + visiblewidth, visibletop + visibleheight, visibletop, -1.0f, 1.0f);
+}
+
+#if GLIST_ANDROID || GLIST_IOS
+void gRenderer::setContentProjection(int unitW, int unitH) {
+	contentprojectionactive = true;
+	contentprojectionwidth = unitW < 1 ? 1 : unitW;
+	contentprojectionheight = unitH < 1 ? 1 : unitH;
+	updateProjectionMatrix2d();
+}
+
+void gRenderer::clearContentProjection() {
+	contentprojectionactive = false;
+	updateProjectionMatrix2d();
+}
+#endif
+
+void gRenderer::setOverscroll(int overscrollX, int overscrollY) {
+	if(overscrollx == overscrollX && overscrolly == overscrollY) return;
+	overscrollx = overscrollX;
+	overscrolly = overscrollY;
+	updateProjectionMatrix2d();
+}
+
+int gRenderer::getOverscrollX() {
+	if(!isHorizontalScrollingEnabled()) return 0;
+	return overscrollx;
+}
+
+int gRenderer::getOverscrollY() {
+	if(!isVerticalScrollingEnabled()) return 0;
+	return overscrolly;
+}
+
+bool gRenderer::isHorizontalScrollingEnabled() {
+	return unitviewportwidth > 0 && screenscaling >= G_SCREENSCALING_AUTO;
+}
+
+bool gRenderer::isVerticalScrollingEnabled() {
+	return unitviewportheight > 0 && screenscaling >= G_SCREENSCALING_AUTO;
+}
+
+void gRenderer::setUnitViewportWidth(int unitViewportWidth) {
+	unitviewportwidth = unitViewportWidth;
+	scrollx = gClamp(scrollx, 0, getMaxScrollX());
+	updateProjectionMatrix2d();
+}
+
+int gRenderer::getUnitViewportWidth() {
+	if(!isHorizontalScrollingEnabled()) return unitwidth;
+	return unitviewportwidth;
+}
+
+void gRenderer::setUnitViewportHeight(int unitViewportHeight) {
+	unitviewportheight = unitViewportHeight;
+	scrolly = gClamp(scrolly, 0, getMaxScrollY());
+	updateProjectionMatrix2d();
+}
+
+int gRenderer::getUnitViewportHeight() {
+	if(!isVerticalScrollingEnabled()) return unitheight;
+	return unitviewportheight;
+}
+
+void gRenderer::setScrollX(int scrollX) {
+	int newscrollx = gClamp(scrollX, 0, getMaxScrollX());
+	if(newscrollx == scrollx) return;
+	scrollx = newscrollx;
+	updateProjectionMatrix2d();
+}
+
+int gRenderer::getScrollX() {
+	if(!isHorizontalScrollingEnabled()) return 0;
+	return scrollx;
+}
+
+int gRenderer::getMaxScrollX() {
+	if(!isHorizontalScrollingEnabled()) return 0;
+	if(unitwidth <= unitviewportwidth) return 0;
+	return unitwidth - unitviewportwidth;
+}
+
+void gRenderer::setScrollY(int scrollY) {
+	int newscrolly = gClamp(scrollY, 0, getMaxScrollY());
+	if(newscrolly == scrolly) return;
+	scrolly = newscrolly;
+	updateProjectionMatrix2d();
+}
+
+int gRenderer::getScrollY() {
+	if(!isVerticalScrollingEnabled()) return 0;
+	return scrolly;
+}
+
+int gRenderer::getMaxScrollY() {
+	if(!isVerticalScrollingEnabled()) return 0;
+	if(unitheight <= unitviewportheight) return 0;
+	return unitheight - unitviewportheight;
 }
 
 int gRenderer::getWidth() {
@@ -573,24 +726,30 @@ int gRenderer::getUnitResolution() {
 }
 
 float gRenderer::getScaleMultiplier() {
-	return width / (float)unitwidth;
+	return width / (float)getUnitViewportWidth();
 }
 
 int gRenderer::scaleX(int x) {
-	return (x * unitwidth) / width;
+	// Screen pixels map onto the visible band, not onto the whole layout area,
+	// so the conversion has to use the visible width to stay undistorted when
+	// the layout is wider than the screen.
+	return (x * getUnitViewportWidth()) / width;
 }
 
 int gRenderer::scaleY(int y) {
-	return (y * unitheight) / height;
+	// Screen pixels map onto the visible band, not onto the whole layout area,
+	// so the conversion has to use the visible height to stay undistorted when
+	// the layout is taller than the screen.
+	return (y * getUnitViewportHeight()) / height;
 }
 
 int gRenderer::unscaleX(int x) {
-	float scale = width / (float)unitwidth;
+	float scale = width / (float)getUnitViewportWidth();
 	return x * scale;
 }
 
 int gRenderer::unscaleY(int y) {
-	float scale = height / (float)unitheight;
+	float scale = height / (float)getUnitViewportHeight();
 	return y * scale;
 }
 

--- a/engine/core/gRenderer.cpp
+++ b/engine/core/gRenderer.cpp
@@ -1096,8 +1096,99 @@ const std::string& gRenderer::getShaderSrcColorVertex() {
 }
 
 const std::string& gRenderer::getShaderSrcColorFragment() {
+#if defined(TARGET_OS_SIMULATOR) && TARGET_OS_SIMULATOR
+	// The iOS simulator executes OpenGL ES on Apple's software renderer, whose
+	// LLVM shader JIT effectively never finishes compiling the full lighting
+	// shader - every draw then falls back to a per-fragment interpreter and the
+	// GUI crawls at a few frames per second. The simulator therefore gets only
+	// the unlit branch of the shader (globalambient * material * renderColor *
+	// vertex color, plus the alpha discard), which compiles instantly. Real
+	// devices and every other platform keep the full shader; lit 3D scenes
+	// simply render unlit on the simulator.
+	static std::string str{
+			"#if GLES\n"
+			"#version 300 es\n"
+			"precision highp float;\n"
+			"precision highp int;\n"
+			"#else\n"
+			"#version 330 core\n"
+			"#endif\n"
+			"\n"
+			"struct Material {\n"
+			"    vec4 ambient;\n"
+			"    vec4 diffuse;\n"
+			"    vec4 specular;\n"
+			"    float shininess;\n"
+			"    sampler2D diffusemap;\n"
+			"    sampler2D specularmap;\n"
+			"    sampler2D normalMap;\n"
+			"    int useDiffuseMap;\n"
+			"    int useSpecularMap;\n"
+			"    int useNormalMap;\n"
+			"};\n"
+			"\n"
+			"struct Light {\n"
+			"    int type;\n"
+			"    vec3 position;\n"
+			"    vec3 direction;\n"
+			"    vec4 ambient;\n"
+			"    vec4 diffuse;\n"
+			"    vec4 specular;\n"
+			"    float constant;\n"
+			"    float linear;\n"
+			"    float quadratic;\n"
+			"    float cutOff;\n"
+			"    float outerCutOff;\n"
+			"};\n"
+			"\n"
+			"struct Fog {\n"
+			"    vec3 color;\n"
+			"    float linearStart;\n"
+			"    float linearEnd;\n"
+			"    float density;\n"
+			"    float gradient;\n"
+			"    int mode;\n"
+			"};\n"
+			"\n"
+			"uniform Material material;\n"
+			"\n"
+			"layout(std140) uniform Lights {\n"
+			"    int lightnum;\n"
+			"    int enabledlights;\n"
+			"    vec4 globalambientcolor;\n"
+			"    Light lights[GLIST_MAX_LIGHTS];\n"
+			"};\n"
+			"\n"
+			"layout(std140) uniform Scene {\n"
+			"    vec4 renderColor;\n"
+			"    vec3 viewPos;\n"
+			"    mat4 viewMatrix;\n"
+			"    int flags;\n"
+			"    Fog fog;\n"
+			"};\n"
+			"\n"
+			"in vec2 TexCoords;\n"
+			"in vec3 incolor;\n"
+			"\n"
+			"out vec4 FragColor;\n"
+			"\n"
+			"void main() {\n"
+			"    vec4 materialAmbient;\n"
+			"    if (material.useDiffuseMap > 0) {\n"
+			"        materialAmbient = texture(material.diffusemap, TexCoords).rgba;\n"
+			"        if (materialAmbient.a < 0.5) {\n"
+			"            discard;\n"
+			"        }\n"
+			"    } else {\n"
+			"        materialAmbient = material.ambient;\n"
+			"    }\n"
+			"    FragColor = globalambientcolor * materialAmbient * renderColor * vec4(incolor, 1.0);\n"
+			"}\n"};
+	return str;
+#else
 	static std::string str{shader_color_frag.data(), shader_color_frag.size()};
 	return str;
+#endif
 }
 
 const std::string& gRenderer::getShaderSrcTextureVertex() {
@@ -1150,14 +1241,65 @@ const std::string& gRenderer::getShaderSrcShadowmapFragment() {
 	return str;
 }
 
+#if defined(TARGET_OS_SIMULATOR) && TARGET_OS_SIMULATOR
+// See getShaderSrcColorFragment for why: these 3D-only shaders are compiled at
+// startup, and on the simulator's software renderer each of them occupies the
+// serial shader-JIT queue for minutes, during which every draw - including the
+// GUI's - runs on the interpreter. A GUI never draws them, and a 3D scene on
+// the simulator merely loses its PBR/IBL shading. The Lights block is kept so
+// the attachUbo("Lights", ...) call made for the PBR shader still finds it.
+static const std::string& getSimulatorStubFragment() {
+	static std::string str{
+			"#if GLES\n"
+			"#version 300 es\n"
+			"precision highp float;\n"
+			"precision highp int;\n"
+			"#else\n"
+			"#version 330 core\n"
+			"#endif\n"
+			"\n"
+			"struct Light {\n"
+			"    int type;\n"
+			"    vec3 position;\n"
+			"    vec3 direction;\n"
+			"    vec4 ambient;\n"
+			"    vec4 diffuse;\n"
+			"    vec4 specular;\n"
+			"    float constant;\n"
+			"    float linear;\n"
+			"    float quadratic;\n"
+			"    float cutOff;\n"
+			"    float outerCutOff;\n"
+			"};\n"
+			"\n"
+			"layout(std140) uniform Lights {\n"
+			"    int lightnum;\n"
+			"    int enabledlights;\n"
+			"    vec4 globalambientcolor;\n"
+			"    Light lights[GLIST_MAX_LIGHTS];\n"
+			"};\n"
+			"\n"
+			"out vec4 FragColor;\n"
+			"\n"
+			"void main() {\n"
+			"    FragColor = clamp(globalambientcolor, vec4(0.0), vec4(1.0));\n"
+			"}\n"};
+	return str;
+}
+#endif
+
 const std::string& gRenderer::getShaderSrcPbrVertex() {
 	static std::string str{shader_pbr_vert.data(), shader_pbr_vert.size()};
 	return str;
 }
 
 const std::string& gRenderer::getShaderSrcPbrFragment() {
+#if defined(TARGET_OS_SIMULATOR) && TARGET_OS_SIMULATOR
+	return getSimulatorStubFragment();
+#else
 	static std::string str{shader_pbr_frag.data(), shader_pbr_frag.size()};
 	return str;
+#endif
 }
 
 const std::string& gRenderer::getShaderSrcCubemapVertex() {
@@ -1171,13 +1313,21 @@ const std::string& gRenderer::getShaderSrcEquirectangularFragment() {
 }
 
 const std::string& gRenderer::getShaderSrcIrradianceFragment() {
+#if defined(TARGET_OS_SIMULATOR) && TARGET_OS_SIMULATOR
+	return getSimulatorStubFragment();
+#else
 	static std::string str{shader_irradiance_frag.data(), shader_irradiance_frag.size()};
 	return str;
+#endif
 }
 
 const std::string& gRenderer::getShaderSrcPrefilterFragment() {
+#if defined(TARGET_OS_SIMULATOR) && TARGET_OS_SIMULATOR
+	return getSimulatorStubFragment();
+#else
 	static std::string str{shader_prefilter_frag.data(), shader_prefilter_frag.size()};
 	return str;
+#endif
 }
 
 const std::string& gRenderer::getShaderSrcBrdfVertex() {
@@ -1186,8 +1336,12 @@ const std::string& gRenderer::getShaderSrcBrdfVertex() {
 }
 
 const std::string& gRenderer::getShaderSrcBrdfFragment() {
+#if defined(TARGET_OS_SIMULATOR) && TARGET_OS_SIMULATOR
+	return getSimulatorStubFragment();
+#else
 	static std::string str{shader_brdf_frag.data(), shader_brdf_frag.size()};
 	return str;
+#endif
 }
 
 const std::string& gRenderer::getShaderSrcFboVertex() {

--- a/engine/core/gRenderer.h
+++ b/engine/core/gRenderer.h
@@ -180,6 +180,126 @@ public:
 	static void setScreenSize(int screenWidth, int screenHeight);
 	static void setUnitScreenSize(int unitWidth, int unitHeight);
 	static void setScreenScaling(int screenScaling);
+	static void updateProjectionMatrix2d();
+
+	/**
+	 * Sets how much of the unit space is actually visible on screen
+	 * horizontally. The horizontal counterpart of setUnitViewportHeight(),
+	 * which keeps a layout wider than the screen reachable instead of letting
+	 * it fall off the right edge.
+	 *
+	 * @param unitViewportWidth visible width in unit space, 0 disables
+	 * horizontal scrolling and makes the whole unit width visible as before.
+	 */
+	static void setUnitViewportWidth(int unitViewportWidth);
+
+	/**
+	 * @return the visible width in unit space, which equals the unit width when
+	 * horizontal scrolling is disabled.
+	 */
+	static int getUnitViewportWidth();
+
+	/**
+	 * Scrolls the visible area horizontally within the unit space. The value is
+	 * clamped to the scrollable range, so it is safe to pass unclamped
+	 * positions.
+	 *
+	 * @param scrollX distance in unit space between the left of the layout area
+	 * and the left of the visible area.
+	 */
+	static void setScrollX(int scrollX);
+	static int getScrollX();
+
+	/**
+	 * @return how far the layout area can be scrolled horizontally, 0 when it
+	 * fully fits.
+	 */
+	static int getMaxScrollX();
+
+	/**
+	 * Sets how much of the unit space is actually visible on screen vertically.
+	 *
+	 * The unit size describes the layout area the app draws into. When that area
+	 * is taller than what fits on the physical screen at the current scale, the
+	 * exceeding part is reached by scrolling instead of being squeezed in. This
+	 * is what lets a portrait layout keep its height in landscape.
+	 *
+	 * @param unitViewportHeight visible height in unit space, 0 disables
+	 * scrolling and makes the whole unit space visible as before.
+	 */
+	static void setUnitViewportHeight(int unitViewportHeight);
+
+	/**
+	 * @return the visible height in unit space, which equals the unit height
+	 * when scrolling is disabled.
+	 */
+	static int getUnitViewportHeight();
+
+	/**
+	 * Scrolls the visible area within the unit space. The value is clamped to
+	 * the scrollable range, so it is safe to pass unclamped positions.
+	 *
+	 * @param scrollY distance in unit space between the top of the layout area
+	 * and the top of the visible area.
+	 */
+	static void setScrollY(int scrollY);
+	static int getScrollY();
+
+	/**
+	 * @return how far the layout area can be scrolled, 0 when it fully fits.
+	 */
+	static int getMaxScrollY();
+
+	/**
+	 * Shifts the visible band beyond where the scroll position is allowed to go.
+	 *
+	 * This is what draws the rubber band at the ends of a scroll: the scroll
+	 * position itself stays clamped and nothing that reads it sees anything
+	 * unusual, while the band - and with it every 2D drawing - moves past the
+	 * end. Keeping the two apart matters, because a scroll position outside its
+	 * range is not merely cosmetic elsewhere: controls turn it into row indices.
+	 *
+	 * It is nobody's business but the code producing the effect, and it must be
+	 * put back to zero afterwards.
+	 *
+	 * @param overscrollX,overscrollY distance in unit space, either sign.
+	 */
+	static void setOverscroll(int overscrollX, int overscrollY);
+	static int getOverscrollX();
+	static int getOverscrollY();
+
+	/**
+	 * @return whether a visible width/height is set and the scaling mode maps
+	 * unit space onto the screen, which is what makes scrolling meaningful.
+	 */
+	static bool isHorizontalScrollingEnabled();
+	static bool isVerticalScrollingEnabled();
+
+#if GLIST_ANDROID || GLIST_IOS
+	/**
+	 * Renders subsequent 2D drawing as if a unitW x unitH box were the whole
+	 * visible area, with the page scroll ignored.
+	 *
+	 * Controls that render their content into an offscreen buffer (gGUIScrollable,
+	 * gGUINotebook) draw it in their own local unit space. Under the normal page
+	 * projection that space is clipped to the on-screen band, so a control wider or
+	 * taller than the band loses whatever falls outside it, and reading the buffer
+	 * back at the control's full size then stretches the clipped edge across the
+	 * gap - straight streaks past the last visible part. This maps the control's
+	 * whole box onto the buffer instead, so the buffer holds all of it whatever the
+	 * band is. Content overscroll still applies, which is the control's own rubber
+	 * band. Must be paired with clearContentProjection().
+	 *
+	 * @param unitW,unitH the control's box in unit space.
+	 */
+	static void setContentProjection(int unitW, int unitH);
+
+	/**
+	 * Ends the content projection begun by setContentProjection() and restores the
+	 * page projection.
+	 */
+	static void clearContentProjection();
+#endif
 
 	int getWidth();
 	int getHeight();
@@ -522,6 +642,13 @@ protected:
 
 	static int width, height;
 	static int unitwidth, unitheight;
+	static int unitviewportwidth, unitviewportheight;
+	static int scrollx, scrolly;
+	static int overscrollx, overscrolly;
+#if GLIST_ANDROID || GLIST_IOS
+	static bool contentprojectionactive;
+	static int contentprojectionwidth, contentprojectionheight;
+#endif
 	static int screenscaling;
 	static int currentresolution, unitresolution;
 

--- a/engine/graphics/gTexture.cpp
+++ b/engine/graphics/gTexture.cpp
@@ -644,7 +644,13 @@ void gTexture::beginDraw() {
 	G_PROFILE_ZONE_SCOPED_N("gTexture::beginDraw()");
 	renderer->getImageShader()->use();
 	imagematrix = glm::mat4(1.0f);
-	renderer->setProjectionMatrix2d(glm::ortho(0.0f, (float)renderer->getWidth(), (float)renderer->getHeight(), 0.0f, -1.0f, 1.0f));
+	// Rebuilt through the renderer rather than here, so that textures and 2D
+	// primitives always share one projection. Building a full unit space ortho
+	// locally would ignore the visible band of a scrollable layout: images and
+	// text would be drawn unscrolled and vertically squeezed, and the matrix
+	// would stay overwritten for every primitive drawn after them in the frame.
+	// With scrolling inactive this produces exactly the same matrix as before.
+	renderer->updateProjectionMatrix2d();
 }
 
 void gTexture::endDraw() {

--- a/engine/ui/gGUIButton.cpp
+++ b/engine/ui/gGUIButton.cpp
@@ -240,3 +240,9 @@ void gGUIButton::setButtonh(int buttonh) {
 void gGUIButton::setButtonw(int buttonw) {
 	this->buttonw = buttonw;
 }
+
+#if GLIST_ANDROID || GLIST_IOS
+int gGUIButton::getNaturalHeight() {
+	return buttonh;
+}
+#endif

--- a/engine/ui/gGUIButton.h
+++ b/engine/ui/gGUIButton.h
@@ -19,6 +19,12 @@ public:
 
 	void setTitle(std::string title);
 	void setSize(int width, int height);
+
+#if GLIST_ANDROID || GLIST_IOS
+	// A button keeps whatever size it was given: the sizer positions it but never
+	// resizes it. So its own height is exactly what its row has to make room for.
+	int getNaturalHeight() override;
+#endif
 	void setToggle(bool isToggle);
 	void setDisabled(bool isDisabled);
 	void setTextVisibility(bool isVisible);

--- a/engine/ui/gGUIControl.h
+++ b/engine/ui/gGUIControl.h
@@ -43,6 +43,34 @@ public:
 		return height;
 	}
 
+	/*
+	 * How tall this control needs to be for its own content, in unit space, or 0
+	 * for "no opinion". A sizer adds these up to find how tall it needs to be,
+	 * and gives a row at least what it asks for.
+	 *
+	 * Deliberately not calculateContentHeight(), whose default returns the height
+	 * the sizer has just handed out. Measuring with that would mean measuring the
+	 * previous answer: the layout could then only ever grow, ratcheting up a
+	 * little every frame. So the rule for any override here is that it may look at
+	 * the content and at nothing else - never at height.
+	 *
+	 * Returning 0 keeps a control out of the calculation entirely, which is why
+	 * that is the default: a control nobody has thought about cannot break a
+	 * layout by guessing.
+	 */
+	virtual int getNaturalHeight() {
+		return 0;
+	}
+
+	/*
+	 * Tells a control how tall its slot would be if nothing needed extra room, so
+	 * that anything nested inside it can measure itself against the same figure
+	 * the page is using. Ignored by controls with nothing nested in them, which is
+	 * most of them.
+	 */
+	virtual void setReferenceHeight(int referenceHeight) {
+	}
+
 	virtual bool countAsSpace();
 	void setCountAsSpace(bool isSpace);
 

--- a/engine/ui/gGUIDate.cpp
+++ b/engine/ui/gGUIDate.cpp
@@ -38,6 +38,14 @@ gGUIDate::~gGUIDate() {
     // TODO Auto-generated destructor stub
 }
 
+#if GLIST_ANDROID || GLIST_IOS
+int gGUIDate::getNaturalHeight() {
+	// The calendar's own height, set in the constructor and via setSize(); the
+	// sizer's set() only touches the base height, so this stays independent.
+	return h;
+}
+#endif
+
 void gGUIDate::draw() {
     drawCalendar(11, 2022);
 }

--- a/engine/ui/gGUIDate.h
+++ b/engine/ui/gGUIDate.h
@@ -16,6 +16,9 @@ public:
 	virtual ~gGUIDate();
 	virtual void setup();
 	virtual void draw();
+#if GLIST_ANDROID || GLIST_IOS
+	int getNaturalHeight() override;
+#endif
 
 	void drawCalendar(int month, int year);
 	void setSize(int w, int h);

--- a/engine/ui/gGUIDropdownList.cpp
+++ b/engine/ui/gGUIDropdownList.cpp
@@ -16,6 +16,13 @@ gGUIDropdownList::gGUIDropdownList() {
 	float columnproportions[2] = {0.8f, 0.2f};
 	guisizer->setColumnProportions(columnproportions);
 	guisizer->enableBorders(false);
+#if GLIST_ANDROID || GLIST_IOS
+	// Tight internal packing, not the page's 24 unit finger gap: the textbox and
+	// the arrow button sit side by side as one control. At 24 they are inset from
+	// each other and from the box, and the arrow button - whose release opens the
+	// list - ends up nowhere near where it is drawn. See the note in gGUINumberBox.
+	guisizer->setSlotPadding(2, 0);
+#endif
 	button.setButtonColor(pressedbuttoncolor);
 	button.setSize(buttonw, buttonw);
 	button.setTitle("");
@@ -92,6 +99,14 @@ void gGUIDropdownList::onGUIEvent(int guiObjectId, int eventType, int sourceEven
 	}
 }
 
+#if GLIST_ANDROID || GLIST_IOS
+int gGUIDropdownList::getNaturalHeight() {
+	// The collapsed textbox, not the open list: the drop-down overlays whatever
+	// is beneath it rather than pushing the layout taller when it opens.
+	return textboxh;
+}
+#endif
+
 void gGUIDropdownList::draw() {
 	gGUIContainer::draw();
 
@@ -147,7 +162,16 @@ void gGUIDropdownList::mouseReleased(int x, int y, int button) {
     }
     setSelectedTitle();
     //Clicking on the Textbox opens the Treelist.
+#if GLIST_ANDROID || GLIST_IOS
+    // The original lower bound was textbox.height + buttonw - a size (~48 units),
+    // not a coordinate. Near the top of a desktop form a small y falls under it and
+    // it happens to work, but on a scrolling mobile page the box sits hundreds of
+    // units down, y is never <= 48, and the list never opened. The real bottom of
+    // the collapsed box is textbox.bottom.
+    if (x >= textbox.left && x <= textbox.right && y >= textbox.top + 5 && y <= textbox.bottom) {
+#else
     if (x >= textbox.left && x <= textbox.right && y >= textbox.top + 5 && y <= textbox.height + buttonw) {
+#endif
         buttonpressed = true;
         frame->addTreelist(&list, listx, listy, listw);
         root->getCurrentCanvas()->onGuiEvent(id, G_GUIEVENT_TREELISTOPENEDONDROPDOWNLIST);

--- a/engine/ui/gGUIDropdownList.h
+++ b/engine/ui/gGUIDropdownList.h
@@ -27,6 +27,9 @@ public:
 	virtual ~gGUIDropdownList();
 	void set(gBaseApp* root, gBaseGUIObject* topParentGUIObject, gBaseGUIObject* parentGUIObject, int parentSlotLineNo, int parentSlotColumnNo, int x, int y, int w, int h) override;
 	void draw() override;
+#if GLIST_ANDROID || GLIST_IOS
+	int getNaturalHeight() override;
+#endif
 	void setParentFrame(gGUIForm* form);
 	void setParentForm(gGUIForm* form);
 	void mousePressed(int x, int y, int button) override;

--- a/engine/ui/gGUIForm.cpp
+++ b/engine/ui/gGUIForm.cpp
@@ -224,7 +224,15 @@ void gGUIForm::setSizer(gGUISizer* guiSizer) {
 	guisizer->bottom = bottom - statush;
 	guisizer->width = guisizer->right - guisizer->left;
 	guisizer->height = guisizer->bottom - guisizer->top;
+#if GLIST_ANDROID || GLIST_IOS
+	// Deliberately not zeroed here on mobile. A desktop form wants its root sizer
+	// flush with the window, and this line is what does that - but it also wipes
+	// out the sizer's own default padding, which is where the page's spacing comes
+	// from. Only a form does this, so the padding survived inside containers and
+	// nowhere else: a notebook's tab body was spaced and the page around it was not.
+#else
 	guisizer->setSlotPadding(0, 0);
+#endif
 }
 
 void gGUIForm::updateSizer() {

--- a/engine/ui/gGUIFrame.cpp
+++ b/engine/ui/gGUIFrame.cpp
@@ -55,6 +55,22 @@ void gGUIFrame::update() {
 
 void gGUIFrame::draw() {
 //	gLogi("gGUIFrame") << "draw";
+#if GLIST_ANDROID || GLIST_IOS
+	// A GUI app never clears the screen - the interface is expected to cover it,
+	// and it always did. While the page is stretched past its end it no longer
+	// does: the band shows ground the layout does not reach, and what sits there
+	// is whatever the last frame left, which is the bottom of the page a moment
+	// ago. That is the flicker of a duplicated page edge during the bounce. The
+	// exposed strip is painted over before anything else is drawn.
+	if(gRenderer::getOverscrollX() != 0 || gRenderer::getOverscrollY() != 0) {
+		gColor* oldcolor = renderer->getColor();
+		renderer->setColor(backgroundcolor);
+		gDrawRectangle(gRenderer::getScrollX() + gRenderer::getOverscrollX(),
+				gRenderer::getScrollY() + gRenderer::getOverscrollY(),
+				gRenderer::getUnitViewportWidth(), gRenderer::getUnitViewportHeight(), true);
+		renderer->setColor(oldcolor);
+	}
+#endif
 	if(guisizer) guisizer->draw();
 	if(toolbarnum > 0) for(int i = 0; i < toolbarnum; i++) toolbars[i]->draw();
 	if(verticaltoolbarnum > 0) for(int i = 0; i < verticaltoolbarnum; i++) verticaltoolbars[i]->draw();

--- a/engine/ui/gGUIListbox.cpp
+++ b/engine/ui/gGUIListbox.cpp
@@ -33,7 +33,16 @@ gGUIListbox::~gGUIListbox() {
 
 void gGUIListbox::set(gBaseApp* root, gBaseGUIObject* topParentGUIObject, gBaseGUIObject* parentGUIObject, int parentSlotLineNo, int parentSlotColumnNo, int x, int y, int w, int h) {
 	gGUIScrollable::set(root, topParentGUIObject, parentGUIObject, parentSlotLineNo, parentSlotColumnNo, x, y, w, h);
+#if GLIST_ANDROID || GLIST_IOS
+	// The height it was given, not the one it would have picked for itself. Using
+	// its own left the box and the control disagreeing about how tall the list is:
+	// the content was drawn for one size and shown at another, so rows past the
+	// end appeared and the scroll stopped short of them. What it wants is still
+	// said, once, through getNaturalHeight() - and then the layout decides.
+	gGUIScrollable::setDimensions(width, height);
+#else
 	gGUIScrollable::setDimensions(width, listboxh + textoffset);
+#endif
 	updateTotalHeight();
 }
 
@@ -130,7 +139,9 @@ void gGUIListbox::mouseReleased(int x, int y, int button) {
 	if(mousepressedonlist) mousepressedonlist = false;
 	if(x >= left && x < left + boxw && y >= top + titleheight && y < top + titleheight + boxh) {
 		int newselectedno = (y - top - titleheight + verticalscroll) / lineh;
-		if(newselectedno < data.size()) selectedno = newselectedno;
+		// Signed on both sides: a negative index would otherwise convert to a huge
+		// unsigned one and pass the test.
+		if(newselectedno >= 0 && newselectedno < (int)data.size()) selectedno = newselectedno;
 		isfocused = true;
 		root->getCurrentCanvas()->onGuiEvent(id, G_GUIEVENT_LISTBOXSELECTED, gToStr(selectedno));
 	}
@@ -266,3 +277,9 @@ void gGUIListbox::setDisabled(bool isDisabled) {
 bool gGUIListbox::isDisabled() {
 	return isdisabled;
 }
+
+#if GLIST_ANDROID || GLIST_IOS
+int gGUIListbox::getNaturalHeight() {
+	return listboxh;
+}
+#endif

--- a/engine/ui/gGUIListbox.h
+++ b/engine/ui/gGUIListbox.h
@@ -77,6 +77,12 @@ public:
 	 */
 	void addData(std::string lineData);
 
+#if GLIST_ANDROID || GLIST_IOS
+	// Room for the number of lines it was asked to show - deliberately not for all
+	// the data, which is the whole point of a list that scrolls.
+	int getNaturalHeight() override;
+#endif
+
 	/*
 	 * Changes the data of the given line no.
 	 *

--- a/engine/ui/gGUINotebook.cpp
+++ b/engine/ui/gGUINotebook.cpp
@@ -7,6 +7,7 @@
 
 #include <gGUINotebook.h>
 #include <algorithm>
+#include <cmath>
 
 gGUINotebook::gGUINotebook() {
 	tabposition = TabPosition::TOP;
@@ -235,10 +236,42 @@ void gGUINotebook::drawHeader() {
 	}
 	int scrollmax = totalbarsize - availablespace;
 	scrollmax = std::max(0, scrollmax);
+	tabscrollmax = scrollmax;
 	tabscroll = std::min(tabscroll, scrollmax);
 	tabscroll = std::max(tabscroll, 0);
 
 	renderer->setColor(0, 0, 0);
+	// The strip is rendered into a screen sized buffer starting at its top left
+	// corner, so it must not inherit the scroll offset of the page this notebook
+	// sits on - with the offset left in, scrolling the page walks the strip out
+	// of the buffer and it simply vanishes. The offset is put back before the
+	// buffer is drawn to the screen, since that drawing does belong to the page.
+	int pagescrollx = gRenderer::getScrollX();
+	int pagescrolly = gRenderer::getScrollY();
+	int pageoverscrollx = gRenderer::getOverscrollX();
+	int pageoverscrolly = gRenderer::getOverscrollY();
+	gRenderer::setScrollX(0);
+	gRenderer::setScrollY(0);
+	// The page's rubber band would otherwise stretch the strip along with it,
+	// which is not what is being pulled.
+	gRenderer::setOverscroll(0, 0);
+#if GLIST_ANDROID || GLIST_IOS
+	// The strip spans the whole notebook width, which can be wider than the
+	// on-screen band once the page scrolls sideways. Drawn through the band's
+	// projection its far part would be clipped, and the buffer read at the bottom
+	// of this function would then stretch the clipped edge across the gap -
+	// straight black streaks past the last visible tab. The buffer is sized to the
+	// strip and the strip is drawn through its own box, so all of it is captured
+	// whatever the band is. See gRenderer::setContentProjection().
+	int bufferwidth = renderer->unscaleX(notebookbox.w);
+	int bufferheight = renderer->unscaleY(notebookbox.h);
+	if (bufferwidth < 1) bufferwidth = 1;
+	if (bufferheight < 1) bufferheight = 1;
+	if (fbo.getWidth() != bufferwidth || fbo.getHeight() != bufferheight) {
+		fbo.allocate(bufferwidth, bufferheight);
+	}
+	gRenderer::setContentProjection(notebookbox.w, notebookbox.h);
+#endif
 	fbo.bind();
 	renderer->clearColor(0, 0, 0, 0);
 	drawHeaderBackground();
@@ -247,12 +280,25 @@ void gGUINotebook::drawHeader() {
 	if (showscrollbuttons) {
 		initialstart = scrollbuttonwidth;
 	}
+#if GLIST_ANDROID || GLIST_IOS
+	// The strip is always laid out left to right in the buffer and rotated on the
+	// way out, so its rubber band is always along x here whichever side the tabs
+	// are on. Applied to the tabs alone: the background and the scroll buttons
+	// belong to the box, not to the strip sliding inside it.
+	gRenderer::setOverscroll((int)std::lround(isVerticalTabStrip() ? contentoverscrolly : contentoverscrollx), 0);
+#endif
 	int start = initialstart;
 	for (int i = 0; i < tabs.size(); ++i) {
 		Tab& tab = tabs[i];
 		int relativestartx = start - tabscroll;
 		int tabwidth = tab.tabwidth;
-		if (relativestartx + tabwidth < initialstart || relativestartx > availablespace) {
+		// The strip runs from initialstart to initialstart + availablespace, so its
+		// far edge is the sum of the two. Testing against availablespace alone cut
+		// the strip short by the width of one scroll button: a tab starting inside
+		// that band was dropped instead of being drawn half in view, which left
+		// grey where it should have been and made it appear all at once after the
+		// smallest drag.
+		if (relativestartx + tabwidth < initialstart || relativestartx > initialstart + availablespace) {
 			start += tabwidth + tabgap;
 			tab.tabbox.enabled = false;
 			tab.closebox.enabled = false;
@@ -305,6 +351,9 @@ void gGUINotebook::drawHeader() {
 		tab.tabbox.enabled = true;
 		start += tabwidth + tabgap;
 	}
+#if GLIST_ANDROID || GLIST_IOS
+	gRenderer::setOverscroll(0, 0);
+#endif
 	if (showscrollbuttons) {
 		renderer->setColor(middlegroundcolor);
 		gDrawRectangle(0, -1, scrollbuttonwidth, headerheight + 1, true);
@@ -359,6 +408,12 @@ void gGUINotebook::drawHeader() {
 	}
 
 	fbo.unbind();
+#if GLIST_ANDROID || GLIST_IOS
+	gRenderer::clearContentProjection();
+#endif
+	gRenderer::setScrollX(pagescrollx);
+	gRenderer::setScrollY(pagescrolly);
+	gRenderer::setOverscroll(pageoverscrollx, pageoverscrolly);
 	renderer->setColor(255, 255, 255, 255);
 	float rotate = 0;
 	int shiftx = 0;
@@ -375,7 +430,13 @@ void gGUINotebook::drawHeader() {
 		shifty = height;
 		scaley = -1;
 	}
+#if GLIST_ANDROID || GLIST_IOS
+	// The buffer was drawn through the strip's own box (setContentProjection), so
+	// it holds the whole strip and nothing else - the full buffer is the source.
+	fbo.getTexture().drawSub(left + shiftx, top + shifty, notebookbox.w * scalex, notebookbox.h * scaley, 0, 0, fbo.getWidth(), fbo.getHeight(), 0, 0, rotate);
+#else
 	fbo.getTexture().drawSub(left + shiftx, top + shifty, notebookbox.w * scalex, notebookbox.h * scaley, 0, renderer->getHeight() - notebookbox.h, notebookbox.w, notebookbox.h, 0, 0, rotate);
+#endif
 
 	// visualise hitboxes for debugging
 	renderer->setColor(255, 0, 0);
@@ -433,31 +494,97 @@ void gGUINotebook::updateSizer() {
 	}
 }
 
-void gGUINotebook::mousePressed(int x, int y, int button) {
+#if GLIST_ANDROID || GLIST_IOS
+int gGUINotebook::getNaturalHeight() {
+	int stripheight = tabvisibility ? headerheight : 0;
+	int bodyheight = guisizer ? guisizer->getNaturalHeight() : 0;
+	return stripheight + bodyheight;
+}
+
+void gGUINotebook::setReferenceHeight(int referenceHeight) {
+	if(!guisizer) return;
+	int stripheight = tabvisibility ? headerheight : 0;
+	int bodyheight = referenceHeight - stripheight;
+	if(bodyheight < 0) bodyheight = 0;
+	guisizer->setReferenceHeight(bodyheight);
+}
+#endif
+
+bool gGUINotebook::handleHeaderPress(int x, int y) {
 	if (scrollpreviousbutton.rotate(tabposition, width, height).isPointInside(x, y)) {
 		tabscroll -= 100;
-		return;
+		if (tabscroll < 0) tabscroll = 0;
+		return true;
 	}
 	if (scrollnextbutton.rotate(tabposition, width, height).isPointInside(x, y)) {
 		tabscroll += 100;
-		return;
+		return true;
 	}
 	for (int i = 0; i < tabs.size(); ++i) {
 		Tab& tab = tabs[i];
 		if (tab.closebox.rotate(tabposition, width, height).isPointInside(x, y)) {
 			closeTab(i);
-			break;
+			return true;
 		}
 		if (tab.tabbox.rotate(tabposition, width, height).isPointInside(x, y)) {
 			setActiveTab(i);
-			break;
+			return true;
 		}
 	}
+	return false;
+}
+
+void gGUINotebook::mousePressed(int x, int y, int button) {
+#if GLIST_ANDROID || GLIST_IOS
+	// Arms the tab strip drag, the strip being this control's touch scroll area.
+	gGUIScrollable::mousePressed(x, y, button);
+	if (isInsideTouchScrollArea(x, y)) {
+		// A finger on the strip is either tapping a tab or starting to drag
+		// across it, and which one it is is not known yet. Acting at release
+		// instead is what stops a drag from switching tabs on its way past.
+		return;
+	}
+#else
+	if (handleHeaderPress(x, y)) {
+		return;
+	}
+#endif
+	gGUIContainer::mousePressed(x, y, button);
+}
+
+void gGUINotebook::mouseDragged(int x, int y, int button) {
+#if GLIST_ANDROID || GLIST_IOS
+	if (iscontentdragarmed) {
+		gGUIScrollable::mouseDragged(x, y, button);
+		return;
+	}
+#endif
+	gGUIContainer::mouseDragged(x, y, button);
+}
+
+void gGUINotebook::mouseReleased(int x, int y, int button) {
+#if GLIST_ANDROID || GLIST_IOS
+	bool wasonstrip = iscontentdragarmed;
+	bool wasdragging = iscontentdragging;
+	// Clears the drag and starts the fling if the strip was thrown.
+	gGUIScrollable::mouseReleased(x, y, button);
+	if (wasonstrip) {
+		// A gesture that never became a drag is a tap, and only then does the
+		// tab under it get picked. A withdrawn gesture arrives from a point no
+		// tab occupies, so it lands on nothing either way.
+		if (!wasdragging) handleHeaderPress(x, y);
+		return;
+	}
+#endif
+	gGUIContainer::mouseReleased(x, y, button);
 }
 
 void gGUINotebook::mouseMoved(int x, int y) {
 	lastmousex = x;
 	lastmousey = y;
+	// Controls living inside a tab are reachable only through here: gGUISizer
+	// routes presses and drags by iscursoron, and nothing but mouseMoved sets it.
+	gGUIContainer::mouseMoved(x, y);
 }
 
 void gGUINotebook::mouseScrolled(int x, int y) {

--- a/engine/ui/gGUINotebook.h
+++ b/engine/ui/gGUINotebook.h
@@ -162,7 +162,7 @@ private:
 
 		bool enabled = false;
 
-		bool isPointInside(int tx, int ty) {
+		bool isPointInside(int tx, int ty) const {
 			if (!enabled) {
 				return false;
 			}
@@ -238,8 +238,57 @@ private:
 	void drawHeaderBackground();
 
 	void mousePressed(int x, int y, int button) override;
+	void mouseDragged(int x, int y, int button) override;
+	void mouseReleased(int x, int y, int button) override;
 	void mouseMoved(int x, int y) override;
 	void mouseScrolled(int x, int y) override;
+
+	/*
+	 * Acts on a press or a tap landing on the tab strip: the scroll buttons and
+	 * the tabs themselves, including their close boxes.
+	 *
+	 * @return true if the point hit something and the event was consumed.
+	 */
+	bool handleHeaderPress(int x, int y);
+
+#if GLIST_ANDROID || GLIST_IOS
+	// The tab strip runs down the side rather than across the top, so it is the
+	// vertical axis a finger drags.
+	bool isVerticalTabStrip() const {
+		return tabposition == TabPosition::LEFT || tabposition == TabPosition::RIGHT;
+	}
+
+	/*
+	 * The tab strip is what a finger scrolls on a notebook - the content below is
+	 * a sizer with controls of its own, and the strip's scroll buttons are far too
+	 * small to aim at on glass. Mapping tabscroll onto the axis the strip is laid
+	 * out along hands the drag, the fling and the hand over to the page straight
+	 * to gGUIScrollable. The idle axis reports a maximum of zero, which is what
+	 * lets a drag across the strip scroll the page instead.
+	 */
+	int getTouchScrollX() const override { return isVerticalTabStrip() ? 0 : tabscroll; }
+	int getTouchScrollY() const override { return isVerticalTabStrip() ? tabscroll : 0; }
+	void setTouchScrollX(int value) override { if(!isVerticalTabStrip()) tabscroll = value; }
+	void setTouchScrollY(int value) override { if(isVerticalTabStrip()) tabscroll = value; }
+	int getTouchScrollMaxX() const override { return isVerticalTabStrip() ? 0 : tabscrollmax; }
+	int getTouchScrollMaxY() const override { return isVerticalTabStrip() ? tabscrollmax : 0; }
+
+	bool isInsideTouchScrollArea(int x, int y) const override {
+		return tabvisibility && headerbox.isPointInside(x, y);
+	}
+
+	/*
+	 * The tab strip plus whatever the open tab needs. Without this a notebook says
+	 * nothing about itself and is left with a bare share of the page, which is not
+	 * enough for a header and a body both - the strip ends up occupying most of
+	 * the box and the tab content is crushed under it.
+	 */
+	int getNaturalHeight() override;
+
+	// Passed on to the tab body, less the strip, since that is what the body will
+	// actually be given.
+	void setReferenceHeight(int referenceHeight) override;
+#endif
 
 	void updateSizer();
 
@@ -249,6 +298,10 @@ private:
 private:
 	std::vector<Tab> tabs;
 	int tabscroll;
+	// How far the strip may be scrolled, as worked out by the last drawHeader().
+	// Zero until the notebook has been drawn once, which simply means a finger
+	// cannot drag a strip that has not been laid out yet.
+	int tabscrollmax = 0;
 	int activetab;
 	int headerheight;
 

--- a/engine/ui/gGUINumberBox.cpp
+++ b/engine/ui/gGUINumberBox.cpp
@@ -56,6 +56,16 @@ gGUINumberBox::gGUINumberBox() {
 	boxsizer.setSize(1, 2);
 	float columnprops[2] = {0.70f, 0.30f};
 	boxsizer.setColumnProportions(columnprops);
+#if GLIST_ANDROID || GLIST_IOS
+	// A sizer defaults to a 24 unit slot padding on mobile, which is the finger
+	// gap wanted between separate controls on a page. This sizer is not a page: it
+	// holds the one textbox the number box is built around, and the inc/dec
+	// buttons are then placed hard against that textbox from its own edges. Left at
+	// 24 the textbox is inset from every side and the buttons drift off it. The
+	// desktop-tight (2, 0) keeps the internal composition the buttons were drawn
+	// for - which is exactly what desktop already uses by default.
+	boxsizer.setSlotPadding(2, 0);
+#endif
 //	boxsizer.setSize(lineno, columno);
 //	float lineprops[] = {0.43f, 0.06f, 0.2f, 0.01f};
 //	float columnprops[] = {0.50f, 0.50f};
@@ -302,6 +312,12 @@ void gGUINumberBox::mouseDragged(int x, int y, int button) {
 void gGUINumberBox::update() {
 	textbox.update();
 }
+
+#if GLIST_ANDROID || GLIST_IOS
+int gGUINumberBox::getNaturalHeight() {
+	return boxheight;
+}
+#endif
 
 void gGUINumberBox::draw() {
 	gColor oldcolor = renderer->getColor();

--- a/engine/ui/gGUINumberBox.h
+++ b/engine/ui/gGUINumberBox.h
@@ -43,6 +43,9 @@ public:
 	void mouseDragged(int x, int y, int button);
 	void update();
 	void draw();
+#if GLIST_ANDROID || GLIST_IOS
+	int getNaturalHeight() override;
+#endif
 	void setMaxValue(int maxValue);
 	void setMinValue(int minValue);
 	void setMaxValue(float maxValuef);

--- a/engine/ui/gGUIProgressBar.cpp
+++ b/engine/ui/gGUIProgressBar.cpp
@@ -30,6 +30,14 @@ gGUIProgressBar::gGUIProgressBar() {
 gGUIProgressBar::~gGUIProgressBar() {
 }
 
+#if GLIST_ANDROID || GLIST_IOS
+int gGUIProgressBar::getNaturalHeight() {
+	// A line bar is as tall as the bar; a circular or spin one is as tall as its
+	// diameter.
+	return type == TYPE_LINE ? progressbarh : radius * 2;
+}
+#endif
+
 void gGUIProgressBar::draw() {
 	gColor oldcolor = renderer->getColor();
 	renderer->setColor(backgroundcolor);// color of the background of progressbar

--- a/engine/ui/gGUIProgressBar.h
+++ b/engine/ui/gGUIProgressBar.h
@@ -63,6 +63,9 @@ public:
 	gGUIProgressBar();
 	virtual ~gGUIProgressBar();
 	void draw();
+#if GLIST_ANDROID || GLIST_IOS
+	int getNaturalHeight() override;
+#endif
 
 	/**
 	 * Sets the shown value of the progress bar. Developers can determine the shown

--- a/engine/ui/gGUIScrollable.cpp
+++ b/engine/ui/gGUIScrollable.cpp
@@ -8,6 +8,181 @@
 #include "gGUIScrollable.h"
 #include "gAppManager.h"
 
+#if GLIST_ANDROID || GLIST_IOS
+#include <cmath>
+
+gGUIScrollable* gGUIScrollable::contentdragowner = nullptr;
+gGUIScrollable* gGUIScrollable::contentflingowner = nullptr;
+gGUIScrollable* gGUIScrollable::contentoverscrollowner = nullptr;
+
+namespace {
+// How far the finger has to travel before the drag counts as scrolling the
+// content rather than pressing what is under it. Deliberately below the page's
+// own threshold in gAppManager, so that a control gets the chance to claim the
+// gesture before the page starts considering it.
+const int contentdragthreshold = 6;
+
+// The content coasts on the same terms as the page does, so that a list and the
+// page it sits on feel like one surface. See the matching block in gAppManager
+// for what each of these means.
+constexpr float contentflingdecayrate = 3.0f;
+constexpr float contentflingminstartspeed = 60.0f;
+constexpr float contentflingstopspeed = 20.0f;
+constexpr float contentflingmaxstep = 0.1f;
+constexpr float contentvelocitymininterval = 0.001f;
+constexpr float contentvelocitymaxinterval = 0.2f;
+constexpr float contentvelocitysmoothing = 0.7f;
+
+// The rubber band follows the page's model too, but stretches less: a control is
+// a small window and a long pull inside it looks like the drawing has come loose.
+// See the matching block in gAppManager for what each of these means.
+constexpr float contentoverscrollmax = 55.0f;
+constexpr float contentoverscrollreturnrate = 12.0f;
+constexpr float contentoverscrollstopdistance = 0.5f;
+constexpr float contentoverscrollbouncetime = 0.12f;
+
+float resistContentOverscroll(float distance) {
+	float magnitude = std::fabs(distance);
+	float resisted = contentoverscrollmax * magnitude / (magnitude + contentoverscrollmax);
+	return distance < 0.0f ? -resisted : resisted;
+}
+}
+
+void gGUIScrollable::enableContentOverscroll(bool isEnabled) {
+	iscontentoverscrollenabled = isEnabled;
+	if(!isEnabled) setContentOverscroll(0.0f, 0.0f);
+}
+
+bool gGUIScrollable::isContentOverscrollEnabled() const {
+	return iscontentoverscrollenabled;
+}
+
+void gGUIScrollable::setContentOverscroll(float overscrollX, float overscrollY) {
+	contentoverscrollx = overscrollX;
+	contentoverscrolly = overscrollY;
+	if(overscrollX == 0.0f && overscrollY == 0.0f) {
+		if(contentoverscrollowner == this) contentoverscrollowner = nullptr;
+		return;
+	}
+	// Taking ownership drops whatever was stretched before. Two controls cannot be
+	// pulled at once, and a band left behind by an earlier gesture would sit there
+	// stretched with nothing to spring it back.
+	if(contentoverscrollowner && contentoverscrollowner != this) {
+		contentoverscrollowner->contentoverscrollx = 0.0f;
+		contentoverscrollowner->contentoverscrolly = 0.0f;
+	}
+	contentoverscrollowner = this;
+}
+
+bool gGUIScrollable::isContentDragActive() {
+	return contentdragowner != nullptr;
+}
+
+void gGUIScrollable::cancelContentFling() {
+	contentflingowner = nullptr;
+	// A stretch left mid spring goes with it: either a finger has landed and is
+	// about to set its own, or the gesture was withdrawn and there is nothing left
+	// to spring back from.
+	if(contentoverscrollowner) contentoverscrollowner->setContentOverscroll(0.0f, 0.0f);
+}
+
+void gGUIScrollable::trackContentVelocity() {
+	std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+	if(hascontentdragvelocity) {
+		float interval = std::chrono::duration<float>(now - lastcontentdragtime).count();
+		if(interval > contentvelocitymininterval && interval < contentvelocitymaxinterval) {
+			// Measured from the scroll that actually took effect rather than from
+			// the finger, so a drag already pinned against an end builds up no
+			// speed and cannot fling away from it once released.
+			float instantx = (float)(getTouchScrollX() - lastcontentdraghorizontalscroll) / interval;
+			float instanty = (float)(getTouchScrollY() - lastcontentdragverticalscroll) / interval;
+			contentflingvelocityx = contentflingvelocityx * (1.0f - contentvelocitysmoothing) + instantx * contentvelocitysmoothing;
+			contentflingvelocityy = contentflingvelocityy * (1.0f - contentvelocitysmoothing) + instanty * contentvelocitysmoothing;
+		}
+	}
+	lastcontentdragtime = now;
+	lastcontentdraghorizontalscroll = getTouchScrollX();
+	lastcontentdragverticalscroll = getTouchScrollY();
+	hascontentdragvelocity = true;
+}
+
+void gGUIScrollable::updateContentOverscroll() {
+	gGUIScrollable* control = contentoverscrollowner;
+	if(!control) return;
+	// A finger still dragging is holding the stretch out on purpose, and sets it
+	// itself every move.
+	if(contentdragowner == control && control->iscontentdragging) return;
+	float step = (float)appmanager->getElapsedTime();
+	if(step <= 0.0f) return;
+	if(step > contentflingmaxstep) step = contentflingmaxstep;
+
+	float decay = std::exp(-contentoverscrollreturnrate * step);
+	float newx = control->contentoverscrollx * decay;
+	float newy = control->contentoverscrolly * decay;
+	if(std::fabs(newx) < contentoverscrollstopdistance) newx = 0.0f;
+	if(std::fabs(newy) < contentoverscrollstopdistance) newy = 0.0f;
+	control->setContentOverscroll(newx, newy);
+}
+
+void gGUIScrollable::updateContentFling() {
+	updateContentOverscroll();
+	gGUIScrollable* control = contentflingowner;
+	if(!control) return;
+	float step = (float)appmanager->getElapsedTime();
+	if(step <= 0.0f) return;
+	if(step > contentflingmaxstep) step = contentflingmaxstep;
+
+	control->contentflingpositionx += control->contentflingvelocityx * step;
+	control->contentflingpositiony += control->contentflingvelocityy * step;
+	float decay = std::exp(-contentflingdecayrate * step);
+	control->contentflingvelocityx *= decay;
+	control->contentflingvelocityy *= decay;
+
+	// Reaching an end stops that axis and pulls the coasting position back onto
+	// the clamped value, so no unseen speed piles up beyond the content.
+	int maxy = control->getTouchScrollMaxY();
+	if(maxy > 0) {
+		int target = (int)std::lround(control->contentflingpositiony);
+		control->setTouchScrollY(gClamp(target, 0, maxy));
+		if(target != control->getTouchScrollY()) {
+			// What is left of the throw becomes the bounce rather than being
+			// dropped, so reaching the end fast looks different from reaching it
+			// slow. Only when nothing is stretched yet, or a fling grinding along
+			// the end would keep topping it up and the spring would never finish.
+			if(control->iscontentoverscrollenabled && control->contentoverscrolly == 0.0f) {
+				control->setContentOverscroll(control->contentoverscrollx,
+						resistContentOverscroll(control->contentflingvelocityy * contentoverscrollbouncetime));
+			}
+			control->contentflingvelocityy = 0.0f;
+			control->contentflingpositiony = (float)control->getTouchScrollY();
+		}
+	} else {
+		control->contentflingvelocityy = 0.0f;
+	}
+	int maxx = control->getTouchScrollMaxX();
+	if(maxx > 0) {
+		int target = (int)std::lround(control->contentflingpositionx);
+		control->setTouchScrollX(gClamp(target, 0, maxx));
+		if(target != control->getTouchScrollX()) {
+			if(control->iscontentoverscrollenabled && control->contentoverscrollx == 0.0f) {
+				control->setContentOverscroll(
+						resistContentOverscroll(control->contentflingvelocityx * contentoverscrollbouncetime),
+						control->contentoverscrolly);
+			}
+			control->contentflingvelocityx = 0.0f;
+			control->contentflingpositionx = (float)control->getTouchScrollX();
+		}
+	} else {
+		control->contentflingvelocityx = 0.0f;
+	}
+
+	if(std::fabs(control->contentflingvelocityx) < contentflingstopspeed &&
+			std::fabs(control->contentflingvelocityy) < contentflingstopspeed) {
+		contentflingowner = nullptr;
+	}
+}
+#endif
+
 
 gGUIScrollable::gGUIScrollable() {
 	boxw = width;
@@ -29,6 +204,16 @@ gGUIScrollable::gGUIScrollable() {
 }
 
 gGUIScrollable::~gGUIScrollable() {
+#if GLIST_ANDROID || GLIST_IOS
+	// The three statics below name whichever control is being dragged, coasting or
+	// stretched. Nothing else clears them, so a control destroyed while it holds
+	// one leaves a pointer to freed memory that updateContentFling() then writes
+	// through, every frame, forever. Closing a tab or swapping a page is enough to
+	// do it.
+	if(contentdragowner == this) contentdragowner = nullptr;
+	if(contentflingowner == this) contentflingowner = nullptr;
+	if(contentoverscrollowner == this) contentoverscrollowner = nullptr;
+#endif
 	delete boxfbo;
 }
 
@@ -90,7 +275,10 @@ void gGUIScrollable::updateScrollbar() {
 		verticalscroll = 0;
 	}
 
-	scrollbarverticalsize = ((float) boxh / totalh) * boxh;
+	// totalh is 0 until a subclass says how tall its content is, and a float
+	// division by it yields infinity - which is undefined behaviour on the way
+	// back to an int, not merely a large number.
+	scrollbarverticalsize = totalh > 0 ? (int)(((float) boxh / totalh) * boxh) : boxh;
 	if (scrollbarverticalsize < barsize) {
 		scrollbarverticalsize = barsize;
 	}
@@ -109,7 +297,7 @@ void gGUIScrollable::updateScrollbar() {
 		horizontalscroll = 0;
 	}
 
-	scrollbarhorizontalsize = ((float) boxw / totalw) * boxw;
+	scrollbarhorizontalsize = totalw > 0 ? (int)(((float) boxw / totalw) * boxw) : boxw;
 	if (scrollbarhorizontalsize < barsize) {
 		scrollbarhorizontalsize = barsize;
 	}
@@ -135,16 +323,71 @@ void gGUIScrollable::draw() {
 	renderer->setColor(fontcolor);
 	if(istitleon) font->drawText(title, titlex, titley);
 	renderer->setColor(0, 0, 0);
+	// The content is rendered into a screen sized buffer starting at its top
+	// left corner, so it must not inherit the scroll offset of the page this
+	// control sits on. The offset is restored before the buffer is drawn back,
+	// since that drawing does belong to the page.
+	int pagescrollx = gRenderer::getScrollX();
+	int pagescrolly = gRenderer::getScrollY();
+	int pageoverscrollx = gRenderer::getOverscrollX();
+	int pageoverscrolly = gRenderer::getOverscrollY();
+	gRenderer::setScrollX(0);
+	gRenderer::setScrollY(0);
+	gRenderer::setOverscroll(0, 0);
+#if GLIST_ANDROID || GLIST_IOS
+	// The box can be wider or taller than the on-screen band once the page
+	// scrolls, and drawn through the band's projection whatever falls outside the
+	// band would be clipped and the buffer read below would stretch the clipped
+	// edge across the gap. The buffer is sized to the box and the content is drawn
+	// through the box's own projection, so all of it is captured whatever the band
+	// is. See gRenderer::setContentProjection().
+	int bufferwidth = renderer->unscaleX(width);
+	int bufferheight = renderer->unscaleY(height);
+	if (bufferwidth < 1) bufferwidth = 1;
+	if (bufferheight < 1) bufferheight = 1;
+	if (bufferwidth != boxfbo->getWidth() || bufferheight != boxfbo->getHeight()) {
+		boxfbo->allocate(bufferwidth, bufferheight);
+	}
+	gRenderer::setContentProjection(width, height);
+#endif
 	boxfbo->bind();
 	renderer->clearColor(0, 0, 0, 0);
+#if GLIST_ANDROID || GLIST_IOS
+	// The control's own rubber band is drawn the same way the page's is: by
+	// shifting the band the content is rendered through. Nothing the content
+	// itself does has to change, and no subclass sees a scroll position outside
+	// its range - which matters, since several of them turn that position into a
+	// row index and would read outside their data with a negative one.
+	gRenderer::setOverscroll((int)std::lround(contentoverscrollx), (int)std::lround(contentoverscrolly));
 	drawContent();
+	// The bars sit against the edge of the box and belong to it, not to the
+	// content, so they stay put while the content stretches away.
+	gRenderer::setOverscroll(0, 0);
+#else
+	drawContent();
+#endif
 	drawScrollbars();
 	boxfbo->unbind();
+#if GLIST_ANDROID || GLIST_IOS
+	gRenderer::clearContentProjection();
+#endif
+	gRenderer::setScrollX(pagescrollx);
+	gRenderer::setScrollY(pagescrolly);
+	gRenderer::setOverscroll(pageoverscrollx, pageoverscrolly);
 	renderer->setColor(255, 255, 255);
+#if GLIST_ANDROID || GLIST_IOS
+	// The buffer was drawn through the box's own projection (setContentProjection),
+	// so it holds the whole box and nothing else - the full buffer is the source.
 	boxfbo->drawSub(left, top + titleheight,
 					width, height,
-					0, renderer->unscaleY(renderer->getHeight() - height),
+					0, 0,
+					boxfbo->getWidth(), boxfbo->getHeight());
+#else
+	boxfbo->drawSub(left, top + titleheight,
+					width, height,
+					0, renderer->getScreenHeight() - renderer->unscaleY(height),
 					renderer->unscaleX(width), renderer->unscaleY(height));
+#endif
 	renderer->setColor(foregroundcolor);
 	gDrawRectangle(left, top + titleheight, width, height, false);
 	if(isalpha) {
@@ -212,6 +455,25 @@ void gGUIScrollable::mousePressed(int x, int y, int button) {
 		horizontalscrolldragstart = x;
 	}
 	verticalscrollclickedtime = 0.4f;
+
+#if GLIST_ANDROID || GLIST_IOS
+	// A content drag is only possible where the content actually is: inside the
+	// control, and not on either scrollbar, which have their own drag.
+	// A finger on the glass takes the content over, which is what lets a coasting
+	// list be stopped mid flight.
+	if(contentflingowner == this) contentflingowner = nullptr;
+	contentflingvelocityx = 0.0f;
+	contentflingvelocityy = 0.0f;
+	hascontentdragvelocity = false;
+	iscontentdragging = false;
+	iscontentdragarmed = !isdraggingverticalscroll && !isdragginghorizontalscroll &&
+			isInsideTouchScrollArea(x, y);
+	contentdragstartx = x;
+	contentdragstarty = y;
+	contentdragstartverticalscroll = getTouchScrollY();
+	contentdragstarthorizontalscroll = getTouchScrollX();
+	if(contentdragowner == this) contentdragowner = nullptr;
+#endif
 }
 
 void gGUIScrollable::mouseDragged(int x, int y, int button) {
@@ -227,11 +489,83 @@ void gGUIScrollable::mouseDragged(int x, int y, int button) {
 		horizontalscroll = gClamp(horizontalscroll + diff, 0, totalw - boxw);
 		horizontalscrolldragstart = x;
 	}
+
+#if GLIST_ANDROID || GLIST_IOS
+	if(isdraggingverticalscroll || isdragginghorizontalscroll || !iscontentdragarmed) return;
+
+	// The content follows the finger one to one, unlike the thumb drag above
+	// which is scaled: here the finger is on the content itself.
+	int draggedx = contentdragstartx - x;
+	int draggedy = contentdragstarty - y;
+	int maxy = getTouchScrollMaxY();
+	int maxx = getTouchScrollMaxX();
+	bool canscrollvertically = maxy > 0;
+	bool canscrollhorizontally = maxx > 0;
+	if(!iscontentdragging) {
+		bool passedvertically = canscrollvertically &&
+				(draggedy >= contentdragthreshold || draggedy <= -contentdragthreshold);
+		bool passedhorizontally = canscrollhorizontally &&
+				(draggedx >= contentdragthreshold || draggedx <= -contentdragthreshold);
+		if(!passedvertically && !passedhorizontally) return;
+		iscontentdragging = true;
+	}
+
+	// Measured against the position the drag started from rather than the last
+	// one seen, so that rounding cannot accumulate over a long drag.
+	bool hasroomleft = false;
+	float overx = 0.0f;
+	float overy = 0.0f;
+	if(canscrollvertically) {
+		int target = contentdragstartverticalscroll + draggedy;
+		setTouchScrollY(gClamp(target, 0, maxy));
+		if(target == getTouchScrollY()) hasroomleft = true;
+		// Whatever the clamp refused is how far past the end the finger is asking
+		// to go, and that is what the rubber band shows.
+		else overy = resistContentOverscroll((float)(target - getTouchScrollY()));
+	}
+	if(canscrollhorizontally) {
+		int target = contentdragstarthorizontalscroll + draggedx;
+		setTouchScrollX(gClamp(target, 0, maxx));
+		if(target == getTouchScrollX()) hasroomleft = true;
+		else overx = resistContentOverscroll((float)(target - getTouchScrollX()));
+	}
+	if(iscontentoverscrollenabled) {
+		// Only where there is genuinely nowhere left to go. A page that can still
+		// scroll is about to take the gesture over, and stretching the control for
+		// the frame before that happens reads as a twitch rather than a limit.
+		if(gRenderer::getMaxScrollX() > 0) overx = 0.0f;
+		if(gRenderer::getMaxScrollY() > 0) overy = 0.0f;
+		setContentOverscroll(overx, overy);
+	}
+	// The gesture is held only while the content still has somewhere to go.
+	// Being pinned against the end releases it, which is the moment the page
+	// behind is allowed to start scrolling instead. Note this is about the drag
+	// running past the end, not about the finger pausing: a still finger keeps
+	// asking for a reachable position and so keeps the gesture.
+	contentdragowner = hasroomleft ? this : nullptr;
+	trackContentVelocity();
+#endif
 }
 
 void gGUIScrollable::mouseReleased(int x, int y, int button) {
 	isdraggingverticalscroll = false;
 	isdragginghorizontalscroll = false;
+#if GLIST_ANDROID || GLIST_IOS
+	// Only a drag that still owned the gesture may coast. Having lost it means
+	// either the content was already pinned against its end, or the page has
+	// taken the gesture over - in both cases a fling here would fight what the
+	// user is actually doing.
+	if(contentdragowner == this && iscontentdragging &&
+			(std::fabs(contentflingvelocityx) >= contentflingminstartspeed ||
+			 std::fabs(contentflingvelocityy) >= contentflingminstartspeed)) {
+		contentflingowner = this;
+		contentflingpositionx = (float)getTouchScrollX();
+		contentflingpositiony = (float)getTouchScrollY();
+	}
+	iscontentdragarmed = false;
+	iscontentdragging = false;
+	if(contentdragowner == this) contentdragowner = nullptr;
+#endif
 }
 
 void gGUIScrollable::mouseScrolled(int x, int y) {

--- a/engine/ui/gGUIScrollable.h
+++ b/engine/ui/gGUIScrollable.h
@@ -43,6 +43,8 @@
 #include "gGUIControl.h"
 #include "gFbo.h"
 
+#include <chrono>
+
 /*
  * This class is a child class of gGUIControl. Scrollable class provide scrollable
  * function on objects. When the box object's width and height is smaller than
@@ -126,6 +128,49 @@ public:
 
 	int getVerticalScroll();
 
+#if GLIST_ANDROID || GLIST_IOS
+	/*
+	 * True while a finger is dragging some control's content and that content
+	 * still has somewhere to go.
+	 *
+	 * On a touch screen the scrollbar thumb is too thin to hit, so scrolling has
+	 * to be done by dragging the content itself. That puts the control in
+	 * competition with the page it sits on, which scrolls by the same gesture.
+	 * gAppManager reads this to settle the question: while it is true the finger
+	 * belongs to the control, and the page keeps still.
+	 *
+	 * It goes false as soon as the drag is pinned against the control's own end,
+	 * which is what lets the page take the gesture over from there.
+	 */
+	static bool isContentDragActive();
+
+	/*
+	 * Advances the content fling of whichever control is still coasting after a
+	 * finger let go of it.
+	 *
+	 * Driven from gAppManager rather than from update() or draw(), because
+	 * several subclasses override both without calling the base and would
+	 * silently never coast. Only one control can be flung at a time - it takes a
+	 * finger to start one - so a single call carries all of them.
+	 */
+	static void updateContentFling();
+
+	// Ends any content fling at once, without letting it come to rest.
+	static void cancelContentFling();
+#endif
+
+#if GLIST_ANDROID || GLIST_IOS
+	/*
+	 * Turns the rubber band at the ends of a control's own scroll on or off.
+	 *
+	 * On by default. Worth turning off for a control whose content is not a plain
+	 * list of things - one where the edge is a hard boundary rather than the end
+	 * of a run - since there the stretch reads as the drawing coming loose.
+	 */
+	void enableContentOverscroll(bool isEnabled);
+	bool isContentOverscrollEnabled() const;
+#endif
+
 
 	gFbo* getFbo();
 
@@ -166,7 +211,72 @@ protected:
 	bool isdragginghorizontalscroll = false;
 	int horizontalscrolldragstart = 0;
 	float horizontalscrollclickedtime = 0.0f;
+
+#if GLIST_ANDROID || GLIST_IOS
+	// for dragging the content itself, which is how a finger scrolls
+	bool iscontentdragarmed = false;
+	bool iscontentdragging = false;
+	int contentdragstartx = 0, contentdragstarty = 0;
+	int contentdragstartverticalscroll = 0, contentdragstarthorizontalscroll = 0;
+
+	// Speed of the drag, kept so the content can carry on when the finger lifts.
+	float contentflingvelocityx = 0.0f, contentflingvelocityy = 0.0f;
+	// The coasting position at sub unit precision, so a slow glide is not
+	// rounded away frame after frame.
+	float contentflingpositionx = 0.0f, contentflingpositiony = 0.0f;
+	bool hascontentdragvelocity = false;
+	std::chrono::steady_clock::time_point lastcontentdragtime;
+	int lastcontentdragverticalscroll = 0, lastcontentdraghorizontalscroll = 0;
+
+	// How far the content is drawn past its end, in unit space, either sign. A
+	// drawing offset only - the scroll position stays clamped, which is what keeps
+	// subclasses that read it as a row index safe.
+	float contentoverscrollx = 0.0f, contentoverscrolly = 0.0f;
+	bool iscontentoverscrollenabled = true;
+
+	void trackContentVelocity();
+	void setContentOverscroll(float overscrollX, float overscrollY);
+	// Springs whichever control is stretched back towards its end. Static for the
+	// same reason the fling is: only one control can be stretched at a time.
+	static void updateContentOverscroll();
+
+	/*
+	 * What the finger moves, and how far it may move it.
+	 *
+	 * By default this is the content scroll every scrollable already has. A
+	 * control whose finger scrollable region is something else - gGUINotebook
+	 * drags its tab strip, which is neither the content nor a scrollbar -
+	 * overrides these, and gets the drag, the hand over to the page and the
+	 * fling without repeating any of it.
+	 *
+	 * A maximum of zero means that axis does not scroll, which is also how the
+	 * page is told it may have the gesture.
+	 */
+	virtual int getTouchScrollX() const { return horizontalscroll; }
+	virtual int getTouchScrollY() const { return verticalscroll; }
+	virtual void setTouchScrollX(int value) { horizontalscroll = value; }
+	virtual void setTouchScrollY(int value) { verticalscroll = value; }
+	virtual int getTouchScrollMaxX() const { return totalw > boxw ? totalw - boxw : 0; }
+	virtual int getTouchScrollMaxY() const { return totalh > boxh ? totalh - boxh : 0; }
+
+	// Where a finger has to land for the drag to be about scrolling at all.
+	virtual bool isInsideTouchScrollArea(int x, int y) const {
+		return x >= left && x < left + boxw && y >= top && y < top + height;
+	}
+#endif
 private:
+#if GLIST_ANDROID || GLIST_IOS
+	// The control currently moving its content under a finger, if any. Only one
+	// can hold the gesture, so a single pointer answers isContentDragActive()
+	// without every control having to be asked.
+	static gGUIScrollable* contentdragowner;
+	// The control still coasting after its finger left, if any.
+	static gGUIScrollable* contentflingowner;
+	// The control currently stretched past one of its ends, if any. Separate from
+	// the two above because a rubber band outlives both: it is still springing
+	// back after the finger has gone and the fling has stopped.
+	static gGUIScrollable* contentoverscrollowner;
+#endif
 	gFbo* boxfbo;
 
 	bool enableverticalscroll, enablehorizontalscroll;

--- a/engine/ui/gGUISizer.cpp
+++ b/engine/ui/gGUISizer.cpp
@@ -19,8 +19,22 @@ gGUISizer::gGUISizer() {
 	resizecolumn = 0;
 	resizeline = 0;
 	fillbackground = false;
+#if GLIST_ANDROID || GLIST_IOS
+	// Controls sat flush against each other, which on a touch screen reads as one
+	// block rather than as separate things to hit. Both axes inset a slot by this
+	// much on every side, so the two numbers mean the same thing and a gap between
+	// neighbours is twice one of them - 48 units, which on a 720 unit wide design
+	// is about a fifteenth of the page between one thing and the next, with half
+	// that left as a margin down the edges.
+	slotpadding = 24;
+	slotheightpadding = 24;
+	referenceheight = 0;
+#else
+	// Desktop keeps its old values: the pointer is precise there and the existing
+	// layouts are already drawn around them.
 	slotpadding = 2;
 	slotheightpadding = 0;
+#endif
 	alignvertically = false;
 	lineprs = nullptr;
 	columnprs = nullptr;
@@ -30,6 +44,11 @@ gGUISizer::gGUISizer() {
 }
 
 gGUISizer::~gGUISizer() {
+	// Allocated by setSize() and never released. Every sizer leaked four arrays.
+	delete[] lineprs;
+	delete[] columnprs;
+	delete[] linetprs;
+	delete[] columntprs;
 }
 
 void gGUISizer::set(gBaseApp* root, gBaseGUIObject* topParentGUIObject, gBaseGUIObject* parentGUIObject, int parentSlotLineNo, int parentSlotColumnNo, int x, int y, int w, int h) {
@@ -59,12 +78,37 @@ void gGUISizer::set(int x, int y, int w, int h) {
 	reloadControls();
 }
 
+#if GLIST_ANDROID || GLIST_IOS
+int gGUISizer::getRowTop(int lineNo) {
+	if((int)rowtops.size() != linenum) computeRowHeights();
+	// A sizer sized to no rows at all leaves these empty, and the size check above
+	// is satisfied by two zeroes. Reading the vector then walks off the front of
+	// it, so the bounds are checked rather than assumed.
+	if(lineNo < 0 || lineNo >= (int)rowtops.size()) return 0;
+	return rowtops[lineNo];
+}
+
+int gGUISizer::getRowHeight(int lineNo) {
+	if((int)rowheights.size() != linenum) computeRowHeights();
+	if(lineNo < 0 || lineNo >= (int)rowheights.size()) return 0;
+	return rowheights[lineNo];
+}
+#else
+int gGUISizer::getRowTop(int lineNo) {
+	return (int)((float)height * linetprs[lineNo]);
+}
+
+int gGUISizer::getRowHeight(int lineNo) {
+	return (int)((float)height * (linetprs[lineNo + 1] - linetprs[lineNo]));
+}
+#endif
+
 int gGUISizer::getSlotWidth(int lineNo, int columnNo) { //
 	return width * columnprs[columnNo];
 }
 
 int gGUISizer::getSlotHeight(int lineNo, int columnNo) { //
-	return height * lineprs[lineNo];
+	return getRowHeight(lineNo);
 }
 
 int gGUISizer::getSlotX(int lineNo, int columnNo) {
@@ -79,14 +123,7 @@ int gGUISizer::getSlotX(int lineNo, int columnNo) {
 }
 
 int gGUISizer::getSlotY(int lineNo, int columnNo) {
-	int totalheight = top;
-
-	for(int row = 0; row < lineNo; row++) {
-		int rowheight = getSlotHeight(row, columnNo);
-		totalheight += rowheight;
-	}
-
-	return totalheight;
+	return top + getRowTop(lineNo);
 }
 
 int gGUISizer::getSizerType() {
@@ -103,19 +140,19 @@ void gGUISizer::setSize(int lineNum, int columnNum) {
 		guicontrols.push_back({nullptr, false});
 	}
 
-	delete lineprs;
+	delete[] lineprs;
 	lineprs = new float[linenum];
 	for(int i = 0; i < linenum; i++) {
 		lineprs[i] = 1.0f / (float)linenum;
 	}
 
-	delete columnprs;
+	delete[] columnprs;
 	columnprs = new float[columnnum];
 	for(int i = 0; i < columnnum; i++) {
 		columnprs[i] = 1.0f / (float)columnnum;
 	}
 
-	delete linetprs;
+	delete[] linetprs;
 	linetprs = new float[linenum + 1];
 	linetprs[0] = 0.0f;
 	linetprs[linenum] = 1.0f;
@@ -126,7 +163,7 @@ void gGUISizer::setSize(int lineNum, int columnNum) {
 		}
 	}
 
-	delete columntprs;
+	delete[] columntprs;
 	columntprs = new float[columnnum + 1];
 	columntprs[0] = 0.0f;
 	columntprs[columnnum] = 1.0f;
@@ -147,13 +184,18 @@ int gGUISizer::getColumnNum() {
 }
 
 void gGUISizer::setLineProportions(float* proportions) {
-	delete lineprs;
-	lineprs = new float[linenum];
+	// Filled before the old array is released, because the source can be that very
+	// array: a sizer with space lines re-proportions itself by calling
+	// setLineProportions(lineprs) from windowResized(). Releasing first would leave
+	// the loop reading freed memory.
+	float* newlineprs = new float[linenum];
 	for(int i = 0; i < linenum; i++) {
-		lineprs[i] = proportions[i];
+		newlineprs[i] = proportions[i];
 	}
+	delete[] lineprs;
+	lineprs = newlineprs;
 
-	delete linetprs;
+	delete[] linetprs;
 	linetprs = new float[linenum + 1];
 	linetprs[0] = 0.0f;
 	linetprs[linenum] = 1.0f;
@@ -166,13 +208,15 @@ void gGUISizer::setLineProportions(float* proportions) {
 }
 
 void gGUISizer::setColumnProportions(float* proportions) {
-	delete columnprs;
-	columnprs = new float[columnnum];
+	// Same aliasing as setLineProportions above: copy first, release after.
+	float* newcolumnprs = new float[columnnum];
 	for(int i = 0; i < columnnum; i++) {
-		columnprs[i] = proportions[i];
+		newcolumnprs[i] = proportions[i];
 	}
+	delete[] columnprs;
+	columnprs = newcolumnprs;
 
-	delete columntprs;
+	delete[] columntprs;
 	columntprs = new float[columnnum + 1];
 	columntprs[0] = 0.0f;
 	columntprs[columnnum] = 1.0f;
@@ -193,7 +237,13 @@ void gGUISizer::setControl(int line, int column, gGUIControl* control) {
 	Entry& entry = guicontrols[indexOf(line, column)];
 	entry.control = control;
 	entry.isset = true;
+#if GLIST_ANDROID || GLIST_IOS
+	// The new control can change what its row needs, and that moves every row
+	// after it, so the whole sizer is laid out again rather than just this slot.
+	reloadControls();
+#else
 	reloadControl(*control, line, column);
+#endif
 }
 
 void gGUISizer::removeControl(int line, int column) {
@@ -216,7 +266,7 @@ int gGUISizer::getCursor(int x, int y) {
 			}
 		}
 		for(int i = 1; i < linenum; i++) {
-			if(y >= top + (height * linetprs[i]) - 1 && y <= top + (height * linetprs[i]) + 1) {
+			if(y >= top + getRowTop(i) - 1 && y <= top + getRowTop(i) + 1) {
 				return CURSOR_VRESIZE;
 			}
 		}
@@ -225,7 +275,8 @@ int gGUISizer::getCursor(int x, int y) {
 	int column = -1;
 	int line = -1;
 	for(int i = 1; i < linenum + 1; i++) {
-		if(y < top + (height * linetprs[i])) {
+		int rowbottom = i < linenum ? getRowTop(i) : getRowTop(i - 1) + getRowHeight(i - 1);
+		if(y < top + rowbottom) {
 			line = i - 1;
 			break;
 		}
@@ -348,8 +399,129 @@ void gGUISizer::checkSpaces() {
 	}
 }
 
+#if GLIST_ANDROID || GLIST_IOS
+void gGUISizer::setReferenceHeight(int referenceHeight) {
+	if(referenceheight == referenceHeight) return;
+	referenceheight = referenceHeight;
+	reloadControls();
+}
+
+int gGUISizer::getRowNaturalHeight(int lineNo) {
+	int designheight = (int)((float)referenceheight * lineprs[lineNo]);
+	int naturalheight = 0;
+	bool hascontrol = false;
+	for(int column = 0; column < columnnum; column++) {
+		gGUIControl* control = getControl(lineNo, column);
+		if(!control) continue;
+		hascontrol = true;
+		// Anything with a layout of its own is measured against the share of the
+		// reference this row would have had, so the floors keep meaning the same
+		// thing all the way down the tree instead of collapsing one level in.
+		control->setReferenceHeight(designheight);
+		int controlheight = control->getNaturalHeight();
+		if(controlheight > naturalheight) naturalheight = controlheight;
+	}
+	// Both insets, since the row now carries one above its control and one below.
+	if(naturalheight > 0) naturalheight += slotheightpadding * 2;
+	// Every row keeps at least the share the reference gives it, whether or not
+	// anything in it has an opinion. Without this floor a row holding something
+	// that does not measure itself is starved the moment the page grows: the rows
+	// that do measure themselves take the whole of the new height between them and
+	// leave nothing over.
+	if(designheight > naturalheight) naturalheight = designheight;
+	// And a row that holds anything at all is never shorter than the padding it
+	// carries. A page with enough rows can drive the reference share below that,
+	// and the slot would then be handed a negative height.
+	if(hascontrol && naturalheight < slotheightpadding * 2) naturalheight = slotheightpadding * 2;
+	return naturalheight;
+}
+
+int gGUISizer::getNaturalHeight() {
+	int naturalheight = 0;
+	for(int line = 0; line < linenum; line++) naturalheight += getRowNaturalHeight(line);
+	return naturalheight;
+}
+
+void gGUISizer::computeRowHeights() {
+	rowheights.assign(linenum, 0);
+	rowtops.assign(linenum, 0);
+	if(linenum <= 0) return;
+
+	std::vector<int> minimums(linenum, 0);
+	std::vector<bool> ispinned(linenum, false);
+	for(int line = 0; line < linenum; line++) minimums[line] = getRowNaturalHeight(line);
+
+	// A row whose proportional share is too small for its content is pinned to
+	// what it needs; the rest share out what is left, in their own proportions.
+	// Pinning shrinks the pool, which can push another row below its own minimum,
+	// so this repeats until a pass pins nothing new. At most linenum passes, since
+	// every pass that changes anything pins at least one row.
+	int remaining = height;
+	float flexweight = 0.0f;
+	for(int line = 0; line < linenum; line++) flexweight += lineprs[line];
+	bool ispinnednew = true;
+	while(ispinnednew) {
+		ispinnednew = false;
+		for(int line = 0; line < linenum; line++) {
+			if(ispinned[line] || minimums[line] <= 0) continue;
+			float share = flexweight > 0.0f ? (float)remaining * (lineprs[line] / flexweight) : 0.0f;
+			// The tolerance matters: at the design height a row's share and its
+			// floor are the same number arrived at by two different roundings, and
+			// without it they would disagree by a unit and pin the whole page onto
+			// the slower path for no reason.
+			if(share >= (float)minimums[line] - 1.0f) continue;
+			ispinned[line] = true;
+			rowheights[line] = minimums[line];
+			remaining -= minimums[line];
+			flexweight -= lineprs[line];
+			ispinnednew = true;
+		}
+	}
+	// Nothing needed pinning, so the old proportional formula is used verbatim
+	// rather than merely reproduced. That makes the ordinary case - which is
+	// almost every page - not approximately unchanged but bit for bit identical.
+	bool isanyrowpinned = false;
+	for(int line = 0; line < linenum; line++) {
+		if(ispinned[line]) isanyrowpinned = true;
+	}
+	if(!isanyrowpinned) {
+		for(int line = 0; line < linenum; line++) {
+			rowtops[line] = (int)((float)height * linetprs[line]);
+			rowheights[line] = (int)((float)height * (linetprs[line + 1] - linetprs[line]));
+		}
+		return;
+	}
+
+	// Everything asked for more than there is. The rows keep their minimums and
+	// the sizer overflows its box, which is the honest outcome: whoever sized it
+	// was told the real natural height and chose not to give it.
+	if(remaining < 0) remaining = 0;
+	// The flexible rows are measured from a running total rather than one by one,
+	// so that truncating each row does not quietly lose a unit per row - nine rows
+	// were losing nine units of the page that way.
+	float cumulative = 0.0f;
+	int used = 0;
+	for(int line = 0; line < linenum; line++) {
+		if(ispinned[line]) continue;
+		cumulative += lineprs[line];
+		int end = flexweight > 0.0f ? (int)((float)remaining * (cumulative / flexweight)) : 0;
+		rowheights[line] = end - used;
+		used = end;
+	}
+
+	int rowtop = 0;
+	for(int line = 0; line < linenum; line++) {
+		rowtops[line] = rowtop;
+		rowtop += rowheights[line];
+	}
+}
+#endif
+
 void gGUISizer::reloadControls() {
 	if(oldwidth != width || oldheight != height) checkSpaces();
+#if GLIST_ANDROID || GLIST_IOS
+	computeRowHeights();
+#endif
 	for (int line = 0; line < linenum; line++) {
 		for (int column = 0; column < columnnum; column++) {
 			gGUIControl* control = getControl(line, column);
@@ -368,9 +540,25 @@ void gGUISizer::reloadControl(gGUIControl& control) {
 
 void gGUISizer::reloadControl(gGUIControl& control, int line, int column) {
 	int x = left + (width * columntprs[column]) + slotpadding;
-	int y = top + (height * linetprs[line]) + slotheightpadding;
 	int w = width * (columntprs[column + 1] - columntprs[column]) - slotpadding * 2;
-	int h = height * (linetprs[line + 1] - linetprs[line]) - slotheightpadding;
+	// Rows are measured rather than merely divided, so that a row holding
+	// something with a size of its own is not squeezed below it. On desktop the
+	// helpers return the old proportional figures unchanged.
+	int y = top + getRowTop(line) + slotheightpadding;
+#if GLIST_ANDROID || GLIST_IOS
+	// Twice, matching the horizontal padding: a slot is inset by the same amount
+	// top and bottom as it is left and right. Subtracting it once left the control
+	// flush with the bottom of its row, so one number produced a visible gap
+	// sideways and half of one downwards.
+	int h = getRowHeight(line) - slotheightpadding * 2;
+#else
+	int h = getRowHeight(line) - slotheightpadding;
+#endif
+	// A slot narrower or shorter than its own padding would otherwise be handed a
+	// negative size, which controls treat as an enormous unsigned one when they
+	// come to allocate or index against it.
+	if(w < 0) w = 0;
+	if(h < 0) h = 0;
 	if (alignvertically) {
 		int contentheight = control.calculateContentHeight();
 		if (contentheight > 0) {
@@ -435,7 +623,7 @@ void gGUISizer::draw() {
 			if(fillbackground) {
 				gColor oldcolor = *renderer->getColor();
 				renderer->setColor(backgroundcolor);
-				gDrawRectangle(left + (width * columntprs[column]), top + (height * linetprs[line]), width * columnprs[column], height * lineprs[line], true);
+				gDrawRectangle(left + (width * columntprs[column]), top + getRowTop(line), width * columnprs[column], getRowHeight(line), true);
 				renderer->setColor(&oldcolor);
 			}
 
@@ -462,7 +650,7 @@ void gGUISizer::draw() {
 				float lc = foregroundcolor->r - (std::fabs(k - 1) * 0.05f);
 
 				renderer->setColor(gColor(lc, lc, lc));
-				int t = top + (height * linetprs[i]) + k - 1;
+				int t = top + getRowTop(i) + k - 1;
 				gDrawLine(left, t, right, t);
 			}
 		}

--- a/engine/ui/gGUISizer.h
+++ b/engine/ui/gGUISizer.h
@@ -10,6 +10,8 @@
 
 #include "gGUIControl.h"
 
+#include <vector>
+
 
 class gGUISizer: public gGUIControl {
 public:
@@ -55,12 +57,53 @@ public:
 	void mouseEntered();
 	void mouseExited();
 	void windowResized(int w, int h);
+	/*
+	 * Where a row starts relative to the sizer's top, and how tall it is.
+	 *
+	 * The single answer to "where is row n", used by the slot geometry, the
+	 * borders, the background fill and the cursor test alike. They each used to
+	 * work the proportions out for themselves, which was fine while that was the
+	 * only way rows were laid out - once rows could be measured instead, the
+	 * copies disagreed with the controls and the borders were drawn across them.
+	 */
+	int getRowTop(int lineNo);
+	int getRowHeight(int lineNo);
+
 	int getSlotWidth(int lineNo, int columnNo);
 	int getSlotHeight(int lineNo, int columnNo);
 	int getSlotX(int lineNo, int columnNo);
 	int getSlotY(int lineNo, int columnNo);
 
 	bool isControlSet(int lineNo, int columnNo);
+
+#if GLIST_ANDROID || GLIST_IOS
+	/*
+	 * The sum of what every row needs for its content, which is how tall this
+	 * sizer has to be for nothing in it to be squashed. 0 when nothing inside has
+	 * an opinion, which is the usual case.
+	 *
+	 * Recursive: a sizer inside a slot answers for its own rows too.
+	 */
+	int getNaturalHeight() override;
+
+	// What one row needs: the tallest opinion among its columns, but never less
+	// than the share the reference height gives it.
+	int getRowNaturalHeight(int lineNo);
+
+	/*
+	 * The height this sizer would have if nothing in it needed extra room - the
+	 * one the page was designed for, or the screen if that is taller.
+	 *
+	 * Told rather than learned. An earlier version had the sizer remember the
+	 * first height it was ever given, which went wrong in both directions: the
+	 * first height arrived before the controls did, so it was measured short and
+	 * the rows then overran their box; and once learned it never changed, so a
+	 * rotation kept using the old orientation's figure. Being given the number
+	 * makes it exact and makes it follow the rotation.
+	 */
+	void setReferenceHeight(int referenceHeight) override;
+	int getReferenceHeight() const { return referenceheight; }
+#endif
 
 private:
 	struct Entry {
@@ -83,6 +126,21 @@ private:
 	int slotpadding;
 	int slotheightpadding;
 	bool alignvertically;
+
+#if GLIST_ANDROID || GLIST_IOS
+	// Where each row starts and how tall it is, in units, relative to the sizer's
+	// own top. Rebuilt by computeRowHeights() whenever the slots are reloaded.
+	// Only mobile lays rows out this way; the desktop path keeps using the
+	// proportions directly and is not compiled with any of this.
+	std::vector<int> rowtops;
+	std::vector<int> rowheights;
+	// Row floors are taken from this rather than from the current height, so that
+	// growing the page cannot grow the floors and feed itself. See
+	// setReferenceHeight().
+	int referenceheight;
+
+	void computeRowHeights();
+#endif
 
 private:
 	int detectSizerType();

--- a/engine/ui/gGUISlider.cpp
+++ b/engine/ui/gGUISlider.cpp
@@ -195,6 +195,17 @@ void gGUISlider::update() {
     }
 }
 
+#if GLIST_ANDROID || GLIST_IOS
+int gGUISlider::getNaturalHeight() {
+	// The bar itself, plus room below for the tick numbers when they are shown.
+	// The current-value label is drawn above the top and falls into the slot's
+	// top padding, so it needs no room of its own here.
+	int naturalheight = sliderh;
+	if(istickvisible) naturalheight += (int)font->getSize() + 4;
+	return naturalheight;
+}
+#endif
+
 void gGUISlider::draw() {
 	gColor oldcolor = renderer->getColor();
 	if(isdisabled) renderer->setColor(&disabledcolor);

--- a/engine/ui/gGUISlider.h
+++ b/engine/ui/gGUISlider.h
@@ -56,6 +56,9 @@ public:
 
 	void update();
 	void draw();
+#if GLIST_ANDROID || GLIST_IOS
+	int getNaturalHeight() override;
+#endif
 	void mousePressed(int x, int y, int button);
 	void mouseReleased(int x, int y, int button);
 	void mouseDragged(int x, int y, int button);

--- a/engine/ui/gGUISwitchButton.cpp
+++ b/engine/ui/gGUISwitchButton.cpp
@@ -20,6 +20,12 @@ gGUISwitchButton::~gGUISwitchButton() {
 
 }
 
+#if GLIST_ANDROID || GLIST_IOS
+int gGUISwitchButton::getNaturalHeight() {
+	return toggleh;
+}
+#endif
+
 void gGUISwitchButton::draw() {
 	gColor oldcolor = renderer->getColor();
 	renderer->setColor(middlegroundcolor);

--- a/engine/ui/gGUISwitchButton.h
+++ b/engine/ui/gGUISwitchButton.h
@@ -52,6 +52,9 @@ public:
 	virtual ~gGUISwitchButton();
 
 	void draw();
+#if GLIST_ANDROID || GLIST_IOS
+	int getNaturalHeight() override;
+#endif
 	void mousePressed(int x, int y, int button);
 
 	/**

--- a/engine/ui/gGUIText.cpp
+++ b/engine/ui/gGUIText.cpp
@@ -208,3 +208,10 @@ std::vector<std::string> gGUIText::splitString(const std::string& textToSplit, g
 void gGUIText::setDisabled(bool isDisabled) {
 	isdisabled = isDisabled;
 }
+
+#if GLIST_ANDROID || GLIST_IOS
+int gGUIText::getNaturalHeight() {
+	if(line.empty()) return 0;
+	return (int)line.size() * lineh;
+}
+#endif

--- a/engine/ui/gGUIText.h
+++ b/engine/ui/gGUIText.h
@@ -24,6 +24,13 @@ public:
 
     void setText(std::string text);
 
+#if GLIST_ANDROID || GLIST_IOS
+    // As many lines as the text was wrapped into, at the line height in use. The
+    // wrap depends on the width, which the layout settles before it asks about
+    // height, so this is answered against the width already assigned.
+    int getNaturalHeight() override;
+#endif
+
     std::string getText();
 
     void setTextAlignment(int textAligment);

--- a/engine/ui/gGUITextbox.cpp
+++ b/engine/ui/gGUITextbox.cpp
@@ -337,6 +337,19 @@ bool gGUITextbox::isBackgroundEnabled() {
 	return isbackgroundenabled;
 }
 
+#if GLIST_ANDROID || GLIST_IOS
+int gGUITextbox::getNaturalHeight() {
+	// Room for one line and its caret. The caret is drawn about 5/3 of a line tall
+	// (linebottom - lineheight up to linebottom + lineheight*2/3) and the box is
+	// inset from the top, so a single line height leaves the caret spilling out the
+	// bottom and the field looking too short for it. Two line heights plus the top
+	// and bottom margins hold the caret with room to spare. Measured from the font,
+	// never from height: set() overwrites boxh with the slot height, so reading
+	// that here would feed the layout its own previous answer and ratchet.
+	return lineheight * 2 + linetopmargin * 2;
+}
+#endif
+
 void gGUITextbox::draw() {
 	gColor oldcolor = *renderer->getColor();
 	if(isbackgroundenabled) {
@@ -1455,6 +1468,10 @@ void gGUITextbox::mouseReleased(int x, int y, int button) {
 		return;
 	}
 	selectionmode = false;
+#if GLIST_ANDROID || GLIST_IOS
+	// Leaving the box drops edit focus, so the keyboard comes down with it.
+	if(editmode && appmanager && appmanager->getWindow()) appmanager->getWindow()->hideKeyboard();
+#endif
 	editmode = false;
 	isdragging = false;
 }
@@ -1482,7 +1499,14 @@ void gGUITextbox::mouseDragged(int x, int y, int button) {
 }
 
 std::vector<int> gGUITextbox::clickTextbox(int x, int y) {
-	if(!editmode) cursorshowcounter = 0;
+	if(!editmode) {
+		cursorshowcounter = 0;
+#if GLIST_ANDROID || GLIST_IOS
+		// Gaining edit focus raises the soft keyboard, so what the caret invites can
+		// actually be typed. On the false->true transition only, so it is asked once.
+		if(appmanager && appmanager->getWindow()) appmanager->getWindow()->showKeyboard();
+#endif
+	}
 	editmode = true;
 
 	if(!ismultiline) {
@@ -1886,6 +1910,14 @@ void gGUITextbox::setDisabled(bool isDisabled) {
 }
 
 void gGUITextbox::setEditMode(bool editMode) {
+#if GLIST_ANDROID || GLIST_IOS
+	// Keep the soft keyboard in step when edit focus is set programmatically, on
+	// the transition only.
+	if(editMode != editmode && appmanager && appmanager->getWindow()) {
+		if(editMode) appmanager->getWindow()->showKeyboard();
+		else appmanager->getWindow()->hideKeyboard();
+	}
+#endif
 	editmode = editMode;
 }
 

--- a/engine/ui/gGUITextbox.cpp
+++ b/engine/ui/gGUITextbox.cpp
@@ -620,8 +620,10 @@ void gGUITextbox::pressKey() {
 						firstchar -= calculateCharNum(deletedtext);
 						int oldutf = firstutf;
 						for(int i = 0; i < deletedtext.length(); i++) {
+							if(sepc1 + i >= (int)letterlength.size()) break;
 							firstutf -= letterlength[sepc1 + i];
 						}
+						if(firstutf < 0) firstutf = 0;
 						if(firstchar < 0) {
 							firstchar = 0;
 							firstutf = 0;
@@ -656,9 +658,13 @@ void gGUITextbox::pressKey() {
 			}
 			else {
 				cursorposx -= cw;
-					if(firstutf > 0 && !ismultiline) {
+					// firstchar/firstutf can be at the very start or past the last
+					// letter after the erase above; indexing letterlength blindly
+					// aborted under the hardened libc++ bounds checks on iOS.
+					if(firstutf > 0 && firstchar > 0 && !ismultiline) {
 						int icw = textfont->getStringWidth(text.substr(firstutf - 1, letterlength[firstchar - 1]));
-						firstutf -= letterlength[firstchar];
+						firstutf -= letterlength[firstchar < (int)letterlength.size() ? firstchar : firstchar - 1];
+						if(firstutf < 0) firstutf = 0;
 						firstposx = textfont->getStringWidth(text.substr(0, firstutf));
 						firstchar--;
 						cursorposx += icw;
@@ -670,9 +676,12 @@ void gGUITextbox::pressKey() {
 			cursorposchar--;
 			if(cursorposx < 0) {
 				if(!ismultiline && !ispassword) {
-					firstutf -= letterlength[firstchar];
+					if(firstchar >= 0 && firstchar < (int)letterlength.size()) {
+						firstutf -= letterlength[firstchar];
+						if(firstutf < 0) firstutf = 0;
+					}
 					firstposx = textfont->getStringWidth(text.substr(0, firstutf));
-					firstchar--;
+					if(firstchar > 0) firstchar--;
 					cursorposx = 0;
 					lastutf = calculateLastUtf();
 				} else if(ismultiline){

--- a/engine/ui/gGUITextbox.h
+++ b/engine/ui/gGUITextbox.h
@@ -190,6 +190,9 @@ public:
 
 	void update();
 	void draw();
+#if GLIST_ANDROID || GLIST_IOS
+	int getNaturalHeight() override;
+#endif
 
 	void keyPressed(int key);
 	void keyReleased(int key);

--- a/engine/ui/gGUITimebox.cpp
+++ b/engine/ui/gGUITimebox.cpp
@@ -13,7 +13,15 @@
 
 gGUITimebox::gGUITimebox() {
 	//Boxes starting and finishing coordination
+#if GLIST_ANDROID || GLIST_IOS
+	// Widen the frame on mobile: at 170 the three digit boxes plus the colons and
+	// the up/down button do not fit, so two-digit values render clipped. Everything
+	// the control draws (button, triangles, sizer width) is derived from timeboxw,
+	// so a wider value scales the whole layout consistently.
+	timeboxw = 260;
+#else
 	timeboxw = 170;
+#endif
 	timeboxh = 60;
 	buttoncoverw = 25;
 	buttoncoverh = 30;
@@ -54,13 +62,44 @@ gGUITimebox::gGUITimebox() {
 	columno = 6;
 	timeboxsizer.setSize(lineno, columno);
 	float lineprops[] = {0.27f, 0.25f, 0.2f};
-	float columnprops[] = {0.040f,0.1f, 0.1f,0.1f,0.025f};
+	// One proportion per column: setSize(lineno, columno) made columno=6, so the
+	// array has to hold 6 entries. It previously had 5, and setColumnProportions
+	// copies columno of them - reading one past the end (undefined behaviour). The
+	// trailing column takes the remaining width.
+#if GLIST_ANDROID || GLIST_IOS
+	// On mobile the inner sizer is constrained to timeboxw, so the desktop's
+	// 0.1-width digit columns come out too narrow for a two-digit value and the
+	// hour/minute/second render clipped to a single digit. Widen the three digit
+	// columns to ~0.18 (about 47px at timeboxw 260) so "00".."59" always fit with
+	// margin, and leave the right ~43% for the up/down button. The colon separators
+	// are positioned from the resulting box geometry in draw().
+	float columnprops[] = {0.02f, 0.18f, 0.18f, 0.18f, 0.01f, 0.43f};
+#else
+	float columnprops[] = {0.040f, 0.1f, 0.1f, 0.1f, 0.025f, 0.635f};
+#endif
 	timeboxsizer.setColumnProportions(columnprops);
 	timeboxsizer.setLineProportions(lineprops);
 	timeboxsizer.enableBorders(false);
+#if GLIST_ANDROID || GLIST_IOS
+	// Tight internal packing, not the page's 24 unit finger gap: the hour, minute
+	// and second boxes have to line up inside the frame this control draws around
+	// them (left + 5, top + 10, timeboxw x timeboxh). At 24 they are pushed out of
+	// that frame and off the up/down triangles. See the same note in gGUINumberBox.
+	timeboxsizer.setSlotPadding(2, 0);
+#endif
 	hourbox.setNumeric(true);
 	minutebox.setNumeric(true);
 	secondbox.setNumeric(true);
+#if GLIST_ANDROID || GLIST_IOS
+	// On mobile the time is set with the up/down triangles this control draws, not by
+	// typing. Leaving the three inner digit boxes editable meant one tap put all three
+	// nested textboxes into edit mode at once and each asked for the soft keyboard -
+	// the wrong interaction, and the source of the crash / voice-input menu seen on
+	// device. Make the digits display-only; the triangles still change the values.
+	hourbox.setEditable(false);
+	minutebox.setEditable(false);
+	secondbox.setEditable(false);
+#endif
 	timeboxsizer.setControl(1, 1, &hourbox);
 	timeboxsizer.setControl(1, 2, &minutebox);
 	timeboxsizer.setControl(1, 3, &secondbox);
@@ -75,7 +114,26 @@ void gGUITimebox::set(gBaseApp* root, gBaseGUIObject* topParentGUIObject, gBaseG
 	totalh = h;
 	gGUIScrollable::set(root, topParentGUIObject, parentGUIObject, parentSlotLineNo, parentSlotColumnNo, x, y, w, h);
 	gGUIScrollable::setDimensions(w, h);
+#if GLIST_ANDROID || GLIST_IOS
+	// The frame (draw: left + 5, top + 10, timeboxw x timeboxh) and the colon
+	// separators are laid out for a timeboxw-wide control. Handing the inner sizer
+	// the full slot width - which on a page is the whole screen - spreads the hour,
+	// minute and second boxes across it, far from the frame drawn around them.
+	// Constrain the sizer to the frame's width so the boxes stay inside it.
+	guisizer->set(root, topParentGUIObject, parentGUIObject, parentSlotLineNo, parentSlotColumnNo, x, y + topbarh, timeboxw, h - topbarh);
+#else
 	guisizer->set(root, topParentGUIObject, parentGUIObject, parentSlotLineNo, parentSlotColumnNo, x, y + topbarh, w, h - topbarh);
+#endif
+#if GLIST_ANDROID || GLIST_IOS
+	// Show the starting time. Done here, after the inner textboxes are positioned by
+	// the sizer above - setText recomputes letter positions, so it must run on a box
+	// that is already set(), not from the constructor. Mobile only: on desktop the
+	// digit boxes are typed into directly, and rewriting them on every relayout
+	// would overwrite what the user typed with the triangle-tracked values.
+	hourbox.setText(gToStr(hour));
+	minutebox.setText(gToStr(minute));
+	secondbox.setText(gToStr(second));
+#endif
 }
 
 void gGUITimebox::set(int x, int y, int w, int h) {
@@ -85,7 +143,11 @@ void gGUITimebox::set(int x, int y, int w, int h) {
 	bottom = y + h;
 	width = w;
 	height = h;
+#if GLIST_ANDROID || GLIST_IOS
+	guisizer->set(x, y + topbarh, timeboxw, h - topbarh);
+#else
 	guisizer->set(x, y + topbarh, w, h - topbarh);
+#endif
 }
 
 void gGUITimebox::keyPressed(int key) {
@@ -113,19 +175,34 @@ void gGUITimebox::mousePressed(int x, int y, int button) {
 	secondbox.mousePressed(x, y, button);
 	if(isdisabled) return;
 
-	if(x >= left + 20 && x < left + 50 && y >= top + buttoncovery && y < top + buttoncovery + 25){
+	// Tapping a digit field selects which of hour/minute/second the up/down triangles
+	// act on. The x ranges below have to line up with where the boxes are actually
+	// drawn; on mobile that is the widened timeboxw layout (hour ~[5,41],
+	// minute ~[41,78], second ~[78,115]), and the whole box height is tappable.
+#if GLIST_ANDROID || GLIST_IOS
+	int selhourl = left + 5,   selhourr = left + 41;
+	int selminl  = left + 41,  selminr  = left + 78;
+	int selsecl  = left + 78,  selsecr  = left + 115;
+	int seltop = top,          selbot   = top + timeboxh;
+#else
+	int selhourl = left + 20,  selhourr = left + 50;
+	int selminl  = left + 60,  selminr  = left + 90;
+	int selsecl  = left + 100, selsecr  = left + 130;
+	int seltop = top + buttoncovery, selbot = top + buttoncovery + 25;
+#endif
+	if(x >= selhourl && x < selhourr && y >= seltop && y < selbot){
 		ishour = true;
 		isminute = false;
 		issecond = false;
 	}
 
-	if(x >= left + 60 && x < left + 90 && y >= top + buttoncovery && y < top + buttoncovery + 25){
+	if(x >= selminl && x < selminr && y >= seltop && y < selbot){
 		ishour = false;
 		isminute = true;
 		issecond = false;
 	}
 
-	if(x >= left + 100 && x < left + 130 && y >= top + buttoncovery && y < top + buttoncovery + 25){
+	if(x >= selsecl && x < selsecr && y >= seltop && y < selbot){
 		ishour = false;
 		isminute = false;
 		issecond = true;
@@ -181,7 +258,17 @@ void gGUITimebox::mouseReleased(int x, int y, int button) {
 	minutebox.mouseReleased(x, y, button);
 	secondbox.mouseReleased(x, y, button);
 	if(isdisabled) return;
-	if(x >= timeboxw / 2 - 14 && x < left + 12 && y >= top + 9 && y < top + 12) {
+#if GLIST_ANDROID || GLIST_IOS
+	// The desktop condition below can never be true with the mobile timeboxw: it
+	// needs x to be both >= timeboxw/2 - 14 (116) and < left + 12, so the release
+	// branch - and with it the G_GUIEVENT_BUTTONRELEASED notification - never ran.
+	// Test the area the up/down button is actually drawn in.
+	bool releasedonbutton = x >= left + timeboxw - buttoncoverw - 6 && x < left + timeboxw - 6
+			&& y >= top + buttoncovery && y < top + buttoncovery + buttoncoverh;
+#else
+	bool releasedonbutton = x >= timeboxw / 2 - 14 && x < left + 12 && y >= top + 9 && y < top + 12;
+#endif
+	if(releasedonbutton) {
 		if(!istoggle) {
 			ispressedb1 = false;
 			ispressedb2 = false;
@@ -214,6 +301,12 @@ void gGUITimebox::update() {
 	secondbox.update();
 }
 
+#if GLIST_ANDROID || GLIST_IOS
+int gGUITimebox::getNaturalHeight() {
+	return timeboxh;
+}
+#endif
+
 void gGUITimebox::draw() {
 	gColor oldcolor = renderer->getColor();
 	renderer->setColor(middlegroundcolor);
@@ -238,10 +331,21 @@ void gGUITimebox::draw() {
 		}
 	}
 	renderer->setColor(fontcolor);
+#if !(GLIST_ANDROID || GLIST_IOS)
 	font->drawText(":", 51.2, 69);
 	font->drawText(":", 89, 69);
+#endif
 	font->drawText(title, left + 2, top + 5);
 	if(guisizer) guisizer->draw();
+#if GLIST_ANDROID || GLIST_IOS
+	// Colons are placed from the actual box geometry, so they stay in the gaps
+	// whatever the mobile column widths work out to, and drawn after the sizer so the
+	// opaque digit boxes never paint over them. Vertically centred on the digit row.
+	renderer->setColor(fontcolor);
+	int coy = hourbox.top + hourbox.height / 2 + (int)(font->getSize() / 2);
+	font->drawText(":", (hourbox.right + minutebox.left) / 2 - 2, coy);
+	font->drawText(":", (minutebox.right + secondbox.left) / 2 - 2, coy);
+#endif
 	renderer->setColor(oldcolor);
 }
 

--- a/engine/ui/gGUITimebox.h
+++ b/engine/ui/gGUITimebox.h
@@ -21,6 +21,9 @@ public:
 	void set(int x, int y, int w, int h);
 
 	void draw();
+#if GLIST_ANDROID || GLIST_IOS
+	int getNaturalHeight() override;
+#endif
 	void update();
 
 	void keyPressed(int key);

--- a/engine/ui/gGUITreelist.cpp
+++ b/engine/ui/gGUITreelist.cpp
@@ -156,7 +156,11 @@ void gGUITreelist::mouseReleased(int x, int y, int button) {
 	if(mousepressedonlist) mousepressedonlist = false;
 	if(x >= left && x < left + boxw && y >= top + titleheight && y < top + titleheight + boxh) {
 		int newselectedno = (y - top - titleheight + verticalscroll) / lineh;
-		if(newselectedno <= allsubtitles.size() - 1) selectedno = newselectedno;
+		// Compared as a signed count. Against size() - 1 an empty list wraps to the
+		// largest unsigned value, every index passes, and the read below is out of
+		// bounds - and the read happens whether or not the test passed.
+		if(newselectedno >= 0 && newselectedno < (int)allsubtitles.size()) selectedno = newselectedno;
+		if(selectedno < 0 || selectedno >= (int)allsubtitles.size()) return;
 		tmptitle = allsubtitles[selectedno];
 
 		if(topelement.isicon == false) { // Process which using default symbols '>' and '-'

--- a/engine/utils/gThread.cpp
+++ b/engine/utils/gThread.cpp
@@ -89,6 +89,13 @@ void gThread::detach() {
 
 void gThread::sleep(std::chrono::duration<double, std::milli> milliseconds) {
 	starttime = std::chrono::high_resolution_clock::now();
+	// Busy-waiting the whole interval pinned a core for every sleeping thread.
+	// The bulk of the wait is a real sleep; only the last stretch is spun, so
+	// the wake-up precision the frame pacing relies on is kept.
+	constexpr std::chrono::duration<double, std::milli> spinwindow{2.0};
+	if(milliseconds > spinwindow) {
+		std::this_thread::sleep_for(milliseconds - spinwindow);
+	}
 	while(true) {
 		timediff = std::chrono::high_resolution_clock::now() - starttime;
 		if(timediff >= milliseconds) break;


### PR DESCRIPTION
All mobile behaviour is gated behind GLIST_ANDROID || GLIST_IOS; desktop
rendering and input paths are byte-identical to before.

Layout & rendering:
- Fixed layout scale on mobile: the design-time unit size is captured once
  and rotations resize the visible band instead of restretching controls
  (gAppManager, gRenderer unit viewport / scroll projection).
- Pages taller than the screen scroll with touch: drag, fling with decay,
  overscroll bounce and a fading scroll indicator (gAppManager).
- gGUISizer insets slots with a finger-sized padding on mobile and supports
  content-driven row heights via gGUIControl::getNaturalHeight(), implemented
  by button, text, textbox, listbox, slider, switch, progress bar, number box,
  dropdown, date and timebox controls.
- gGUIScrollable renders its content through an FBO sized to the visible band
  so nested scrolling controls (listbox, notebook) stay correct on a page.
- gTexture shares the renderer's 2D projection so images scroll with the page.

Input:
- Touch events are translated by the page scroll before hitting controls
  (gGUIManager) and GUI mutation is queued to the render thread.
- gBaseWindow gains showKeyboard()/hideKeyboard() virtuals; gGUITextbox raises
  and dismisses the platform soft keyboard on edit-mode transitions.
- Char/key events are queued to the GUI thread on mobile, mirroring the touch
  path, so soft-keyboard input does not race drawing (gAppManager).

Control fixes found along the way:
- gGUITimebox: out-of-bounds column proportions array (5 entries for 6
  columns), digit fields too narrow for two digits, colons pinned to absolute
  screen coordinates, an unsatisfiable mouseReleased hit test, and a crash on
  mobile from three nested textboxes requesting the keyboard at once (digit
  fields are display-only on mobile; the up/down triangles drive the value).
- gGUIListbox / gGUITreelist: signed/unsigned comparison let negative or
  out-of-range row indices through on empty lists.
- Touch action index is clamped against the input count before indexing.
- Scroll indicator guards against zero unit sizes; sizer proportion arrays are
  copied before the old ones are freed.