### PR TITLE
Add isolated mobile GUI scrolling, rotation, and navigation

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -353,6 +353,16 @@ if(WIN32)
 	)
 endif()
 
+# miniaudio includes AVFoundation on iOS, so this translation unit must accept
+# Objective-C declarations. Keep the override platform-local; other targets
+# continue compiling gSound.cpp as ordinary C++.
+if(IOS)
+	set_source_files_properties(${ENGINE_DIR}/media/gSound.cpp PROPERTIES
+		LANGUAGE OBJCXX
+		XCODE_EXPLICIT_FILE_TYPE "sourcecode.cpp.objcpp"
+	)
+endif()
+
 # These are handled from the appropriate plugin.
 if(NOT (ANDROID OR IOS OR EMSCRIPTEN))
 	list(APPEND SRC_FILES

--- a/engine/core/gAppManager.cpp
+++ b/engine/core/gAppManager.cpp
@@ -14,6 +14,7 @@
 #include "gCanvasManager.h"
 #include "gGUIFrame.h"
 
+#include <algorithm>
 #include <thread>
 #include "gGUIAppThread.h"
 #include "gTracy.h"
@@ -228,6 +229,7 @@ void gAppManager::initialize() {
 }
 
 void gAppManager::loop() {
+
     if(loopmode == G_LOOPMODE_NONE) {
         return;
     }
@@ -240,6 +242,14 @@ void gAppManager::loop() {
 #endif
     //gLogi("gAppManager") << "starting loop";
     isrunning = true;
+#if defined(ANDROID) || TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
+	// Android and iOS drive the app through initialize()/setup()/loop() directly
+	// instead of runApp(), so the GUI app thread must also be started here. The
+	// desktop platforms reach this function through runApp(), which has already
+	// started it, so the call is confined here rather than changing their
+	// startup path. (On iOS this function runs once, from setup().)
+	if(isguiapp && guiappthread) guiappthread->start();
+#endif
 	starttime = AppClock::now();
 
 #ifdef ANDROID
@@ -369,12 +379,37 @@ void gAppManager::setScreenSize(int width, int height) {
 	G_PROFILE_ZONE_SCOPED_N("gAppManager::setScreenSize()");
 	G_PROFILE_ZONE_VALUE(width);
 	G_PROFILE_ZONE_VALUE(height);
-	if(screenscaling == G_SCREENSCALING_AUTO_ONCE) {
+#if defined(ANDROID) || defined(IOS)
+	// Surface recreation can briefly report an empty drawable. Keep the last
+	// valid logical layout until the platform delivers the replacement surface.
+	if(width <= 0 || height <= 0) return;
+#endif
+	if(screenscaling == G_SCREENSCALING_AUTO_ONCE
+#if defined(ANDROID) || defined(IOS)
+			&& !isguiapp
+#endif
+	) {
 		// We don't want to update the unitresolution, that's why its setting directly. gAppManager needs to be a friend of gRenderer to do this.
 		renderer->unitwidth = renderer->scaleX(width);
 		renderer->unitheight = renderer->scaleY(height);
 	}
 	renderer->setScreenSize(width, height);
+#if defined(ANDROID) || defined(IOS)
+	if(isguiapp && screenscaling >= G_SCREENSCALING_AUTO && unitwidth > 0 && unitheight > 0) {
+		// Match the logical GUI aspect to the current mobile surface while
+		// preserving the app's short-edge design unit. This must run after
+		// setScreenSize(), which resets the 2D projection to physical dimensions.
+		const int shortedge = std::min(unitwidth, unitheight);
+		const bool islandscape = width > height;
+		const int logicalwidth = islandscape
+				? (width * shortedge + height / 2) / height
+				: shortedge;
+		const int logicalheight = islandscape
+				? shortedge
+				: (height * shortedge + width / 2) / width;
+		renderer->setUnitScreenSize(logicalwidth, logicalheight);
+	}
+#endif
     if(iscanvasset && canvasmanager->getCurrentCanvas()) {
 	    canvasmanager->getCurrentCanvas()->windowResized(renderer->getWidth(), renderer->getHeight());
     }
@@ -593,41 +628,15 @@ bool gAppManager::onWindowResizedEvent(gWindowResizeEvent& event) {
     if(!canvasmanager || !initialized || (!getCurrentCanvas() && !canvasmanager->getTempCanvas())) {
         return true;
     }
-    setScreenSize(event.getWidth(), event.getHeight());
 #ifdef ANDROID
+    // setScreenSize relayouts GUI frames. Choose the logical dimensions before
+    // that relayout so a rotated scrollable never receives the old viewport.
+    // The EGL surface is authoritative here: Android can deliver an orientation
+    // callback before the new surface size is available.
     delayedresize = false;
-    if(gRenderer::getScreenScaling() >= G_SCREENSCALING_AUTO && olddeviceorientation != deviceorientation) {
-		DeviceOrientation orientation = deviceorientation;
-		DeviceOrientation oldorientation = olddeviceorientation;
-		// Normalize values
-		if(orientation == DEVICEORIENTATION_REVERSE_PORTRAIT) {
-			orientation = DEVICEORIENTATION_PORTRAIT;
-		} else if(orientation == DEVICEORIENTATION_REVERSE_LANDSCAPE) {
-			orientation = DEVICEORIENTATION_LANDSCAPE;
-		}
-		if(oldorientation == DEVICEORIENTATION_REVERSE_PORTRAIT) {
-			oldorientation = DEVICEORIENTATION_PORTRAIT;
-		} else if(oldorientation == DEVICEORIENTATION_REVERSE_LANDSCAPE) {
-			oldorientation = DEVICEORIENTATION_LANDSCAPE;
-		}
-
-		bool swapdimensions = oldorientation != orientation;
-		if((orientation != DEVICEORIENTATION_PORTRAIT && orientation != DEVICEORIENTATION_LANDSCAPE) ||
-			(oldorientation != DEVICEORIENTATION_PORTRAIT && oldorientation != DEVICEORIENTATION_LANDSCAPE)) {
-			// If this orientation is not known, we should not do anything
-			swapdimensions = false;
-		}
-
-		// Orientation changed, we should swap height and width
-		if(swapdimensions) {
-			int unitwidth = gBaseCanvas::getRenderer()->getUnitWidth();
-			int unitheight = gBaseCanvas::getRenderer()->getUnitHeight();
-			// Swap width and height values
-			gRenderer::setUnitScreenSize(unitheight, unitwidth);
-		}
-    }
     olddeviceorientation = deviceorientation;
 #endif
+    setScreenSize(event.getWidth(), event.getHeight());
     return false;
 }
 
@@ -854,6 +863,36 @@ bool gAppManager::onDeviceOrientationChangedEvent(gDeviceOrientationChangedEvent
 }
 
 bool gAppManager::onTouchEvent(gTouchEvent& event) {
+	// A GUI application owns its touch interpretation.  The application manager
+	// only converts the platform event into the existing GUI mouse contract; it
+	// deliberately carries no page-scroll state or gesture policy.
+	if(isguiapp && guimanager && guimanager->isframeset && event.getInputCount() > 0) {
+		const int inputindex = event.getActionIndex();
+		if(inputindex >= 0 && inputindex < event.getInputCount()) {
+			TouchInput& input = event.getInputs()[inputindex];
+			int x = input.x;
+			int y = input.y;
+			if(gRenderer::getScreenScaling() > G_SCREENSCALING_NONE) {
+				x = gRenderer::scaleX(x);
+				y = gRenderer::scaleY(y);
+			}
+			const ActionType action = event.getAction();
+			submitToMainThread([this, x, y, action]() {
+				if(!guimanager || !guimanager->isframeset) return;
+				if(action == ACTIONTYPE_POINTER_DOWN || action == ACTIONTYPE_DOWN) {
+					guimanager->mouseMoved(x, y);
+					guimanager->mousePressed(x, y, 0);
+				} else if(action == ACTIONTYPE_MOVE) {
+					guimanager->mouseDragged(x, y, 0);
+				} else if(action == ACTIONTYPE_POINTER_UP || action == ACTIONTYPE_UP
+						|| action == ACTIONTYPE_CANCEL || action == ACTIONTYPE_OUTSIDE) {
+					guimanager->mouseReleased(x, y, 0);
+				}
+			});
+			return false;
+		}
+	}
+
 	if(canvasmanager && getCurrentCanvas()) {
 		auto* target = getCurrentCanvas();
 		if (event.getAction() == ACTIONTYPE_POINTER_DOWN || (event.getInputCount() == 1 && event.getAction() == ACTIONTYPE_DOWN)) {

--- a/engine/core/gRenderer.cpp
+++ b/engine/core/gRenderer.cpp
@@ -181,7 +181,6 @@ void gRenderer::init() {
 	height = gDefaultHeight();
 	unitwidth = gDefaultUnitWidth();
 	unitheight = gDefaultUnitHeight();
-
 	// TODO Check matrix maths
 	projectionmatrix = glm::mat4(1.0f);
 	projectionmatrix = glm::perspective(glm::radians(60.0f), (float)width / height, 0.0f, 1000.0f);
@@ -477,18 +476,35 @@ void gRenderer::setScreenSize(int screenWidth, int screenHeight) {
 	width = screenWidth;
 	height = screenHeight;
 	setCurrentResolution(getResolution(screenWidth, screenHeight));
+	updateProjectionMatrix2d();
 }
 
 void gRenderer::setUnitScreenSize(int unitWidth, int unitHeight) {
 	unitwidth = unitWidth;
 	unitheight = unitHeight;
 	setUnitResolution(getResolution(unitWidth, unitHeight));
+	updateProjectionMatrix2d();
 }
 
 void gRenderer::setScreenScaling(int screenScaling) {
 	screenscaling = screenScaling;
 	gObject::setCurrentResolution(screenscaling, currentresolution);
+	updateProjectionMatrix2d();
 }
+
+void gRenderer::updateProjectionMatrix2d() {
+	gRenderer* r = gRenderObject::getRenderer();
+	if(!r) return;
+	// The projection must use the same coordinate space returned by getWidth()
+	// and getHeight(). Deriving it here also makes initialization order safe:
+	// setUnitScreenSize() is called before setScreenScaling() on desktop.
+	const int projectionwidth = screenscaling >= G_SCREENSCALING_AUTO ? unitwidth : width;
+	const int projectionheight = screenscaling >= G_SCREENSCALING_AUTO ? unitheight : height;
+	if(projectionwidth <= 0 || projectionheight <= 0) return;
+	r->projectionmatrix2d = glm::ortho(0.0f, (float)projectionwidth,
+			(float)projectionheight, 0.0f, -1.0f, 1.0f);
+}
+
 
 int gRenderer::getWidth() {
 	if (screenscaling >= G_SCREENSCALING_AUTO) {

--- a/engine/core/gRenderer.h
+++ b/engine/core/gRenderer.h
@@ -180,6 +180,7 @@ public:
 	static void setScreenSize(int screenWidth, int screenHeight);
 	static void setUnitScreenSize(int unitWidth, int unitHeight);
 	static void setScreenScaling(int screenScaling);
+	static void updateProjectionMatrix2d();
 
 	int getWidth();
 	int getHeight();

--- a/engine/ui/gGUIButton.cpp
+++ b/engine/ui/gGUIButton.cpp
@@ -8,6 +8,7 @@
 #include "gGUIButton.h"
 #include "gBaseApp.h"
 #include "gBaseCanvas.h"
+#include <algorithm>
 
 gGUIButton::gGUIButton() {
 	ispressed = false;
@@ -30,6 +31,7 @@ gGUIButton::gGUIButton() {
 	pressedfcolor = *pressedbuttonfontcolor;
 	disabledfcolor = *disabledbuttonfontcolor;
 	fillbackground = true;
+	contentcentered = false;
 	resetTitlePosition();
 }
 
@@ -83,6 +85,8 @@ void gGUIButton::update() {
 void gGUIButton::draw() {
 //	gLogi("gGUIButton") << "draw, w:" << width;
 	gColor* oldcolor = renderer->getColor();
+	const int drawleft = getButtonDrawLeft();
+	const int drawtop = getButtonDrawTop();
 	if(fillbackground) {
 		if(isdisabled) renderer->setColor(&disabledbcolor);
 		else {
@@ -91,7 +95,7 @@ void gGUIButton::draw() {
 			else renderer->setColor(&bcolor);
 		}
 	//	renderer->setColor(gColor(0.1f, 0.45f, 0.87f));
-		gDrawRectangle(left, top + ispressed, buttonw, buttonh, true);
+		gDrawRectangle(drawleft, drawtop + ispressed, buttonw, buttonh, true);
 	}
 
 	if(istextvisible) {
@@ -103,7 +107,7 @@ void gGUIButton::draw() {
 
 	    resetTitlePosition();
 
-	    font->drawText(title, left + tx, top + buttonh - ty + ispressed - 2);
+	    font->drawText(title, drawleft + tx, drawtop + buttonh - ty + ispressed - 2);
 	}
 	renderer->setColor(oldcolor);
 }
@@ -111,7 +115,9 @@ void gGUIButton::draw() {
 void gGUIButton::mousePressed(int x, int y, int button) {
 //	gLogi("Button") << "pressed, id:" << id;
 	if(isdisabled) return;
-	if(x >= left && x < left + buttonw && y >= top && y < top + buttonh) {
+	const int drawleft = getButtonDrawLeft();
+	const int drawtop = getButtonDrawTop();
+	if(x >= drawleft && x < drawleft + buttonw && y >= drawtop && y < drawtop + buttonh) {
 		if(!istoggle) ispressed = true;
 		else {
 			if(!ispressed) {
@@ -126,7 +132,9 @@ void gGUIButton::mousePressed(int x, int y, int button) {
 void gGUIButton::mouseReleased(int x, int y, int button) {
 //	gLogi("Button") << "released, id:" << id;
 	if(isdisabled) return;
-	if(ispressed && x >= left && x < left + buttonw && y >= top && y < top + buttonh) {
+	const int drawleft = getButtonDrawLeft();
+	const int drawtop = getButtonDrawTop();
+	if(ispressed && x >= drawleft && x < drawleft + buttonw && y >= drawtop && y < drawtop + buttonh) {
 		if(!istoggle) ispressed = false;
 		else {
 			if(!ispressednow) ispressed = false;
@@ -140,12 +148,16 @@ void gGUIButton::mouseReleased(int x, int y, int button) {
 }
 
 void gGUIButton::mouseMoved(int x, int y) {
-	if(iscursoron && x >= left && y >= top && x < left + buttonw && y < top + buttonh) ishover = true;
+	const int drawleft = getButtonDrawLeft();
+	const int drawtop = getButtonDrawTop();
+	if(iscursoron && x >= drawleft && y >= drawtop && x < drawleft + buttonw && y < drawtop + buttonh) ishover = true;
 	else ishover = false;
 }
 
 void gGUIButton::mouseDragged(int x, int y, int button) {
-	if(iscursoron && x >= left && y >= top && x < left + buttonw && y < top + buttonh) ishover = true;
+	const int drawleft = getButtonDrawLeft();
+	const int drawtop = getButtonDrawTop();
+	if(iscursoron && x >= drawleft && y >= drawtop && x < drawleft + buttonw && y < drawtop + buttonh) ishover = true;
 	else ishover = false;
 }
 
@@ -223,6 +235,18 @@ gColor* gGUIButton::getDisabledButtonFontColor() {
 
 void gGUIButton::enableBackgroundFill(bool isEnabled) {
 	fillbackground = isEnabled;
+}
+
+void gGUIButton::setContentCentered(bool centered) {
+	contentcentered = centered;
+}
+
+int gGUIButton::getButtonDrawLeft() const {
+	return contentcentered ? left + std::max(0, (width - buttonw) / 2) : left;
+}
+
+int gGUIButton::getButtonDrawTop() const {
+	return contentcentered ? top + std::max(0, (height - buttonh) / 2) : top;
 }
 
 int gGUIButton::getButtonWidth() {

--- a/engine/ui/gGUIButton.h
+++ b/engine/ui/gGUIButton.h
@@ -42,6 +42,7 @@ public:
 	gColor* getDisabledButtonFontColor();
 
 	void enableBackgroundFill(bool isEnabled);
+	void setContentCentered(bool centered);
 
 	int getButtonWidth();
 	int getButtonHeight();
@@ -71,8 +72,11 @@ protected:
 	gColor fcolor, pressedfcolor, disabledfcolor;
 	gColor hcolor;
 	bool fillbackground;
+	bool contentcentered;
 
 	void resetTitlePosition();
+	int getButtonDrawLeft() const;
+	int getButtonDrawTop() const;
 
 private:
 };

--- a/engine/ui/gGUIContainer.cpp
+++ b/engine/ui/gGUIContainer.cpp
@@ -7,10 +7,23 @@
 
 #include "gGUIContainer.h"
 
+#include <algorithm>
+
+// GUI coordinates are already normalized by gAppManager on mobile.  Six units
+// was small enough for ordinary finger jitter to turn a tap into a scroll.  A
+// twelve-unit slop keeps taps reliable without making an intentional drag feel
+// delayed.  This applies only to containers which explicitly enable scrolling.
+const int gGUIContainer::CONTENT_DRAG_SLOP = 12;
+
 
 gGUIContainer::gGUIContainer() {
 	iscontainer = true;
 	topbarh = 0;
+	contentwidth = 0;
+	contentheight = 0;
+	contentscrollingenabled = false;
+	iscontentdragging = false;
+	iscontentdragmoved = false;
 	guisizer = nullptr;
 	temporaryemptysizer.setSize(1, 1);
 	setSizer(&temporaryemptysizer);
@@ -20,7 +33,14 @@ gGUIContainer::~gGUIContainer() {
 }
 
 void gGUIContainer::set(gBaseApp* root, gBaseGUIObject* topParentGUIObject, gBaseGUIObject* parentGUIObject, int parentSlotLineNo, int parentSlotColumnNo, int x, int y, int w, int h) {
-	totalh = h;
+	if(contentscrollingenabled) {
+		totalw = contentwidth > 0 ? contentwidth : w;
+		totalh = contentheight > 0 ? contentheight : h;
+	} else {
+		// Preserve the original container contract. Legacy desktop controls use
+		// absolute sizer coordinates and must not be moved into an FBO-local space.
+		totalh = h;
+	}
 	gGUIScrollable::set(root, topParentGUIObject, parentGUIObject, parentSlotLineNo, parentSlotColumnNo, x, y, w, h);
 	gGUIScrollable::setDimensions(w, h);
 	guisizer->set(root, topParentGUIObject, parentGUIObject, parentSlotLineNo, parentSlotColumnNo, x, y + topbarh, w, h - topbarh);
@@ -33,6 +53,11 @@ void gGUIContainer::set(int x, int y, int w, int h) {
 	bottom = y + h;
 	width = w;
 	height = h;
+	if(contentscrollingenabled) {
+		// Scroll-enabled mobile containers need their viewport refreshed during
+		// relayout. Legacy containers retain their original lightweight behavior.
+		gGUIScrollable::setDimensions(w, h);
+	}
 	guisizer->set(x, y + topbarh, w, h - topbarh);
 }
 
@@ -55,16 +80,56 @@ gGUISizer* gGUIContainer::getSizer() {
 	return guisizer;
 }
 
+void gGUIContainer::setContentSize(int contentWidth, int contentHeight) {
+	contentscrollingenabled = true;
+	contentwidth = std::max(contentWidth, 1);
+	contentheight = std::max(contentHeight, 1);
+	totalw = contentwidth;
+	totalh = contentheight;
+}
+
+void gGUIContainer::enableContentScrolling(bool enabled) {
+	contentscrollingenabled = enabled;
+	if(!enabled) {
+		horizontalscroll = 0;
+		verticalscroll = 0;
+		iscontentdragging = false;
+		iscontentdragmoved = false;
+	}
+}
+
+bool gGUIContainer::isContentScrollingEnabled() const {
+	return contentscrollingenabled;
+}
+
 void gGUIContainer::update() {
 	if(guisizer) guisizer->update();
 }
 
 void gGUIContainer::draw() {
+	if(contentscrollingenabled) {
+		gGUIScrollable::draw();
+	} else if(guisizer) {
+		guisizer->draw();
+	}
+}
+
+void gGUIContainer::drawContent() {
+	if(!guisizer) return;
+	// gGUIScrollable renders content into its local framebuffer.  Keep the
+	// sizer in that local coordinate system and translate only this container's
+	// children by its own scroll offsets.
+	const int layoutwidth = isHorizontalScrollEnabled() ? totalw : boxw;
+	guisizer->set(-horizontalscroll, topbarh - verticalscroll,
+			std::max(0, layoutwidth), std::max(0, totalh - topbarh));
 	guisizer->draw();
 }
 
 int gGUIContainer::getCursor(int x, int y) {
-	return guisizer->getCursor(x, y);
+	if(!contentscrollingenabled) return guisizer->getCursor(x, y);
+	// drawContent() has already positioned the child controls in viewport-local
+	// coordinates. Convert screen to viewport coordinates exactly once here.
+	return guisizer->getCursor(x - left, y - top);
 }
 
 void gGUIContainer::keyPressed(int key) {
@@ -80,32 +145,98 @@ void gGUIContainer::charPressed(unsigned int codepoint) {
 }
 
 void gGUIContainer::mouseMoved(int x, int y) {
-	guisizer->mouseMoved(x, y);
+	if(!contentscrollingenabled) {
+		guisizer->mouseMoved(x, y);
+		return;
+	}
+	guisizer->mouseMoved(x - left, y - top);
 }
 
 void gGUIContainer::mousePressed(int x, int y, int button) {
-	guisizer->mousePressed(x, y, button);
+	if(!contentscrollingenabled) {
+		guisizer->mousePressed(x, y, button);
+		return;
+	}
+	gGUIScrollable::mousePressed(x, y, button);
+	const bool onverticalbar = isVerticalScrollEnabled() && isPointInsideVerticalScrollbar(x, y, true);
+	const bool onhorizontalbar = isHorizontalScrollEnabled() && isPointInsideHorizontalScrollbar(x, y, true);
+	iscontentdragging = false;
+	iscontentdragmoved = false;
+	if(!onverticalbar && !onhorizontalbar) {
+		iscontentdragging = hasVerticalOverflow() || hasHorizontalOverflow();
+		contentdragstartx = x;
+		contentdragstarty = y;
+		contentdragscrollx = horizontalscroll;
+		contentdragscrolly = verticalscroll;
+		guisizer->mousePressed(x - left, y - top, button);
+	}
 }
 
 void gGUIContainer::mouseDragged(int x, int y, int button) {
-	guisizer->mouseDragged(x, y, button);
+	if(!contentscrollingenabled) {
+		guisizer->mouseDragged(x, y, button);
+		return;
+	}
+	gGUIScrollable::mouseDragged(x, y, button);
+	if(iscontentdragging) {
+		const int dx = x - contentdragstartx;
+		const int dy = y - contentdragstarty;
+		const int scrolldx = isHorizontalScrollEnabled() ? dx : 0;
+		const int scrolldy = isVerticalScrollEnabled() ? dy : 0;
+		if(!iscontentdragmoved
+				&& scrolldx * scrolldx + scrolldy * scrolldy
+				> CONTENT_DRAG_SLOP * CONTENT_DRAG_SLOP) {
+			iscontentdragmoved = true;
+			// Cancel the child press as soon as this gesture becomes a drag. This
+			// clears its visual/interaction state even if Android later reports the
+			// release outside the viewport.
+			guisizer->mouseReleased(-100000, -100000, button);
+		}
+		// Do not move content during the tap-candidate phase. Apart from matching
+		// native scroll views, this keeps press and release hit coordinates equal.
+		if(!iscontentdragmoved) return;
+		horizontalscroll = isHorizontalScrollEnabled()
+				? gClamp(contentdragscrollx - dx, 0, std::max(0, totalw - boxw)) : 0;
+		verticalscroll = isVerticalScrollEnabled()
+				? gClamp(contentdragscrolly - dy, 0, std::max(0, totalh - boxh)) : 0;
+	} else if(!isdraggingverticalscroll && !isdragginghorizontalscroll) {
+		guisizer->mouseDragged(x - left, y - top, button);
+	}
 }
 
 void gGUIContainer::mouseReleased(int x, int y, int button) {
-	guisizer->mouseReleased(x, y, button);
+	if(!contentscrollingenabled) {
+		guisizer->mouseReleased(x, y, button);
+		return;
+	}
+	gGUIScrollable::mouseReleased(x, y, button);
+	if(iscontentdragging && iscontentdragmoved) {
+		// A drag started on a button must cancel its press instead of becoming a
+		// click when the finger leaves the screen.
+		guisizer->mouseReleased(-100000, -100000, button);
+	} else {
+		guisizer->mouseReleased(x - left, y - top, button);
+	}
+	iscontentdragging = false;
+	iscontentdragmoved = false;
 }
 
 void gGUIContainer::mouseScrolled(int x, int y) {
-	guisizer->mouseScrolled(x, y);
+	if(!contentscrollingenabled) {
+		guisizer->mouseScrolled(x, y);
+	} else if(hasVerticalOverflow() || hasHorizontalOverflow()) {
+		gGUIScrollable::mouseScrolled(x, y);
+	} else {
+		guisizer->mouseScrolled(x, y);
+	}
 }
 
 void gGUIContainer::windowResized(int w, int h) {
-	guisizer->windowResized(w, h);
+	if(contentscrollingenabled) gGUIScrollable::setDimensions(width, height);
+	if(guisizer) guisizer->windowResized(w, h);
 }
 
 void gGUIContainer::setCursorOn(bool isOn) {
 	gBaseGUIObject::setCursorOn(isOn);
 	guisizer->setCursorOn(isOn);
 }
-
-

--- a/engine/ui/gGUIContainer.h
+++ b/engine/ui/gGUIContainer.h
@@ -17,32 +17,51 @@ public:
 	gGUIContainer();
 	virtual ~gGUIContainer();
 
-	virtual void set(gBaseApp* root, gBaseGUIObject* topParentGUIObject, gBaseGUIObject* parentGUIObject, int parentSlotLineNo, int parentSlotColumnNo, int x, int y, int w, int h);
-	virtual void set(int x, int y, int w, int h);
+	void set(gBaseApp* root, gBaseGUIObject* topParentGUIObject, gBaseGUIObject* parentGUIObject, int parentSlotLineNo, int parentSlotColumnNo, int x, int y, int w, int h) override;
+	void set(int x, int y, int w, int h);
 
 	void setSizer(gGUISizer* guiSizer);
 	gGUISizer* getSizer();
 
-	virtual int getCursor(int x, int y);
-	virtual void keyPressed(int key);
-	virtual void keyReleased(int key);
-	virtual void charPressed(unsigned int codepoint);
-	virtual void mouseMoved(int x, int y);
-	virtual void mousePressed(int x, int y, int button);
-	virtual void mouseDragged(int x, int y, int button);
-	virtual void mouseReleased(int x, int y, int button);
-	virtual void mouseScrolled(int x, int y);
-	virtual void windowResized(int w, int h);
+	/**
+	 * Sets the extent of the container's content in GUI units.  The visible
+	 * rectangle remains the size assigned by its parent; overflow is handled by
+	 * this container's gGUIScrollable base class.
+	 */
+	void setContentSize(int contentWidth, int contentHeight);
+	void enableContentScrolling(bool enabled);
+	bool isContentScrollingEnabled() const;
 
-	void update();
-	void draw();
+	int getCursor(int x, int y) override;
+	void keyPressed(int key) override;
+	void keyReleased(int key) override;
+	void charPressed(unsigned int codepoint) override;
+	void mouseMoved(int x, int y) override;
+	void mousePressed(int x, int y, int button) override;
+	void mouseDragged(int x, int y, int button) override;
+	void mouseReleased(int x, int y, int button) override;
+	void mouseScrolled(int x, int y) override;
+	void windowResized(int w, int h) override;
 
-	void setCursorOn(bool isOn);
+	void update() override;
+	void draw() override;
+	void drawContent() override;
+
+	void setCursorOn(bool isOn) override;
 
 
 protected:
 	gGUISizer* guisizer, temporaryemptysizer;
 	int topbarh;
+	int contentwidth, contentheight;
+	bool contentscrollingenabled;
+	bool iscontentdragging;
+	bool iscontentdragmoved;
+	int contentdragstartx, contentdragstarty;
+	int contentdragscrollx, contentdragscrolly;
+
+private:
+	static const int CONTENT_DRAG_SLOP;
 };
 
 #endif /* UI_GGUICONTAINER_H_ */

--- a/engine/ui/gGUIImageButton.cpp
+++ b/engine/ui/gGUIImageButton.cpp
@@ -7,6 +7,8 @@
 
 #include "gGUIImageButton.h"
 
+#include <algorithm>
+
 gGUIImageButton::gGUIImageButton() {
 
 	imagew = 0;
@@ -19,6 +21,8 @@ gGUIImageButton::gGUIImageButton() {
 
 	iconid = gGUIResources::ICON_NONE;
 	pressediconid = gGUIResources::ICON_NONE;
+	iscircularbackground = false;
+	circularbackgroundcolor = gColor(0.129f, 0.588f, 0.953f);
 }
 
 gGUIImageButton::~gGUIImageButton() {
@@ -26,6 +30,16 @@ gGUIImageButton::~gGUIImageButton() {
 }
 
 void gGUIImageButton::draw() {
+	gColor oldcolor = *renderer->getColor();
+	const int drawleft = getButtonDrawLeft();
+	const int drawtop = getButtonDrawTop();
+	const bool moderncontent = contentcentered || iscircularbackground;
+	if(iscircularbackground) {
+		renderer->setColor(&circularbackgroundcolor);
+		gDrawCircle(drawleft + buttonw / 2, drawtop + buttonh / 2,
+				std::max(0, std::min(buttonw, buttonh) / 2 - 3), true, 40);
+		renderer->setColor(&oldcolor);
+	}
     if(!stretch) {
     	 	imagew = pressedbuttonimage.getWidth();
             imageh = pressedbuttonimage.getHeight();
@@ -44,13 +58,23 @@ void gGUIImageButton::draw() {
             imagew = buttonw;
             imageh = buttonh;
         }
-    if(isPressed()) {
-    	if (iconid != gGUIResources::ICON_NONE) res.getIconImage(iconid, isiconbig)->draw(left + 8, top + ispressed + 8, buttonw - 20, buttonh - 20);
-    	else buttonimage.draw(left, top + ispressed, buttonw, buttonh);
-    }
-    else {
-    	if (pressediconid != gGUIResources::ICON_NONE) res.getIconImage(pressediconid, isiconbig)->draw(left + 8, top + ispressed + 8, buttonw - 20, buttonh - 20);
-    	else pressedbuttonimage.draw(left, top + ispressed, buttonw, buttonh);
+    if(moderncontent) {
+		const int iconinset = iscircularbackground ? 14 : 8;
+		if(isPressed()) {
+			if(pressediconid != gGUIResources::ICON_NONE) res.getIconImage(pressediconid, isiconbig)->draw(drawleft + iconinset, drawtop + ispressed + iconinset, buttonw - iconinset * 2, buttonh - iconinset * 2);
+			else pressedbuttonimage.draw(drawleft, drawtop + ispressed, buttonw, buttonh);
+		} else {
+			if(iconid != gGUIResources::ICON_NONE) res.getIconImage(iconid, isiconbig)->draw(drawleft + iconinset, drawtop + ispressed + iconinset, buttonw - iconinset * 2, buttonh - iconinset * 2);
+			else buttonimage.draw(drawleft, drawtop + ispressed, buttonw, buttonh);
+		}
+    } else if(isPressed()) {
+		// Keep the historical image/icon state mapping and dimensions for existing
+		// desktop applications. The corrected mapping is opt-in with modern content.
+		if(iconid != gGUIResources::ICON_NONE) res.getIconImage(iconid, isiconbig)->draw(left + 8, top + ispressed + 8, buttonw - 20, buttonh - 20);
+		else buttonimage.draw(left, top + ispressed, buttonw, buttonh);
+    } else {
+		if(pressediconid != gGUIResources::ICON_NONE) res.getIconImage(pressediconid, isiconbig)->draw(left + 8, top + ispressed + 8, buttonw - 20, buttonh - 20);
+		else pressedbuttonimage.draw(left, top + ispressed, buttonw, buttonh);
     }
     setSize(imagew, imageh);
 }
@@ -97,6 +121,11 @@ void gGUIImageButton::setImageStretched(bool stretchMod) {
    	isiconbig = isIconBig;
    }
    void gGUIImageButton::setPressedButtonImageFromIcon(int pressedIconId, bool isIconBig){
-   	pressediconid = pressedIconId;
-   	isiconbig = isIconBig;
+	   pressediconid = pressedIconId;
+	   isiconbig = isIconBig;
    }
+
+void gGUIImageButton::setCircularBackground(bool enabled, const gColor& color) {
+	iscircularbackground = enabled;
+	circularbackgroundcolor = color;
+}

--- a/engine/ui/gGUIImageButton.h
+++ b/engine/ui/gGUIImageButton.h
@@ -129,6 +129,10 @@ public:
  */
     void setPressedButtonImageFromIcon(int pressedIconId, bool isIconBig = false);
 
+    // Draws a filled circular surface behind the image while keeping the
+    // regular rectangular hit area. Useful for mobile floating action buttons.
+    void setCircularBackground(bool enabled, const gColor& color = gColor(0.129f, 0.588f, 0.953f));
+
 
 private:
         float imagew, imageh, proportion;
@@ -140,6 +144,8 @@ private:
 
         int iconid;
         int pressediconid;
+        bool iscircularbackground;
+        gColor circularbackgroundcolor;
 };
 
 #endif /* UI_GGUIIMAGEBUTTONH */

--- a/engine/ui/gGUINavigation.cpp
+++ b/engine/ui/gGUINavigation.cpp
@@ -7,6 +7,7 @@
 
 #include "gGUINavigation.h"
 #include "gBaseApp.h"
+#include <algorithm>
 
 
 gGUINavigation::gGUINavigation() {
@@ -15,6 +16,17 @@ gGUINavigation::gGUINavigation() {
 	panelinepad = 20;
 	selectedpane = 0;
 	toolbarenabled = false;
+	bottombarenabled = false;
+	bottombarpressactive = false;
+	bottombarhorizontalpadding = 16;
+	bottombarmaximumcontentwidth = 720;
+	modernbottombarenabled = false;
+	bottombarsurfaceleft = 0;
+	bottombarsurfacetop = 0;
+	bottombarsurfacewidth = 0;
+	bottombarsurfaceheight = 0;
+	bottombarsurfacecolor = gColor(0.98f, 0.985f, 1.0f, 1.0f);
+	bottombarshadowcolor = gColor(0.02f, 0.05f, 0.12f, 0.16f);
 }
 
 gGUINavigation::~gGUINavigation() {
@@ -24,20 +36,48 @@ void gGUINavigation::set(gBaseApp* root, gBaseGUIObject* topParentGUIObject, gBa
 	totalh = h;
 	gGUIScrollable::set(root, topParentGUIObject, parentGUIObject, parentSlotLineNo, parentSlotColumnNo, x, y, w, h);
 	gGUIScrollable::setDimensions(w, h);
+	if(bottombarenabled) layoutBottomBar();
 }
 
 void gGUINavigation::update() {
-	height = renderer->getHeight();
-	maintoolbarsizer.set( 0, height - 40, width, 32);
+	if(bottombarenabled) {
+		layoutBottomBar();
+	} else {
+		// Legacy navigation fills the desktop window. Keep this exact behavior
+		// unless the new bottom-bar mode was explicitly enabled.
+		height = renderer->getHeight();
+		maintoolbarsizer.set(0, height - 40, width, 32);
+	}
 }
 
 void gGUINavigation::draw() {
-	gColor* oldcolor = renderer->getColor();
+	gColor oldcolor = *renderer->getColor();
 	gGUIScrollable::drawContent();
-	renderer->setColor(navigationbackgroundcolor);
-	gDrawRectangle(0, 0, boxw, boxh + panetoph, true);
+	if(modernbottombarenabled) {
+		renderer->setColor(backgroundcolor);
+		gDrawRectangle(left, top, width, height, true);
+		const int radius = bottombarsurfaceheight / 2;
+		renderer->setColor(&bottombarshadowcolor);
+		gDrawRectangle(bottombarsurfaceleft + radius, bottombarsurfacetop + 3,
+				std::max(0, bottombarsurfacewidth - radius * 2), bottombarsurfaceheight, true);
+		gDrawCircle(bottombarsurfaceleft + radius, bottombarsurfacetop + radius + 3, radius, true, 40);
+		gDrawCircle(bottombarsurfaceleft + bottombarsurfacewidth - radius,
+				bottombarsurfacetop + radius + 3, radius, true, 40);
+		renderer->setColor(&bottombarsurfacecolor);
+		gDrawRectangle(bottombarsurfaceleft + radius, bottombarsurfacetop,
+				std::max(0, bottombarsurfacewidth - radius * 2), bottombarsurfaceheight, true);
+		gDrawCircle(bottombarsurfaceleft + radius, bottombarsurfacetop + radius, radius, true, 40);
+		gDrawCircle(bottombarsurfaceleft + bottombarsurfacewidth - radius,
+				bottombarsurfacetop + radius, radius, true, 40);
+	} else if(bottombarenabled) {
+		renderer->setColor(navigationbackgroundcolor);
+		gDrawRectangle(left, top, width, height, true);
+	} else {
+		renderer->setColor(navigationbackgroundcolor);
+		gDrawRectangle(0, 0, boxw, boxh + panetoph, true);
+	}
 
-	for(int i = 0; i < panes.size(); i++) {
+	for(int i = 0; !bottombarenabled && i < panes.size(); i++) {
 		if(!paneenabled[i]) {
 			renderer->setColor(196, 196, 196);
 			font->drawText(gToStr(i + 1) + ". " + panes[i]->getTitle(), panelinepad, panetoph + i * panelineh);
@@ -55,7 +95,7 @@ void gGUINavigation::draw() {
 		toolbar.draw();
 	}
 
-	renderer->setColor(oldcolor);
+	renderer->setColor(&oldcolor);
 }
 
 void gGUINavigation::addPane(gGUIPane* newPane, bool isEnabled) {
@@ -123,14 +163,21 @@ void gGUINavigation::showPane(gGUIPane* paneToShow) {
 void gGUINavigation::mousePressed(int x, int y, int button) {
 	gGUIScrollable::mousePressed(x, y, button);
 
-	if(toolbarenabled && x >= 0 && y >= height - 40 && x < width && y < height - 40 + 32) {
+	if(bottombarenabled && x >= left && y >= top && x < right && y < bottom) {
+		// Bottom-bar controls are laid out in absolute GUI coordinates. Forward
+		// directly to their sizer so gGUIContainer does not localize them twice.
+		// Refresh hover first because mobile touch streams may not send a move.
+		toolbarsizer.mouseMoved(x, y);
+		toolbarsizer.mousePressed(x, y, button);
+		bottombarpressactive = true;
+	} else if(toolbarenabled && x >= 0 && y >= height - 40 && x < width && y < height - 8) {
 		toolbar.mousePressed(x, y, button);
 	}
 }
 
 void gGUINavigation::mouseReleased(int x, int y, int button) {
 	gGUIScrollable::mouseReleased(x, y, button);
-	for(int i = 0; i < panes.size(); i++) {
+	for(int i = 0; !bottombarenabled && i < panes.size(); i++) {
 		if(!paneenabled[i]) continue;
 		if(x >= panelinepad && x < width - panelinepad && y >= panetoph + i * panelineh - font->getSize() && y < panetoph + i * panelineh + font->getSize() / 2) {
 			selectedpane = i;
@@ -139,19 +186,29 @@ void gGUINavigation::mouseReleased(int x, int y, int button) {
 		}
 	}
 
-	if(toolbarenabled && x >= 0 && y >= height - 40 && x < width && y < height - 40 + 32) {
+	if(bottombarenabled && bottombarpressactive) {
+		const bool isinside = x >= left && y >= top && x < right && y < bottom;
+		// A control which received press must always receive release. Passing an
+		// outside coordinate cancels the click while reliably clearing its state.
+		toolbarsizer.mouseReleased(isinside ? x : -100000, isinside ? y : -100000, button);
+		bottombarpressactive = false;
+	} else if(toolbarenabled && x >= 0 && y >= height - 40 && x < width && y < height - 8) {
 		toolbar.mouseReleased(x, y, button);
 	}
 }
 
 void gGUINavigation::mouseMoved(int x, int y) {
-	if(toolbarenabled && x >= 0 && y >= height - 40 && x < width && y < height - 40 + 32) {
+	if(bottombarenabled && x >= left && y >= top && x < right && y < bottom) {
+		toolbarsizer.mouseMoved(x, y);
+	} else if(toolbarenabled && x >= 0 && y >= height - 40 && x < width && y < height - 8) {
 		toolbar.mouseMoved(x, y);
 	}
 }
 
 void gGUINavigation::mouseDragged(int x, int y, int button) {
-	if(toolbarenabled && x >= 0 && y >= height - 40 && x < width && y < height - 40 + 32) {
+	if(bottombarenabled && x >= left && y >= top && x < right && y < bottom) {
+		toolbarsizer.mouseDragged(x, y, button);
+	} else if(toolbarenabled && x >= 0 && y >= height - 40 && x < width && y < height - 8) {
 		toolbar.mouseDragged(x, y, button);
 	}
 }
@@ -181,7 +238,45 @@ void gGUINavigation::enableToolbar() {
 	toolbarenabled = true;
 }
 
+void gGUINavigation::enableBottomBar() {
+	enableToolbar();
+	bottombarenabled = true;
+	layoutBottomBar();
+}
+
+void gGUINavigation::enableModernBottomBar() {
+	enableBottomBar();
+	modernbottombarenabled = true;
+	toolbar.enableBackgroundFill(false);
+	layoutBottomBar();
+}
+
+void gGUINavigation::setBottomBarLayout(int horizontalPadding, int maximumContentWidth) {
+	bottombarhorizontalpadding = std::max(0, horizontalPadding);
+	bottombarmaximumcontentwidth = std::max(0, maximumContentWidth);
+	if(bottombarenabled) layoutBottomBar();
+}
+
+void gGUINavigation::layoutBottomBar() {
+	const int verticalmargin = modernbottombarenabled ? 6 : 0;
+	const int surfacemargin = modernbottombarenabled ? 12 : 0;
+	bottombarsurfacewidth = std::max(0, width - surfacemargin * 2);
+	if(modernbottombarenabled && bottombarmaximumcontentwidth > 0) {
+		bottombarsurfacewidth = std::min(bottombarsurfacewidth,
+				bottombarmaximumcontentwidth + bottombarhorizontalpadding * 2);
+	}
+	bottombarsurfaceheight = std::max(0, height - verticalmargin * 2);
+	bottombarsurfaceleft = left + (width - bottombarsurfacewidth) / 2;
+	bottombarsurfacetop = top + verticalmargin;
+
+	int contentwidth = std::max(0, bottombarsurfacewidth - bottombarhorizontalpadding * 2);
+	if(bottombarmaximumcontentwidth > 0) {
+		contentwidth = std::min(contentwidth, bottombarmaximumcontentwidth);
+	}
+	const int contentleft = left + (width - contentwidth) / 2;
+	maintoolbarsizer.set(contentleft, bottombarsurfacetop, contentwidth, bottombarsurfaceheight);
+}
+
 gGUISizer* gGUINavigation::getToolbarSizer() {
 	return &toolbarsizer;
 }
-

--- a/engine/ui/gGUINavigation.h
+++ b/engine/ui/gGUINavigation.h
@@ -47,6 +47,9 @@ public:
 	virtual void mouseExited();
 
 	void enableToolbar();
+	void enableBottomBar();
+	void enableModernBottomBar();
+	void setBottomBarLayout(int horizontalPadding, int maximumContentWidth);
 	gGUISizer* getToolbarSizer();
 
 private:
@@ -61,6 +64,19 @@ private:
 	gGUIToolbar toolbar;
 	gGUISizer toolbarsizer;
 	bool toolbarenabled;
+	bool bottombarenabled;
+	bool bottombarpressactive;
+	int bottombarhorizontalpadding;
+	int bottombarmaximumcontentwidth;
+	bool modernbottombarenabled;
+	int bottombarsurfaceleft;
+	int bottombarsurfacetop;
+	int bottombarsurfacewidth;
+	int bottombarsurfaceheight;
+	gColor bottombarsurfacecolor;
+	gColor bottombarshadowcolor;
+
+	void layoutBottomBar();
 };
 
 #endif /* UI_GGUINAVIGATION_H_ */

--- a/engine/ui/gGUIScrollable.cpp
+++ b/engine/ui/gGUIScrollable.cpp
@@ -8,6 +8,8 @@
 #include "gGUIScrollable.h"
 #include "gAppManager.h"
 
+#include <algorithm>
+
 
 gGUIScrollable::gGUIScrollable() {
 	boxw = width;
@@ -17,8 +19,14 @@ gGUIScrollable::gGUIScrollable() {
 	scrollamount = 8;
 	enableverticalscroll = false;
 	enablehorizontalscroll = false;
+	#if defined(ANDROID) || defined(IOS)
+	barbackgroundcolor = backgroundcolor;
+	barforegroundcolor = middlegroundcolor;
+	#else
+	// Keep the established desktop theme for existing applications.
 	barbackgroundcolor = middlegroundcolor;
 	barforegroundcolor = backgroundcolor;
+	#endif
 	titlex = left;
 	titley = top + font->getStringHeight("AE");
 	titleheight = font->getSize() * 1.8f;
@@ -47,12 +55,14 @@ void gGUIScrollable::setDimensions(int newWidth, int newHeight) {
 		boxw -= barsize;
 	}
 	boxw -= toolbarw;
+	boxw = std::max(0, boxw);
 
 	boxh = height;
 	if (enablehorizontalscroll) {
 		boxh -= barsize;
 	}
 	boxh -= toolbarh;
+	boxh = std::max(0, boxh);
 
 //	totalw = boxw;
 //	totalh = boxh + barsize;
@@ -60,8 +70,11 @@ void gGUIScrollable::setDimensions(int newWidth, int newHeight) {
 	titlex = left + font->getStringWidth("i");
 	titley = top + font->getStringHeight("AE");
 
-	if (renderer->getScreenWidth() != boxfbo->getWidth() || renderer->getScreenHeight() != boxfbo->getHeight()) {
-		boxfbo->allocate(renderer->getScreenWidth(), renderer->getScreenHeight());
+	const int screenwidth = renderer->getScreenWidth();
+	const int screenheight = renderer->getScreenHeight();
+	if(screenwidth > 0 && screenheight > 0
+			&& (screenwidth != boxfbo->getWidth() || screenheight != boxfbo->getHeight())) {
+		boxfbo->allocate(screenwidth, screenheight);
 	}
 }
 
@@ -83,42 +96,40 @@ void gGUIScrollable::updateScrollbar() {
 
 	// update scroll bar
 	// vertical bar
-	int scrollableheight = totalh - boxh;
-	if (scrollableheight > 0) {
+	int scrollableheight = enableverticalscroll ? totalh - boxh : 0;
+	if (enableverticalscroll && scrollableheight > 0) {
 		verticalscroll = gClamp(verticalscroll, 0, scrollableheight);
 	} else {
 		verticalscroll = 0;
 	}
 
-	scrollbarverticalsize = ((float) boxh / totalh) * boxh;
-	if (scrollbarverticalsize < barsize) {
-		scrollbarverticalsize = barsize;
-	}
+	scrollbarverticalsize = totalh > 0 ? ((float) boxh / totalh) * boxh : boxh;
+	scrollbarverticalsize = gClamp(scrollbarverticalsize, std::min(barsize, boxh), boxh);
 	if (scrollableheight > 0) {
 		// Calculate the position of the scrollbar thumb within the viewport
 		verticalscrollbarpos = ((float) verticalscroll / scrollableheight) * (boxh - scrollbarverticalsize);
 	} else {
 		verticalscrollbarpos = 0; // Set scrollbar position to the top if no scrolling is needed
 	}
+	verticalscrollbarpos = gClamp(verticalscrollbarpos, 0, std::max(0, boxh - scrollbarverticalsize));
 
 	// horizontal bar
-	int scrollablewidth = totalw - boxw;
-	if (scrollablewidth > 0) {
+	int scrollablewidth = enablehorizontalscroll ? totalw - boxw : 0;
+	if (enablehorizontalscroll && scrollablewidth > 0) {
 		horizontalscroll = gClamp(horizontalscroll, 0, scrollablewidth);
 	} else {
 		horizontalscroll = 0;
 	}
 
-	scrollbarhorizontalsize = ((float) boxw / totalw) * boxw;
-	if (scrollbarhorizontalsize < barsize) {
-		scrollbarhorizontalsize = barsize;
-	}
+	scrollbarhorizontalsize = totalw > 0 ? ((float) boxw / totalw) * boxw : boxw;
+	scrollbarhorizontalsize = gClamp(scrollbarhorizontalsize, std::min(barsize, boxw), boxw);
 	if (scrollablewidth > 0) {
 		// Calculate the position of the scrollbar thumb within the viewport
 		horizontalscrollbarpos = ((float) horizontalscroll / scrollablewidth) * (boxw - scrollbarhorizontalsize);
 	} else {
 		horizontalscrollbarpos = 0; // Set scrollbar position to the top if no scrolling is needed
 	}
+	horizontalscrollbarpos = gClamp(horizontalscrollbarpos, 0, std::max(0, boxw - scrollbarhorizontalsize));
 }
 
 void gGUIScrollable::draw() {
@@ -164,7 +175,9 @@ void gGUIScrollable::drawContent() {
 void gGUIScrollable::drawScrollbars() {
 	// render
 	gColor* oldcolor = renderer->getColor();
-	if(enableverticalscroll) {
+	const bool drawvertical = hasVerticalOverflow();
+	const bool drawhorizontal = hasHorizontalOverflow();
+	if(drawvertical) {
 		renderer->setColor(&barbackgroundcolor);
 		gDrawRectangle(boxw, toolbarh, barsize, boxh, true);
 
@@ -172,7 +185,7 @@ void gGUIScrollable::drawScrollbars() {
 		gDrawRectangle(boxw, verticalscrollbarpos, barsize, scrollbarverticalsize, true);
 	}
 
-	if(enablehorizontalscroll) {
+	if(drawhorizontal) {
 		renderer->setColor(&barbackgroundcolor);
 		gDrawRectangle(toolbarw, boxh, boxw, barsize, true);
 
@@ -180,8 +193,10 @@ void gGUIScrollable::drawScrollbars() {
 		gDrawRectangle(toolbarw + horizontalscrollbarpos, boxh, scrollbarhorizontalsize, barsize, true);
 	}
 
-	renderer->setColor(foregroundcolor);
-	gDrawRectangle(boxw + toolbarw, boxh + toolbarh, barsize, barsize, true);
+	if(drawvertical && drawhorizontal) {
+		renderer->setColor(foregroundcolor);
+		gDrawRectangle(boxw + toolbarw, boxh + toolbarh, barsize, barsize, true);
+	}
 
 	// reset color back to before
 	renderer->setColor(oldcolor);
@@ -191,11 +206,11 @@ void gGUIScrollable::mouseMoved(int x, int y) {
 }
 
 void gGUIScrollable::mousePressed(int x, int y, int button) {
-	isdraggingverticalscroll = isPointInsideVerticalScrollbar(x, y);
-	isdragginghorizontalscroll = isPointInsideHorizontalScrollbar(x, y);
+	isdraggingverticalscroll = hasVerticalOverflow() && isPointInsideVerticalScrollbar(x, y);
+	isdragginghorizontalscroll = hasHorizontalOverflow() && isPointInsideHorizontalScrollbar(x, y);
 	// double click behavior
-	if (!isdragginghorizontalscroll && isPointInsideHorizontalScrollbar(x, y, true)  && horizontalscrollclickedtime > 0.2f) {
-		verticalscrolldragstart = 0;
+	if (hasHorizontalOverflow() && !isdragginghorizontalscroll && isPointInsideHorizontalScrollbar(x, y, true)  && horizontalscrollclickedtime > 0.2f) {
+		horizontalscrolldragstart = 0;
 		isdragginghorizontalscroll = true;
 		mouseDragged(x, y, button);
 		isdragginghorizontalscroll = false;
@@ -203,8 +218,8 @@ void gGUIScrollable::mousePressed(int x, int y, int button) {
 		verticalscrolldragstart = y;
 	}
 	horizontalscrollclickedtime = 0.4f;
-	if (!isdraggingverticalscroll && isPointInsideVerticalScrollbar(x, y, true) && verticalscrollclickedtime > 0.2f) {
-		horizontalscrolldragstart = 0;
+	if (hasVerticalOverflow() && !isdraggingverticalscroll && isPointInsideVerticalScrollbar(x, y, true) && verticalscrollclickedtime > 0.2f) {
+		verticalscrolldragstart = 0;
 		isdraggingverticalscroll = true;
 		mouseDragged(x, y, button);
 		isdraggingverticalscroll = false;
@@ -215,13 +230,13 @@ void gGUIScrollable::mousePressed(int x, int y, int button) {
 }
 
 void gGUIScrollable::mouseDragged(int x, int y, int button) {
-	if(isdraggingverticalscroll && totalh > boxh) {
+	if(isdraggingverticalscroll && boxh > 0 && totalh > boxh) {
 		int pos = y - verticalscrolldragstart;
 		int diff = (float)pos / boxh * totalh;
 		verticalscroll = gClamp(verticalscroll + diff, 0, totalh - boxh);
 		verticalscrolldragstart = y;
 	}
-	if(isdragginghorizontalscroll && totalw > boxw) {
+	if(isdragginghorizontalscroll && boxw > 0 && totalw > boxw) {
 		int pos = x - horizontalscrolldragstart;
 		int diff = (float)pos / boxw * totalw;
 		horizontalscroll = gClamp(horizontalscroll + diff, 0, totalw - boxw);
@@ -264,12 +279,29 @@ int gGUIScrollable::getTitleTop() {
 	return titleheight;
 }
 
+bool gGUIScrollable::isVerticalScrollEnabled() const {
+	return enableverticalscroll;
+}
+
+bool gGUIScrollable::isHorizontalScrollEnabled() const {
+	return enablehorizontalscroll;
+}
+
+bool gGUIScrollable::hasVerticalOverflow() const {
+	return enableverticalscroll && totalh > boxh;
+}
+
+bool gGUIScrollable::hasHorizontalOverflow() const {
+	return enablehorizontalscroll && totalw > boxw;
+}
+
 void gGUIScrollable::setToolbarSpace(int toolbarW, int toolbarH) {
 	toolbarw = toolbarW;
 	toolbarh = toolbarH;
 }
 
 bool gGUIScrollable::isPointInsideVerticalScrollbar(int x, int y, bool checkFullSize) {
+	if(!hasVerticalOverflow()) return false;
 	int scrollbarsize = checkFullSize ? boxh : scrollbarverticalsize;
 	int scrollbarpos = checkFullSize ? 0 : verticalscrollbarpos;
 	int startx = left + boxw;
@@ -281,6 +313,7 @@ bool gGUIScrollable::isPointInsideVerticalScrollbar(int x, int y, bool checkFull
 }
 
 bool gGUIScrollable::isPointInsideHorizontalScrollbar(int x, int y, bool checkFullSize) {
+	if(!hasHorizontalOverflow()) return false;
 	int scrollbarsize = checkFullSize ? boxw : scrollbarhorizontalsize;
 	int scrollbarpos = checkFullSize ? 0 : horizontalscrollbarpos;
 	int startx = left + scrollbarpos;

--- a/engine/ui/gGUIScrollable.h
+++ b/engine/ui/gGUIScrollable.h
@@ -134,6 +134,10 @@ public:
 	void setToolbarSpace(int toolbarW, int toolbarH);
 
 protected:
+	bool isVerticalScrollEnabled() const;
+	bool isHorizontalScrollEnabled() const;
+	bool hasVerticalOverflow() const;
+	bool hasHorizontalOverflow() const;
 	bool isPointInsideVerticalScrollbar(int x, int y, bool checkFullSize = false);
 	bool isPointInsideHorizontalScrollbar(int x, int y, bool checkFullSize = false);
 

--- a/engine/ui/gGUIToolbar.cpp
+++ b/engine/ui/gGUIToolbar.cpp
@@ -14,6 +14,7 @@ gGUIToolbar::gGUIToolbar() {
 	toolbartype = TOOLBAR_HORIZONTAL;
 	toolbarforegroundcolor = *foregroundcolor;
 	toolbarbottomlinecolor = *backgroundcolor;
+	backgroundfillenabled = true;
 }
 
 gGUIToolbar::~gGUIToolbar() {
@@ -32,13 +33,13 @@ void gGUIToolbar::draw() {
 //	gLogi("gGUIToolbar") << "draw";
 //	gLogi("gGUIToolbar") << "l:" << left << ", t:" << top << ", w:" << width << ", h:" << height;
 	gColor* oldcolor = renderer->getColor();
-	if(toolbartype == TOOLBAR_HORIZONTAL) {
+	if(backgroundfillenabled && toolbartype == TOOLBAR_HORIZONTAL) {
 		renderer->setColor(&toolbarforegroundcolor);
 		gDrawRectangle(left, top, width, height, true);
 		renderer->setColor(&toolbarbottomlinecolor);
 		gDrawLine(left, bottom, right, bottom);
 	//	gDrawRectangle(left, top, width, height, false);
-	} else {
+	} else if(backgroundfillenabled) {
 		renderer->setColor(&toolbarforegroundcolor);
 		gDrawRectangle(left, top, width, height, true);
 		renderer->setColor(&toolbarbottomlinecolor);
@@ -212,4 +213,8 @@ void gGUIToolbar::setToolbarForegroundColor(gColor color) {
 
 void gGUIToolbar::setToolbarBottomLineColor(gColor color) {
 	toolbarbottomlinecolor = color;
+}
+
+void gGUIToolbar::enableBackgroundFill(bool enabled) {
+	backgroundfillenabled = enabled;
 }

--- a/engine/ui/gGUIToolbar.h
+++ b/engine/ui/gGUIToolbar.h
@@ -50,6 +50,7 @@ public:
 	void addSpace();
 	void setToolbarForegroundColor(gColor color);
 	void setToolbarBottomLineColor(gColor color);
+	void enableBackgroundFill(bool enabled);
 
 	void draw();
 
@@ -60,6 +61,7 @@ private:
 	std::deque<gGUIControl*> controlObjects;
 	std::deque<float> sizerPrs;
 	gColor toolbarforegroundcolor, toolbarbottomlinecolor;
+	bool backgroundfillenabled;
 
 	void resizeSizer();
 };


### PR DESCRIPTION
## Summary

- adds opt-in content scrolling to `gGUIContainer` without changing legacy container behavior
- keeps touch gesture ownership in GUI classes, including tap slop, drag cancellation, and scroll-aware hit testing
- keeps scrollbar sizing and clamping in `gGUIScrollable`
- adds responsive modern bottom navigation support to `gGUINavigation`
- updates mobile logical dimensions and the 2D projection safely across Android/iOS surface rotations
- preserves established desktop GUI input, drawing, and theme behavior
- keeps the content drag threshold as a private static `gGUIContainer` implementation detail

This PR is rebuilt on the current `main`, including merged Vulkan backend PR #1165, and supersedes #1168.

## Validation

- full macOS Release build of `GlistEngine` succeeded, including `gGLRenderEngine` and `gVKRenderEngine`
- Android arm64-v8a Debug APK build succeeded with the existing GUI scroll/navigation test application
- `git diff --check` passed
- PR diff contains only engine C++/header sources and `engine/CMakeLists.txt`

The Android runtime touch, scrolling, navigation, and rotation behavior was validated on the previous branch before rebasing these same net changes onto current `main`. No emulator was connected for an additional runtime pass after the rebase.
