### PR TITLE
Fix Android real-device black 3D scene by including depth texture format condition

### DIFF
--- a/engine/graphics/gTexture.cpp
+++ b/engine/graphics/gTexture.cpp
@@ -68,7 +68,7 @@ gTexture::gTexture(int w, int h, int format, bool isFbo) {
 	wrapt = TEXTUREWRAP_REPEAT;
 	filtermin = TEXTUREMINMAGFILTER_LINEAR;
 	filtermag = TEXTUREMINMAGFILTER_LINEAR;
-#if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR || EMSCRIPTEN
+#if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR || EMSCRIPTEN || defined(ANDROID)
 	if(format == GL_DEPTH_COMPONENT) {
 		internalformat = GL_DEPTH_COMPONENT24;
 		valuetype = GL_UNSIGNED_INT;


### PR DESCRIPTION
- Fixes a real-device-only bug (Mali GPU tested, works fine on SwiftShader/emulator)                                                                                                                                                
  where the entire 3D scene renders completely black on Android while HUD renders fine

- Root cause: the GLES3-valid depth texture format/type combination used for shadow                                                                                                                                                 
  map depth textures (GL_DEPTH_COMPONENT24 + GL_UNSIGNED_INT) was gated behind                                                                                                                                                      
  `#if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR || EMSCRIPTEN`, missing ANDROID.                                                                                                                                                     
  Android fell through to GL_DEPTH_COMPONENT + GL_UNSIGNED_BYTE, an invalid GLES3                                                                                                                                                   
  combination that real GPU drivers reject (leaving the shadow map framebuffer                                                                                                                                                      
  incomplete), while software renderers tolerate it silently

- Tested multiple times