### PR TITLE
Fix/guiapp rotation and touch

### DIFF
--- a/engine/base/gBaseCanvas.cpp
+++ b/engine/base/gBaseCanvas.cpp
@@ -268,6 +268,10 @@ void gBaseCanvas::enableAlphaBlending() {
 	renderer->enableAlphaBlending();
 }
 
+void gBaseCanvas::enableAdditiveBlending() {
+	renderer->enableAdditiveBlending();
+}
+
 void gBaseCanvas::disableAlphaBlending() {
 	renderer->disableAlphaBlending();
 }

--- a/engine/base/gBaseCanvas.h
+++ b/engine/base/gBaseCanvas.h
@@ -98,6 +98,7 @@ protected:
 	int getDepthTestType();
 
 	void enableAlphaBlending();
+	void enableAdditiveBlending();
 	void disableAlphaBlending();
 	void enableAlphaTest();
 	void disableAlphaTest();

--- a/engine/core/gAppManager.cpp
+++ b/engine/core/gAppManager.cpp
@@ -200,10 +200,10 @@ void gAppManager::initialize() {
 		// Update size
 		width = window->getWidth();
 		height = window->getHeight();
-		if(unitwidth == 0) {
+		if(unitwidth == 0 || isguiapp) {
 			unitwidth = this->width;
 		}
-		if(unitheight == 0) {
+		if(unitheight == 0 || isguiapp) {
 			unitheight = this->height;
 		}
 		// Create renderer
@@ -369,14 +369,18 @@ void gAppManager::setScreenSize(int width, int height) {
 	G_PROFILE_ZONE_VALUE(height);
 	if(screenscaling == G_SCREENSCALING_AUTO_ONCE) {
 		// We don't want to update the unitresolution, that's why its setting directly. gAppManager needs to be a friend of gRenderer to do this.
-		renderer->unitwidth = renderer->scaleX(width);
-		renderer->unitheight = renderer->scaleY(height);
+		if(isguiapp) {
+			renderer->setUnitScreenSize(width, height);
+		} else {
+			renderer->unitwidth = renderer->scaleX(width);
+			renderer->unitheight = renderer->scaleY(height);
+		}
 	}
 	renderer->setScreenSize(width, height);
     if(iscanvasset && canvasmanager->getCurrentCanvas()) {
 	    canvasmanager->getCurrentCanvas()->windowResized(renderer->getWidth(), renderer->getHeight());
     }
-    if(iscanvasset && guimanager->isframeset) {
+    if(guimanager && guimanager->isframeset) {
 	    guimanager->windowResized(renderer->getWidth(), renderer->getHeight());
     }
 }
@@ -588,13 +592,13 @@ void gAppManager::onEvent(gEvent& event) {
 }
 
 bool gAppManager::onWindowResizedEvent(gWindowResizeEvent& event) {
-    if(!canvasmanager || !initialized || (!getCurrentCanvas() && !canvasmanager->getTempCanvas())) {
+    if(!canvasmanager || !initialized || (!isguiapp && !getCurrentCanvas() && !canvasmanager->getTempCanvas())) {
         return true;
     }
     setScreenSize(event.getWidth(), event.getHeight());
 #ifdef ANDROID
     delayedresize = false;
-    if(gRenderer::getScreenScaling() >= G_SCREENSCALING_AUTO && olddeviceorientation != deviceorientation) {
+    if(gRenderer::getScreenScaling() == G_SCREENSCALING_AUTO && olddeviceorientation != deviceorientation) {
 		DeviceOrientation orientation = deviceorientation;
 		DeviceOrientation oldorientation = olddeviceorientation;
 		// Normalize values
@@ -630,14 +634,18 @@ bool gAppManager::onWindowResizedEvent(gWindowResizeEvent& event) {
 }
 
 bool gAppManager::onWindowScaleChangedEvent(gWindowScaleChangedEvent& event) {
-	if(!canvasmanager || !initialized || (!getCurrentCanvas() && !canvasmanager->getTempCanvas())) {
+	if(!canvasmanager || !initialized || (!isguiapp && !getCurrentCanvas() && !canvasmanager->getTempCanvas())) {
 		return true;
 	}
 	renderer->width = event.getWidth();
 	renderer->height = event.getHeight();
 	if(screenscaling == G_SCREENSCALING_AUTO_ONCE) {
-		renderer->unitwidth = renderer->width / event.getScaleX();
-		renderer->unitheight = renderer->height / event.getScaleY();
+		if(isguiapp) {
+			renderer->setUnitScreenSize(renderer->width / event.getScaleX(), renderer->height / event.getScaleY());
+		} else {
+			renderer->unitwidth = renderer->width / event.getScaleX();
+			renderer->unitheight = renderer->height / event.getScaleY();
+		}
 	}
 	return false;
 }
@@ -875,15 +883,16 @@ bool gAppManager::onTouchEvent(gTouchEvent& event) {
 			}
 			target->touchReleased(x, y, input.fingerid);
 		} else if (event.getAction() == ACTIONTYPE_MOVE) {
-			int inputindex = event.getActionIndex();
-			TouchInput& input = event.getInputs()[inputindex];
-			int x = input.x;
-			int y = input.y;
-			if(gRenderer::getScreenScaling() > G_SCREENSCALING_NONE) {
-				x = gRenderer::scaleX(x);
-				y = gRenderer::scaleY(y);
+			for(int i = 0; i < event.getInputCount(); i++) {
+				TouchInput& input = event.getInputs()[i];
+				int x = input.x;
+				int y = input.y;
+				if(gRenderer::getScreenScaling() > G_SCREENSCALING_NONE) {
+					x = gRenderer::scaleX(x);
+					y = gRenderer::scaleY(y);
+				}
+				target->touchMoved(x, y, input.fingerid);
 			}
-			target->touchMoved(x, y, input.fingerid);
 		}
 	}
 	return false;

--- a/engine/core/gGLRenderEngine.cpp
+++ b/engine/core/gGLRenderEngine.cpp
@@ -107,6 +107,12 @@ void gGLRenderEngine::enableAlphaBlending() {
 	isalphablendingenabled = true;
 }
 
+void gGLRenderEngine::enableAdditiveBlending() {
+	G_CHECK_GL(glEnable(GL_BLEND));
+	G_CHECK_GL(glBlendFunc(GL_SRC_ALPHA, GL_ONE));
+	isalphablendingenabled = true;
+}
+
 void gGLRenderEngine::disableAlphaBlending() {
 	G_CHECK_GL(glDisable(GL_BLEND));
 	isalphablendingenabled = false;

--- a/engine/core/gGLRenderEngine.h
+++ b/engine/core/gGLRenderEngine.h
@@ -29,6 +29,7 @@ public:
 	int getDepthTestType() override;
 
 	void enableAlphaBlending() override;
+	void enableAdditiveBlending() override;
 	void disableAlphaBlending() override;
 	bool isAlphaBlendingEnabled() override;
 	void enableAlphaTest() override;

--- a/engine/core/gRenderer.cpp
+++ b/engine/core/gRenderer.cpp
@@ -51,6 +51,9 @@ int gRenderer::unitheight;
 int gRenderer::screenscaling;
 int gRenderer::currentresolution;
 int gRenderer::unitresolution;
+glm::mat4 gRenderer::projectionmatrix;
+glm::mat4 gRenderer::projectionmatrix2d;
+gShader* gRenderer::imageshader;
 
 void gDrawLine(float x1, float y1, float x2, float y2, float thickness) {
 	G_PROFILE_ZONE_SCOPED_N("gDrawLine()");
@@ -483,6 +486,11 @@ void gRenderer::setUnitScreenSize(int unitWidth, int unitHeight) {
 	unitwidth = unitWidth;
 	unitheight = unitHeight;
 	setUnitResolution(getResolution(unitWidth, unitHeight));
+	projectionmatrix2d = glm::ortho(0.0f, (float)unitwidth, (float)unitheight, 0.0f, -1.0f, 1.0f);
+	if(imageshader) {
+		imageshader->use();
+		imageshader->setMat4("projection", projectionmatrix2d);
+	}
 }
 
 void gRenderer::setScreenScaling(int screenScaling) {

--- a/engine/core/gRenderer.h
+++ b/engine/core/gRenderer.h
@@ -573,7 +573,7 @@ protected:
 	gShader* colorshader;
 	gShader* textureshader;
 	gShader* fontshader;
-	gShader* imageshader;
+	static gShader* imageshader;
 	gShader* skyboxshader;
 	gShader* shadowmapshader;
 	gShader* pbrshader;
@@ -584,9 +584,9 @@ protected:
 	gShader* fboshader;
 	gShader* gridshader;
 
-	glm::mat4 projectionmatrix;
+	static glm::mat4 projectionmatrix;
 	glm::mat4 projectionmatrixold;
-	glm::mat4 projectionmatrix2d;
+	static glm::mat4 projectionmatrix2d;
 	glm::mat4 viewmatrix;
 	glm::mat4 viewmatrixold;
 	glm::vec3 cameraposition;

--- a/engine/core/gRenderer.h
+++ b/engine/core/gRenderer.h
@@ -300,6 +300,7 @@ public:
 	virtual int getDepthTestType() = 0;
 
 	virtual void enableAlphaBlending() = 0;
+	virtual void enableAdditiveBlending() = 0;
 	virtual void disableAlphaBlending() = 0;
 	virtual bool isAlphaBlendingEnabled() = 0;
 	virtual void enableAlphaTest() = 0;

--- a/engine/graphics/gTexture.cpp
+++ b/engine/graphics/gTexture.cpp
@@ -68,7 +68,7 @@ gTexture::gTexture(int w, int h, int format, bool isFbo) {
 	wrapt = TEXTUREWRAP_REPEAT;
 	filtermin = TEXTUREMINMAGFILTER_LINEAR;
 	filtermag = TEXTUREMINMAGFILTER_LINEAR;
-#if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR || EMSCRIPTEN
+#if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR || EMSCRIPTEN || defined(ANDROID)
 	if(format == GL_DEPTH_COMPONENT) {
 		internalformat = GL_DEPTH_COMPONENT24;
 		valuetype = GL_UNSIGNED_INT;


### PR DESCRIPTION
- gAppManager: resize/scale-change events were unconditionally ignored for GUI apps (they never set a canvas), so a GUIAPP window never resized after launch, including its very first orientation. Guards now exempt isguiapp.
- gAppManager: GUIAPP's screen-size branch wrote unitwidth/unitheight directly instead of calling gRenderer::setUnitScreenSize(), so the 2D projection below was never refreshed. Now goes through the real setter.
- gAppManager: the Android orientation-swap block ran even for G_SCREENSCALING_AUTO_ONCE, double-swapping unit dimensions already computed by setScreenSize(). Tightened to G_SCREENSCALING_AUTO only.
- gAppManager: onTouchEvent's ACTION_MOVE only forwarded the touch at getActionIndex(), dropping movement for any other simultaneously active pointer (e.g. a look-drag held alongside a joystick). Now forwards all active pointers.
- gRenderer: setUnitScreenSize() recomputed the 2D projection matrix but never re-uploaded it to the image shader, which only received it once at init(). GUI content kept rendering with the launch-time projection regardless of later resizes. projectionmatrix/projectionmatrix2d/ imageshader made static (setScreenSize/setUnitScreenSize are themselves static) so the fix can live there.
- gTexture: the GLES depth-texture format branch excluded Android, leaving shadow-map FBOs incomplete on real Android GPUs (worked on emulator only).
- Also adds gRenderer::enableAdditiveBlending() (GL_SRC_ALPHA, GL_ONE) as a                                                                                      
  reusable blend mode alongside the existing alpha-blending pair - useful for                                                                                    
  glow/muzzle-flash/explosion-style effects in any project