### PR TITLE
Add custom cursor support

### DIFF
--- a/engine/core/gAppManager.cpp
+++ b/engine/core/gAppManager.cpp
@@ -476,6 +476,10 @@ gCursorMode gAppManager::getCursorMode() {
 	return window->getCursorMode();
 }
 
+void gAppManager::setCustomCursor(gImage& image, int hotspotX, int hotspotY){
+	window->setCustomCursor(image, hotspotX, hotspotY);
+}
+
 void gAppManager::setWindowIcon(std::string pngFullpath) {
 	window->setIcon(pngFullpath);
 }

--- a/engine/core/gAppManager.h
+++ b/engine/core/gAppManager.h
@@ -59,6 +59,7 @@ class gBaseApp;
 class gAppManager;
 class gGUIFrame;
 class gInputManager;
+class gImage;
 
 /**
  * Sets the app settings for the engine according to given name, mode of window,
@@ -322,6 +323,8 @@ public:
     void setCursor(int cursorId);
     void setCursorMode(gCursorMode cursorMode);
 	gCursorMode getCursorMode();
+
+	void setCustomCursor(gImage& image, int hotspotX, int hotspotY);
 
     void setWindowIcon(std::string pngFullpath);
     void setWindowIcon(unsigned char* imageData, int w, int h);

--- a/engine/core/gBaseWindow.cpp
+++ b/engine/core/gBaseWindow.cpp
@@ -121,6 +121,10 @@ void gBaseWindow::setCursorPos(int x, int y) {
 
 }
 
+void gBaseWindow::setCustomCursor(gImage& image, int hotspotX, int hotspotY){
+
+}
+
 void gBaseWindow::setIcon(std::string pngFullpath) {
 
 }

--- a/engine/core/gBaseWindow.h
+++ b/engine/core/gBaseWindow.h
@@ -16,6 +16,7 @@
 #include <unistd.h>
 
 class gAppManager;
+class gImage;
 
 /**
  * gBaseWindow, looks at events for the game window, sets and gets the properties of the game window.
@@ -28,7 +29,7 @@ class gBaseWindow : public gObject {
 public:
 
 	static const int WINDOWMODE_NONE = -1, WINDOWMODE_GAME = 0, WINDOWMODE_FULLSCREEN = 1, WINDOWMODE_APP = 2, WINDOWMODE_FULLSCREENGUIAPP = 3, WINDOWMODE_GUIAPP = 4;
-	static const int CURSOR_ARROW = 0, CURSOR_IBEAM = 1, CURSOR_CROSSHAIR = 2, CURSOR_HAND = 3, CURSOR_HRESIZE = 4, CURSOR_VRESIZE = 5;
+	static const int CURSOR_ARROW = 0, CURSOR_IBEAM = 1, CURSOR_CROSSHAIR = 2, CURSOR_HAND = 3, CURSOR_HRESIZE = 4, CURSOR_VRESIZE = 5, CURSOR_CUSTOM = 6;
 
 
 	gBaseWindow();
@@ -67,6 +68,8 @@ public:
 	virtual void setCursorMode(gCursorMode cursorMode);
 	gCursorMode getCursorMode();
 	virtual void setCursorPos(int x, int y);
+
+	virtual void setCustomCursor(gImage& image, int hotspotX = 0, int hotspotY = 0);
 
 	virtual void setIcon(std::string pngFullpath);
 	virtual void setIcon(unsigned char* imageData, int w, int h);

--- a/engine/core/gGLFWWindow.cpp
+++ b/engine/core/gGLFWWindow.cpp
@@ -164,7 +164,7 @@ static void glfwErrorCallback(int error, const char* description) {
 
 gGLFWWindow::gGLFWWindow() {
 	window = nullptr;
-	cursor = new GLFWcursor*[6];
+	cursor = new GLFWcursor*[7];
 	scalex = 1.0f;
 	scaley = 1.0f;
 }
@@ -274,12 +274,13 @@ void gGLFWWindow::initialize(int width, int height, int windowMode, bool isResiz
 #endif
 
 	// Create cursors
-	cursor[0] = glfwCreateStandardCursor(0x00036001);
-	cursor[1] = glfwCreateStandardCursor(0x00036002);
-	cursor[2] = glfwCreateStandardCursor(0x00036003);
-	cursor[3] = glfwCreateStandardCursor(0x00036004);
-	cursor[4] = glfwCreateStandardCursor(0x00036005);
-	cursor[5] = glfwCreateStandardCursor(0x00036006);
+	cursor[CURSOR_ARROW] = glfwCreateStandardCursor(0x00036001);
+	cursor[CURSOR_IBEAM] = glfwCreateStandardCursor(0x00036002);
+	cursor[CURSOR_CROSSHAIR] = glfwCreateStandardCursor(0x00036003);
+	cursor[CURSOR_HAND] = glfwCreateStandardCursor(0x00036004);
+	cursor[CURSOR_HRESIZE] = glfwCreateStandardCursor(0x00036005);
+	cursor[CURSOR_VRESIZE] = glfwCreateStandardCursor(0x00036006);
+	cursor[CURSOR_CUSTOM] = nullptr;
 
 	if (cursor[0]) {
 		glfwSetCursor(window, cursor[0]);
@@ -338,7 +339,7 @@ void gGLFWWindow::update() {
 
 void gGLFWWindow::close() {
 	// Clean up cursors
-	for (int i = 0; i < 6; i++) {
+	for (int i = 0; i < 7; i++) {
 		if (cursor[i]) {
 			glfwDestroyCursor(cursor[i]);
 			cursor[i] = nullptr;
@@ -357,7 +358,7 @@ void gGLFWWindow::setVsync(bool vsync) {
 }
 
 void gGLFWWindow::setCursor(int cursorNo) {
-	if (cursorNo >= 0 && cursorNo < 6 && cursor[cursorNo]) {
+	if (cursorNo >= 0 && cursorNo < 7 && cursor[cursorNo]) {
 		glfwSetCursor(window, cursor[cursorNo]);
 	}
 }
@@ -392,6 +393,35 @@ void gGLFWWindow::setCursorMode(gCursorMode cursorMode) {
 
 void gGLFWWindow::setCursorPos(int x, int y) {
 	glfwSetCursorPos(window, x / scalex, y / scaley);
+}
+
+void gGLFWWindow::setCustomCursor(gImage& image, int hotspotX, int hotspotY){
+	int w = image.getWidth();
+	int h = image.getHeight();
+	unsigned char* pixels = image.getImageData();
+
+	if(!pixels || w <= 0 || h <= 0){
+		gLogw("gGLFWWindow") << "Failed to set custom cursor: invalid gImage" << std::endl;
+		return;
+	}
+
+	GLFWimage img;
+	img.width = w;
+	img.height = h;
+	img.pixels = pixels;
+	GLFWcursor* newcursor = glfwCreateCursor(&img, hotspotX, hotspotY);
+
+	if(!newcursor){
+		gLoge("gGLFWWindow") << "Failed to create custom cursor" << std::endl;
+		return;
+	}
+	
+	if(cursor[CURSOR_CUSTOM]){
+		glfwDestroyCursor(cursor[CURSOR_CUSTOM]);
+	}
+
+	cursor[CURSOR_CUSTOM] = newcursor;
+	setCursor(CURSOR_CUSTOM);
 }
 
 void gGLFWWindow::setClipboardString(std::string text) {

--- a/engine/core/gGLFWWindow.h
+++ b/engine/core/gGLFWWindow.h
@@ -13,6 +13,7 @@
 #include <GL/glew.h>
 #include <GLFW/glfw3.h>
 #include "gCamera.h"
+#include "gImage.h"
 
 /**
  * gGLFWWindow, contain functions for game's window.
@@ -61,6 +62,8 @@ public:
 	void setCursor(int cursorNo) override;
 	void setCursorMode(gCursorMode cursorMode) override;
 	void setCursorPos(int x, int y) override;
+
+	void setCustomCursor(gImage& image, int hotspotX = 0, int hotspotY = 0);
 
 	void setClipboardString(std::string text) override;
 	std::string getClipboardString() override;


### PR DESCRIPTION
### Summary

Adds support for custom image cursors.

**Changes**
- Added `setCustomCursor` to `gBaseWindow`
- Added `setCustomCursor` to `gAppManager`
- Implemented custom cursor creation in the GLFW backend using `glfwCreateCursor`

### Example
**cpp:**
```
cursor.loadImage("cursor.png");
appmanager->setCustomCursor(cursor, 0, 0);
```