### PR TITLE
PR #1173 is arranged for the engine to be able to build itself for all platforms

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -578,6 +578,13 @@ elseif(IOS)
 	# These are added by gipIOS plugin
 	# Do not remove this block
 elseif(WIN32)
+	find_package(Vulkan QUIET)
+	if(Vulkan_FOUND)
+		set(Lib_Vulkan Vulkan::Vulkan)
+		target_compile_definitions(GlistEngine PRIVATE GLIST_HAS_VULKAN)
+	else()
+		message(STATUS "Vulkan development files not found; Vulkan backend disabled")
+	endif()
     link_directories(
             ${MINGW64_DIR}/bin
             ${MINGW64_DIR}/lib
@@ -594,6 +601,14 @@ elseif(LINUX)
 #	    OUTPUT_STRIP_TRAILING_WHITESPACE)
 #	string(STRIP ${CL_TMP_VAR} CL_VAR_1)
 #	add_definitions(${CL_VAR_1})
+
+	find_package(Vulkan QUIET)
+	if(Vulkan_FOUND)
+		set(Lib_Vulkan Vulkan::Vulkan)
+		target_compile_definitions(GlistEngine PRIVATE GLIST_HAS_VULKAN)
+	else()
+		message(STATUS "Vulkan development files not found; Vulkan backend disabled")
+	endif()
 	
 	add_library(glfw SHARED IMPORTED)
 	set_target_properties(glfw PROPERTIES IMPORTED_LOCATION
@@ -611,15 +626,23 @@ elseif(LINUX)
 	set_target_properties(freetype PROPERTIES IMPORTED_LOCATION
 			${MINGW64_DIR}/lib/libfreetype.so)
 elseif(APPLE)
-    set(APPLE_LIBDIR "/opt/homebrew/lib")
     find_package(PkgConfig REQUIRED)
-    set(ENV{PKG_CONFIG_PATH} "${APPLE_LIBDIR}/pkgconfig")
     
     pkg_check_modules(curl     REQUIRED IMPORTED_TARGET libcurl)
     pkg_check_modules(freetype REQUIRED IMPORTED_TARGET freetype2)
     pkg_check_modules(glfw     REQUIRED IMPORTED_TARGET glfw3)
     pkg_check_modules(assimp   REQUIRED IMPORTED_TARGET assimp)
     pkg_check_modules(glew     REQUIRED IMPORTED_TARGET glew)
+    # Vulkan on macOS is provided by MoltenVK via the Homebrew vulkan-loader,
+    # resolved through pkg-config like the rest of the stack. The imported target
+    # carries the header include dirs and links the loader.
+    pkg_check_modules(vulkan QUIET IMPORTED_TARGET vulkan)
+    if(vulkan_FOUND)
+        set(Lib_Vulkan PkgConfig::vulkan)
+        target_compile_definitions(GlistEngine PRIVATE GLIST_HAS_VULKAN)
+    else()
+        message(STATUS "Vulkan development files not found; Vulkan backend disabled")
+    endif()
 
     find_library(Lib_GL GL HINTS ${OSX_SDK_PATH}/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries)
 
@@ -656,7 +679,7 @@ elseif(WIN32)
 		glfw3
 		opengl32
 		glew32
-		vulkan-1
+		${Lib_Vulkan}
 		dbghelp
 		Shcore
 #		msvcr100
@@ -686,6 +709,7 @@ elseif(LINUX)
 		glfw
 		GL
 		GLEW
+		${Lib_Vulkan}
 		dl
 	# TODO: FFMPEG
 	)
@@ -697,6 +721,7 @@ elseif(APPLE)
 		PkgConfig::glfw
 		${Lib_GL}
 		PkgConfig::glew
+		${Lib_Vulkan}
 		${Lib_crypto}
 #		${Lib_cpp}
 	# TODO: FFMPEG

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -578,12 +578,11 @@ elseif(IOS)
 	# These are added by gipIOS plugin
 	# Do not remove this block
 elseif(WIN32)
-	find_package(Vulkan QUIET)
-	if(Vulkan_FOUND)
-		set(Lib_Vulkan Vulkan::Vulkan)
+	if(EXISTS "${MINGW64_DIR}/include/vulkan/vulkan.h")
+		set(Lib_Vulkan vulkan-1)
 		target_compile_definitions(GlistEngine PRIVATE GLIST_HAS_VULKAN)
 	else()
-		message(STATUS "Vulkan development files not found; Vulkan backend disabled")
+		message(STATUS "Vulkan development files not found in zbin; Vulkan backend disabled")
 	endif()
     link_directories(
             ${MINGW64_DIR}/bin

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -578,8 +578,13 @@ elseif(IOS)
 	# These are added by gipIOS plugin
 	# Do not remove this block
 elseif(WIN32)
-	if(EXISTS "${MINGW64_DIR}/include/vulkan/vulkan.h")
-		set(Lib_Vulkan vulkan-1)
+	find_library(GLIST_VULKAN_LIBRARY
+		NAMES vulkan-1
+		PATHS "${MINGW64_DIR}/lib"
+		NO_DEFAULT_PATH
+	)
+	if(EXISTS "${MINGW64_DIR}/include/vulkan/vulkan.h" AND GLIST_VULKAN_LIBRARY)
+		set(Lib_Vulkan "${GLIST_VULKAN_LIBRARY}")
 		target_compile_definitions(GlistEngine PRIVATE GLIST_HAS_VULKAN)
 	else()
 		message(STATUS "Vulkan development files not found in zbin; Vulkan backend disabled")

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -656,6 +656,7 @@ elseif(WIN32)
 		glfw3
 		opengl32
 		glew32
+		vulkan-1
 		dbghelp
 		Shcore
 #		msvcr100

--- a/engine/core/gAppManager.cpp
+++ b/engine/core/gAppManager.cpp
@@ -178,6 +178,14 @@ void gAppManager::setup() {
     if(setupcomplete) {
         return;
     }
+    // App setup loads images, fonts and shaders through the OpenGL path. It is
+    // skipped while the Vulkan backend has no rendering path, otherwise it would
+    // call GL functions without a context.
+    if(renderengine == G_RENDERER_VK) {
+        gLogi("gAppManager") << "Vulkan backend: skipping app setup until the Vulkan rendering path is implemented.";
+        setupcomplete = true;
+        return;
+    }
     app->setup();
     setupcomplete = true;
 }
@@ -211,14 +219,18 @@ void gAppManager::initialize() {
 		}
 		// Create renderer
 		gRenderObject::createRenderer(renderengine);
-		gBaseGUIObject::initializeResources();
+		// The engine's GUI resources are OpenGL based. Under the Vulkan backend the
+		// window carries no GL context, so they stay uninitialised until the Vulkan
+		// rendering path exists.
+		const bool isvulkanbackend = (renderengine == G_RENDERER_VK);
+		if(!isvulkanbackend) gBaseGUIObject::initializeResources();
 		// Update renderer dimensions
 		renderer->setScreenSize(width, height);
 		renderer->setUnitScreenSize(unitwidth, unitheight);
 		renderer->setScreenScaling(screenscaling);
 
 		// Create managers if not created
-		if(!guimanager) {
+		if(!isvulkanbackend && !guimanager) {
 			guimanager = new gGUIManager(app, renderer->getWidth(), renderer->getHeight());
 			guimanager->getCurrentFrame()->getRenderer()->updateLights();
 		}
@@ -413,7 +425,7 @@ void gAppManager::setScreenSize(int width, int height) {
     if(iscanvasset && canvasmanager->getCurrentCanvas()) {
 	    canvasmanager->getCurrentCanvas()->windowResized(renderer->getWidth(), renderer->getHeight());
     }
-    if(iscanvasset && guimanager->isframeset) {
+    if(iscanvasset && guimanager != nullptr && guimanager->isframeset) {
 	    guimanager->windowResized(renderer->getWidth(), renderer->getHeight());
     }
 }
@@ -542,6 +554,16 @@ void gAppManager::tick() {
         return;
     }
 
+    // The Vulkan backend initialises only: there is no GL context and no Vulkan
+    // frame path yet, so the frame body is skipped. Events are still polled so the
+    // window stays responsive and closable.
+    if(renderengine == G_RENDERER_VK) {
+        if(inputmanager) inputmanager->update();
+        window->update();
+        executeQueue();
+        return;
+    }
+
     if(canvasmanager) canvasmanager->update();
     if(guimanager) guimanager->update();
     if(!isguiapp) {
@@ -659,7 +681,7 @@ bool gAppManager::onWindowScaleChangedEvent(gWindowScaleChangedEvent& event) {
 
 bool gAppManager::onCharTypedEvent(gCharTypedEvent& event) {
 //	if (!canvasmanager || !getCurrentCanvas()) return true;
-    if(guimanager->isframeset) guimanager->charPressed(event.getCharacter());
+    if(guimanager != nullptr && guimanager->isframeset) guimanager->charPressed(event.getCharacter());
     for (gBasePlugin*& plugin : gBasePlugin::usedplugins) plugin->charPressed(event.getCharacter());
     if(canvasmanager && getCurrentCanvas()) getCurrentCanvas()->charPressed(event.getCharacter());
     return false;
@@ -667,7 +689,7 @@ bool gAppManager::onCharTypedEvent(gCharTypedEvent& event) {
 
 bool gAppManager::onKeyPressedEvent(gKeyPressedEvent& event) {
 //    if (!canvasmanager || !getCurrentCanvas()) return true;
-    if(guimanager->isframeset) guimanager->keyPressed(event.getKeyCode());
+    if(guimanager != nullptr && guimanager->isframeset) guimanager->keyPressed(event.getKeyCode());
     for (gBasePlugin*& plugin : gBasePlugin::usedplugins) plugin->keyPressed(event.getKeyCode());
     if(canvasmanager && getCurrentCanvas()) getCurrentCanvas()->keyPressed(event.getKeyCode());
     return false;
@@ -675,7 +697,7 @@ bool gAppManager::onKeyPressedEvent(gKeyPressedEvent& event) {
 
 bool gAppManager::onKeyReleasedEvent(gKeyReleasedEvent& event) {
 //    if (!canvasmanager || !getCurrentCanvas()) return true;
-    if(guimanager->isframeset) guimanager->keyReleased(event.getKeyCode());
+    if(guimanager != nullptr && guimanager->isframeset) guimanager->keyReleased(event.getKeyCode());
     for (gBasePlugin*& plugin : gBasePlugin::usedplugins) plugin->keyReleased(event.getKeyCode());
     if(canvasmanager && getCurrentCanvas()) canvasmanager->getCurrentCanvas()->keyReleased(event.getKeyCode());
     return false;
@@ -690,11 +712,11 @@ bool gAppManager::onMouseMovedEvent(gMouseMovedEvent& event) {
         ypos = gRenderer::scaleY(event.getY());
     }
     if(mousebuttonstate) {
-        if(guimanager->isframeset) guimanager->mouseDragged(xpos, ypos, mousebuttonstate);
+        if(guimanager != nullptr && guimanager->isframeset) guimanager->mouseDragged(xpos, ypos, mousebuttonstate);
         for(gBasePlugin*& plugin : gBasePlugin::usedplugins) plugin->mouseDragged(xpos, ypos, mousebuttonstate);
         if(canvasmanager && getCurrentCanvas()) canvasmanager->getCurrentCanvas()->mouseDragged(xpos, ypos, mousebuttonstate);
     } else {
-        if(guimanager->isframeset) guimanager->mouseMoved(xpos, ypos);
+        if(guimanager != nullptr && guimanager->isframeset) guimanager->mouseMoved(xpos, ypos);
         for(gBasePlugin*& plugin : gBasePlugin::usedplugins) plugin->mouseMoved(xpos, ypos);
         if(canvasmanager && getCurrentCanvas()) canvasmanager->getCurrentCanvas()->mouseMoved(xpos, ypos);
     }
@@ -711,7 +733,7 @@ bool gAppManager::onMouseButtonPressedEvent(gMouseButtonPressedEvent& event) {
         xpos = gRenderer::scaleX(event.getX());
         ypos = gRenderer::scaleY(event.getY());
     }
-    if(guimanager->isframeset) guimanager->mousePressed(xpos, ypos, event.getMouseButton());
+    if(guimanager != nullptr && guimanager->isframeset) guimanager->mousePressed(xpos, ypos, event.getMouseButton());
     for(gBasePlugin*& plugin : gBasePlugin::usedplugins) plugin->mousePressed(xpos, ypos, event.getMouseButton());
     if(canvasmanager && getCurrentCanvas()) canvasmanager->getCurrentCanvas()->mousePressed(xpos, ypos, event.getMouseButton());
     return false;
@@ -727,7 +749,7 @@ bool gAppManager::onMouseButtonReleasedEvent(gMouseButtonReleasedEvent& event) {
         xpos = gRenderer::scaleX(event.getX());
         ypos = gRenderer::scaleY(event.getY());
     }
-    if(guimanager->isframeset) guimanager->mouseReleased(xpos, ypos, event.getMouseButton());
+    if(guimanager != nullptr && guimanager->isframeset) guimanager->mouseReleased(xpos, ypos, event.getMouseButton());
     for(gBasePlugin*& plugin : gBasePlugin::usedplugins) plugin->mouseReleased(xpos, ypos, event.getMouseButton());
     if(canvasmanager && getCurrentCanvas()) canvasmanager->getCurrentCanvas()->mouseReleased(xpos, ypos, event.getMouseButton());
     return false;
@@ -751,7 +773,7 @@ bool gAppManager::onWindowMouseExitEvent(gWindowMouseExitEvent& event) {
 
 bool gAppManager::onMouseScrolledEvent(gMouseScrolledEvent& event) {
 //    if (!canvasmanager || !getCurrentCanvas()) return true;
-    if(guimanager->isframeset) guimanager->mouseScrolled(event.getOffsetX(), event.getOffsetY());
+    if(guimanager != nullptr && guimanager->isframeset) guimanager->mouseScrolled(event.getOffsetX(), event.getOffsetY());
     for (gBasePlugin*& plugin : gBasePlugin::usedplugins) plugin->mouseScrolled(event.getOffsetX(), event.getOffsetY());
     if(canvasmanager && getCurrentCanvas()) canvasmanager->getCurrentCanvas()->mouseScrolled(event.getOffsetX(), event.getOffsetY());
     return false;

--- a/engine/core/gGLFWWindow.cpp
+++ b/engine/core/gGLFWWindow.cpp
@@ -199,14 +199,31 @@ void gGLFWWindow::initialize(int width, int height, int windowMode, bool isResiz
 		return;
 	}
 
+	// --- Render backend selection (single, safe decision point) ---
+	// The window is created before the renderer, so the backend has to be final
+	// here; otherwise the window and the renderer could disagree.
+	bool usevulkan = (appmanager != nullptr && appmanager->getRenderEngine() == G_RENDERER_VK);
+	if (usevulkan && !glfwVulkanSupported()) {
+		gLoge("gGLFWWindow") << "Vulkan backend requested but not available at runtime "
+								"(is the Vulkan loader installed?). Falling back to OpenGL." << std::endl;
+		usevulkan = false;
+		if (appmanager != nullptr) appmanager->setRenderEngine(G_RENDERER_GL);
+	}
+
 	// Configure glfw
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
-	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+	if (usevulkan) {
+		// Vulkan renders to a surface it creates itself, so the window must not
+		// carry an OpenGL context.
+		glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+	} else {
+		glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+		glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+		glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
 #if TARGET_OS_OSX
-	glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE); //case_mac
+		glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE); //case_mac
 #endif
+	}
 
 	// All hints available at https://www.glfw.org/docs/latest/window.html#window_hints
 
@@ -286,14 +303,18 @@ void gGLFWWindow::initialize(int width, int height, int windowMode, bool isResiz
 		glfwSetCursor(window, cursor[0]);
 	}
 
-	glfwMakeContextCurrent(window);
-    glfwSwapInterval(vsync ? 1 : 0);
-	glewExperimental = GL_TRUE;
-	GLenum glewError = glewInit();
-	if (glewError != GLEW_OK) {
-		gLoge("gGLFWWindow") << "Failed to initialize GLEW: " << glewGetErrorString(glewError) << std::endl;
-		glfwTerminate();
-		return;
+	// OpenGL context management and GLEW are meaningless under Vulkan; that
+	// window has no client API at all.
+	if (!usevulkan) {
+		glfwMakeContextCurrent(window);
+		glfwSwapInterval(vsync ? 1 : 0);
+		glewExperimental = GL_TRUE;
+		GLenum glewError = glewInit();
+		if (glewError != GLEW_OK) {
+			gLoge("gGLFWWindow") << "Failed to initialize GLEW: " << glewGetErrorString(glewError) << std::endl;
+			glfwTerminate();
+			return;
+		}
 	}
 
 //	if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {
@@ -332,8 +353,11 @@ bool gGLFWWindow::getShouldClose() {
 
 void gGLFWWindow::update() {
 	G_PROFILE_ZONE_SCOPED_N("gGLFWWindow::update()");
-	// End window drawing
-	G_CHECK_GL(glfwSwapBuffers(window));
+	// End window drawing. A GLFW_NO_API window (Vulkan) owns no buffers to swap,
+	// and asking GLFW to swap them raises GLFW_NO_WINDOW_CONTEXT.
+	if(appmanager == nullptr || appmanager->getRenderEngine() != G_RENDERER_VK) {
+		G_CHECK_GL(glfwSwapBuffers(window));
+	}
 	G_CHECK_GL(glfwPollEvents());
 }
 

--- a/engine/core/gGLFWWindow.cpp
+++ b/engine/core/gGLFWWindow.cpp
@@ -203,6 +203,14 @@ void gGLFWWindow::initialize(int width, int height, int windowMode, bool isResiz
 	// The window is created before the renderer, so the backend has to be final
 	// here; otherwise the window and the renderer could disagree.
 	bool usevulkan = (appmanager != nullptr && appmanager->getRenderEngine() == G_RENDERER_VK);
+#if !defined(GLIST_HAS_VULKAN)
+	if(usevulkan) {
+		gLoge("gGLFWWindow") << "Vulkan backend requested but Vulkan development support "
+								"was not available when GlistEngine was built. Falling back to OpenGL." << std::endl;
+		usevulkan = false;
+		appmanager->setRenderEngine(G_RENDERER_GL);
+	}
+#endif
 	if (usevulkan && !glfwVulkanSupported()) {
 		gLoge("gGLFWWindow") << "Vulkan backend requested but not available at runtime "
 								"(is the Vulkan loader installed?). Falling back to OpenGL." << std::endl;
@@ -538,4 +546,3 @@ void gGLFWWindow::setScale(float x, float y) {
 	callEvent(event);
 	setSize(width, height);
 }
-

--- a/engine/core/gGLFWWindow.h
+++ b/engine/core/gGLFWWindow.h
@@ -90,6 +90,9 @@ public:
 
 	void setScale(float x, float y);
 
+	// The Vulkan backend needs the raw handle to create its surface.
+	GLFWwindow* getGLFWWindow() const { return window; }
+
   private:
 	GLFWwindow* window;
 	GLFWcursor** cursor;

--- a/engine/core/gVKRenderEngine.cpp
+++ b/engine/core/gVKRenderEngine.cpp
@@ -20,7 +20,7 @@
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
 #endif
-#if !defined(ANDROID) && !defined(EMSCRIPTEN) && !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
+#if defined(GLIST_HAS_VULKAN) && !defined(ANDROID) && !defined(EMSCRIPTEN) && !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
 	#define GVK_DESKTOP_GLFW 1
 	#define GLFW_INCLUDE_VULKAN
 	#include <vulkan/vulkan.h>

--- a/engine/core/gVKRenderEngine.cpp
+++ b/engine/core/gVKRenderEngine.cpp
@@ -12,7 +12,27 @@
 #include "gShader.h"
 #include "gTracy.h"
 
+// Vulkan is only wired up on the desktop GLFW platforms. This file is compiled
+// everywhere, but gGLFWWindow.cpp is desktop only, so the guard below mirrors
+// the CMake condition exactly. <vulkan/vulkan.h> must be included before GLFW
+// so that glfwCreateWindowSurface / glfwGetRequiredInstanceExtensions become
+// visible.
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+#if !defined(ANDROID) && !defined(EMSCRIPTEN) && !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
+	#define GVK_DESKTOP_GLFW 1
+	#define GLFW_INCLUDE_VULKAN
+	#include <vulkan/vulkan.h>
+	#include "gGLFWWindow.h"
+	#include "gAppManager.h"
+	#include <vector>
+	#include <set>
+	#include <cstring>
+#endif
+
 gVKRenderEngine::~gVKRenderEngine() {
+	cleanupVulkan();
 	delete originalgrid;
 }
 
@@ -675,39 +695,345 @@ void gVKRenderEngine::popMatrix() {
 #endif
 }
 
-#if !defined(GLIST_OPENGLES) && (defined(DEBUG) || defined(ENGINE_OPENGL_CHECKS))
-// Made static (internal linkage) so it does not collide with the identically-named
-// callback in gGLRenderEngine.cpp when both are compiled in a DEBUG build.
-static void GLAPIENTRY openglErrorCallback(GLenum source, GLenum type, GLuint id,
-								   GLenum severity, GLsizei length,
-								   const GLchar* message, const void* userParam) {
-	if (severity == GL_DEBUG_SEVERITY_NOTIFICATION) {
-		return;
+#ifdef GVK_DESKTOP_GLFW
+
+// Every Vulkan handle lives here so the header stays Vulkan free. All members
+// start as VK_NULL_HANDLE, which is what makes the "destroy only if non null"
+// teardown correct even when initialisation fails half way through.
+struct gVKContext {
+	VkInstance instance = VK_NULL_HANDLE;
+	VkDebugUtilsMessengerEXT debugmessenger = VK_NULL_HANDLE;
+	VkSurfaceKHR surface = VK_NULL_HANDLE;
+	VkPhysicalDevice physicaldevice = VK_NULL_HANDLE;
+	VkDevice device = VK_NULL_HANDLE;
+	VkQueue graphicsqueue = VK_NULL_HANDLE;
+	VkQueue presentqueue = VK_NULL_HANDLE;
+	uint32_t graphicsfamily = 0;
+	uint32_t presentfamily = 0;
+};
+
+// Validation layers cost performance, so they follow the same DEBUG condition
+// the OpenGL debug output already uses in this engine.
+#if defined(DEBUG) || defined(ENGINE_OPENGL_CHECKS)
+static constexpr bool gvkenablevalidation = true;
+#else
+static constexpr bool gvkenablevalidation = false;
+#endif
+
+static const char* const GVK_VALIDATION_LAYER = "VK_LAYER_KHRONOS_validation";
+
+// Routes validation output into the engine log instead of stderr, so Vulkan
+// problems show up next to every other engine message.
+static VKAPI_ATTR VkBool32 VKAPI_CALL gvkDebugCallback(
+		VkDebugUtilsMessageSeverityFlagBitsEXT severity,
+		VkDebugUtilsMessageTypeFlagsEXT type,
+		const VkDebugUtilsMessengerCallbackDataEXT* data,
+		void* userdata) {
+	if(severity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) {
+		gLoge("gVKRenderEngine") << "Validation: " << data->pMessage;
+	} else if(severity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) {
+		gLogw("gVKRenderEngine") << "Validation: " << data->pMessage;
+	}
+	return VK_FALSE;
+}
+
+static bool gvkHasLayer(const char* name) {
+	uint32_t count = 0;
+	if(vkEnumerateInstanceLayerProperties(&count, nullptr) != VK_SUCCESS || count == 0) return false;
+	std::vector<VkLayerProperties> items(count);
+	vkEnumerateInstanceLayerProperties(&count, items.data());
+	for(const auto& item : items) {
+		if(strcmp(item.layerName, name) == 0) return true;
+	}
+	return false;
+}
+
+static bool gvkHasInstanceExtension(const char* name) {
+	uint32_t count = 0;
+	if(vkEnumerateInstanceExtensionProperties(nullptr, &count, nullptr) != VK_SUCCESS || count == 0) return false;
+	std::vector<VkExtensionProperties> items(count);
+	vkEnumerateInstanceExtensionProperties(nullptr, &count, items.data());
+	for(const auto& item : items) {
+		if(strcmp(item.extensionName, name) == 0) return true;
+	}
+	return false;
+}
+
+#endif
+
+
+bool gVKRenderEngine::initVulkan() {
+#ifndef GVK_DESKTOP_GLFW
+	gLoge("gVKRenderEngine") << "Vulkan backend is not supported on this platform.";
+	return false;
+#else
+	vkcontext = new gVKContext();
+	gVKContext* ctx = vkcontext;
+
+#if defined(__APPLE__)
+	// MoltenVK (the macOS driver) and the Homebrew validation layers are not on
+	// the loader's default search path. The trailing 0 means "do not overwrite",
+	// so an explicitly exported value always wins.
+#ifdef GLIST_VK_ICD_FILE
+	setenv("VK_ICD_FILENAMES", GLIST_VK_ICD_FILE, 0);
+#endif
+#ifdef GLIST_VK_LAYER_PATH
+	setenv("VK_LAYER_PATH", GLIST_VK_LAYER_PATH, 0);
+#endif
+#endif
+
+	gGLFWWindow* glfwwindow = dynamic_cast<gGLFWWindow*>(appmanager != nullptr ? appmanager->getWindow() : nullptr);
+	if(glfwwindow == nullptr) {
+		gLoge("gVKRenderEngine") << "Vulkan init: no GLFW window available for surface creation.";
+		cleanupVulkan();
+		return false;
+	}
+	GLFWwindow* handle = glfwwindow->getGLFWWindow();
+	if(handle == nullptr) {
+		gLoge("gVKRenderEngine") << "Vulkan init: the GLFW window handle is null.";
+		cleanupVulkan();
+		return false;
 	}
 
-	gLoge("gVKRenderEngine") << "Received OpenGL Debug Message: "<<
-			"src: " << source << "\n"
-			"type: " << type << "\n"
-			"id: " << id << "\n"
-			"severity: " << severity << "\n"
-			"message: " << message;
-	// We flush here because it might not show on the console immediately, having this function being spammed will slow down the game but for purpose of debugging, it is required.
-	std::cerr << std::flush;
-}
+	/* ---------------- instance ---------------- */
+	// Asking GLFW for the surface extensions keeps this portable instead of
+	// hardcoding VK_KHR_win32_surface / VK_EXT_metal_surface per platform.
+	uint32_t glfwextcount = 0;
+	const char** glfwexts = glfwGetRequiredInstanceExtensions(&glfwextcount);
+	if(glfwexts == nullptr) {
+		gLoge("gVKRenderEngine") << "Vulkan init: GLFW could not report the required instance extensions.";
+		cleanupVulkan();
+		return false;
+	}
+	std::vector<const char*> extensions(glfwexts, glfwexts + glfwextcount);
+
+#if defined(__APPLE__)
+	// MoltenVK is a portability driver: without these the loader does not even
+	// enumerate it and vkCreateInstance fails with VK_ERROR_INCOMPATIBLE_DRIVER.
+	// They are Apple only - requesting them on a conformant driver would fail.
+	extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+	extensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 #endif
+
+	// Only ask for the layer if it is actually installed; requesting a missing
+	// layer makes vkCreateInstance fail outright.
+	std::vector<const char*> layers;
+	bool usevalidation = false;
+	if(gvkenablevalidation) {
+		if(gvkHasLayer(GVK_VALIDATION_LAYER) && gvkHasInstanceExtension(VK_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
+			layers.push_back(GVK_VALIDATION_LAYER);
+			extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+			usevalidation = true;
+		} else {
+			gLogi("gVKRenderEngine") << "Validation layer not found, continuing without it. "
+					"Point VK_LAYER_PATH at the folder holding VkLayer_khronos_validation.json to enable it.";
+		}
+	}
+
+	VkApplicationInfo appinfo{};
+	appinfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+	appinfo.pApplicationName = "GlistApp";
+	appinfo.applicationVersion = VK_MAKE_API_VERSION(0, 1, 0, 0);
+	appinfo.pEngineName = "GlistEngine";
+	appinfo.engineVersion = VK_MAKE_API_VERSION(0, 1, 0, 0);
+	appinfo.apiVersion = VK_API_VERSION_1_2;
+
+	VkInstanceCreateInfo instanceinfo{};
+	instanceinfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+	instanceinfo.pApplicationInfo = &appinfo;
+#if defined(__APPLE__)
+	instanceinfo.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+#endif
+	instanceinfo.enabledExtensionCount = static_cast<uint32_t>(extensions.size());
+	instanceinfo.ppEnabledExtensionNames = extensions.data();
+	instanceinfo.enabledLayerCount = static_cast<uint32_t>(layers.size());
+	instanceinfo.ppEnabledLayerNames = layers.empty() ? nullptr : layers.data();
+
+	VkResult result = vkCreateInstance(&instanceinfo, nullptr, &ctx->instance);
+	if(result != VK_SUCCESS) {
+		gLoge("gVKRenderEngine") << "vkCreateInstance failed! VkResult: " << result;
+		cleanupVulkan();
+		return false;
+	}
+
+	/* ---------------- debug messenger ---------------- */
+	if(usevalidation) {
+		VkDebugUtilsMessengerCreateInfoEXT debuginfo{};
+		debuginfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
+		debuginfo.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
+				VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+		debuginfo.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT |
+				VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT |
+				VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
+		debuginfo.pfnUserCallback = gvkDebugCallback;
+		// Extension entry points are not exported by the loader, so fetch them.
+		auto createmessenger = (PFN_vkCreateDebugUtilsMessengerEXT)
+				vkGetInstanceProcAddr(ctx->instance, "vkCreateDebugUtilsMessengerEXT");
+		if(createmessenger != nullptr) {
+			createmessenger(ctx->instance, &debuginfo, nullptr, &ctx->debugmessenger);
+		}
+	}
+
+	/* ---------------- surface ---------------- */
+	// GLFW creates it, so the engine never touches Win32/Cocoa/Metal directly.
+	result = glfwCreateWindowSurface(ctx->instance, handle, nullptr, &ctx->surface);
+	if(result != VK_SUCCESS) {
+		gLoge("gVKRenderEngine") << "glfwCreateWindowSurface failed! VkResult: " << result;
+		cleanupVulkan();
+		return false;
+	}
+
+	/* ---------------- physical device ---------------- */
+	uint32_t devicecount = 0;
+	vkEnumeratePhysicalDevices(ctx->instance, &devicecount, nullptr);
+	if(devicecount == 0) {
+		gLoge("gVKRenderEngine") << "No Vulkan capable GPU was found.";
+		cleanupVulkan();
+		return false;
+	}
+	std::vector<VkPhysicalDevice> devices(devicecount);
+	vkEnumeratePhysicalDevices(ctx->instance, &devicecount, devices.data());
+
+	// A GPU is usable only if it can both render and present to our surface, and
+	// in Vulkan those are separate queue family capabilities queried per family.
+	for(const auto& dev : devices) {
+		uint32_t familycount = 0;
+		vkGetPhysicalDeviceQueueFamilyProperties(dev, &familycount, nullptr);
+		if(familycount == 0) continue;
+		std::vector<VkQueueFamilyProperties> families(familycount);
+		vkGetPhysicalDeviceQueueFamilyProperties(dev, &familycount, families.data());
+
+		bool foundgraphics = false, foundpresent = false;
+		uint32_t graphics = 0, present = 0;
+		for(uint32_t i = 0; i < familycount; i++) {
+			if(!foundgraphics && (families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT)) {
+				graphics = i;
+				foundgraphics = true;
+			}
+			VkBool32 presentsupport = VK_FALSE;
+			vkGetPhysicalDeviceSurfaceSupportKHR(dev, i, ctx->surface, &presentsupport);
+			if(!foundpresent && presentsupport == VK_TRUE) {
+				present = i;
+				foundpresent = true;
+			}
+		}
+		if(foundgraphics && foundpresent) {
+			ctx->physicaldevice = dev;
+			ctx->graphicsfamily = graphics;
+			ctx->presentfamily = present;
+			break;
+		}
+	}
+	if(ctx->physicaldevice == VK_NULL_HANDLE) {
+		gLoge("gVKRenderEngine") << "No GPU can both render and present to this surface.";
+		cleanupVulkan();
+		return false;
+	}
+
+	/* ---------------- logical device ---------------- */
+	// A set, because graphics and present are usually the same family and the
+	// same family must not be requested twice.
+	std::set<uint32_t> uniquefamilies = {ctx->graphicsfamily, ctx->presentfamily};
+	std::vector<VkDeviceQueueCreateInfo> queueinfos;
+	float queuepriority = 1.0f;
+	for(uint32_t family : uniquefamilies) {
+		VkDeviceQueueCreateInfo queueinfo{};
+		queueinfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+		queueinfo.queueFamilyIndex = family;
+		queueinfo.queueCount = 1;
+		queueinfo.pQueuePriorities = &queuepriority;
+		queueinfos.push_back(queueinfo);
+	}
+
+	// Swapchain is requested now because presentation is the next phase and
+	// asking here proves the device supports it.
+	std::vector<const char*> deviceextensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME};
+	// VK_KHR_portability_subset is mandatory on portability drivers such as
+	// MoltenVK and absent on conformant ones, so it is queried, never assumed.
+	uint32_t devextcount = 0;
+	vkEnumerateDeviceExtensionProperties(ctx->physicaldevice, nullptr, &devextcount, nullptr);
+	if(devextcount > 0) {
+		std::vector<VkExtensionProperties> devexts(devextcount);
+		vkEnumerateDeviceExtensionProperties(ctx->physicaldevice, nullptr, &devextcount, devexts.data());
+		for(const auto& ext : devexts) {
+			if(strcmp(ext.extensionName, "VK_KHR_portability_subset") == 0) {
+				deviceextensions.push_back("VK_KHR_portability_subset");
+				break;
+			}
+		}
+	}
+
+	VkPhysicalDeviceFeatures devicefeatures{};
+	VkDeviceCreateInfo deviceinfo{};
+	deviceinfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+	deviceinfo.queueCreateInfoCount = static_cast<uint32_t>(queueinfos.size());
+	deviceinfo.pQueueCreateInfos = queueinfos.data();
+	deviceinfo.pEnabledFeatures = &devicefeatures;
+	deviceinfo.enabledExtensionCount = static_cast<uint32_t>(deviceextensions.size());
+	deviceinfo.ppEnabledExtensionNames = deviceextensions.data();
+	deviceinfo.enabledLayerCount = static_cast<uint32_t>(layers.size());
+	deviceinfo.ppEnabledLayerNames = layers.empty() ? nullptr : layers.data();
+
+	result = vkCreateDevice(ctx->physicaldevice, &deviceinfo, nullptr, &ctx->device);
+	if(result != VK_SUCCESS) {
+		gLoge("gVKRenderEngine") << "vkCreateDevice failed! VkResult: " << result;
+		cleanupVulkan();
+		return false;
+	}
+	vkGetDeviceQueue(ctx->device, ctx->graphicsfamily, 0, &ctx->graphicsqueue);
+	vkGetDeviceQueue(ctx->device, ctx->presentfamily, 0, &ctx->presentqueue);
+
+	VkPhysicalDeviceProperties props{};
+	vkGetPhysicalDeviceProperties(ctx->physicaldevice, &props);
+	gLogi("gVKRenderEngine") << "Vulkan Instance successfully created! API Version: "
+			<< VK_API_VERSION_MAJOR(props.apiVersion) << "."
+			<< VK_API_VERSION_MINOR(props.apiVersion) << "."
+			<< VK_API_VERSION_PATCH(props.apiVersion);
+	gLogi("gVKRenderEngine") << "Vulkan device: " << props.deviceName
+			<< " | graphics family: " << ctx->graphicsfamily
+			<< " | present family: " << ctx->presentfamily
+			<< " | validation: " << (usevalidation ? "on" : "off");
+	return true;
+#endif
+}
+
+
+void gVKRenderEngine::cleanupVulkan() {
+#ifdef GVK_DESKTOP_GLFW
+	if(vkcontext == nullptr) return;
+	gVKContext* ctx = vkcontext;
+	// Strict reverse creation order: Vulkan requires children to be destroyed
+	// before their parent, and the surface must die before its instance.
+	if(ctx->device != VK_NULL_HANDLE) vkDestroyDevice(ctx->device, nullptr);
+	if(ctx->surface != VK_NULL_HANDLE) vkDestroySurfaceKHR(ctx->instance, ctx->surface, nullptr);
+	if(ctx->debugmessenger != VK_NULL_HANDLE) {
+		auto destroymessenger = (PFN_vkDestroyDebugUtilsMessengerEXT)
+				vkGetInstanceProcAddr(ctx->instance, "vkDestroyDebugUtilsMessengerEXT");
+		if(destroymessenger != nullptr) destroymessenger(ctx->instance, ctx->debugmessenger, nullptr);
+	}
+	if(ctx->instance != VK_NULL_HANDLE) vkDestroyInstance(ctx->instance, nullptr);
+	delete vkcontext;
+#endif
+	vkcontext = nullptr;
+}
+
 
 void gVKRenderEngine::init() {
-	gLogi("gVKRenderEngine") << "Vulkan render engine active (currently running GL code)";
-#if !defined(GLIST_OPENGLES) && (defined(DEBUG) || defined(ENGINE_OPENGL_CHECKS))
-	// On newer versions of OpenGL, debug callbacks are available; we enable them only for debug builds because it might have a performance impact.
-	// You can place a debug point and go back to the original source of the message from the stack trace, because it is sync.
-	if (GLEW_VERSION_4_3 || GLEW_ARB_debug_output) {
-		glEnable(GL_DEBUG_OUTPUT);
-		glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
-		glDebugMessageCallback(openglErrorCallback, nullptr);
+	// gRenderer::init() is deliberately not called: it compiles shaders and
+	// builds GL objects, and there is no GL context under Vulkan. originalgrid
+	// is assigned only inside that function and is never initialised in a
+	// constructor, so it is nulled here to keep the destructor's delete safe.
+	originalgrid = nullptr;
+	if(!initVulkan()) {
+		gLoge("gVKRenderEngine") << "Vulkan initialization failed; the Vulkan backend is not usable.";
 	}
-#endif
-	gRenderer::init();
+}
+
+
+void gVKRenderEngine::cleanup() {
+	// The GL resources gRenderer::cleanup() would release were never created,
+	// because init() skips gRenderer::init().
+	cleanupVulkan();
 }
 
 void gVKRenderEngine::updatePackUnpackAlignment(int i) {

--- a/engine/core/gVKRenderEngine.h
+++ b/engine/core/gVKRenderEngine.h
@@ -9,6 +9,11 @@
 #include "gRenderer.h"
 #include "gUbo.h"
 
+// All Vulkan objects live behind this opaque pointer, so <vulkan/vulkan.h> is
+// not pushed into every translation unit that includes this header and the
+// class still compiles on platforms that have no Vulkan headers.
+struct gVKContext;
+
 class gVKRenderEngine : public gRenderer {
 public:
 	gVKRenderEngine() = default;
@@ -177,8 +182,12 @@ public:
 
 protected:
 	void init() override;
+	void cleanup() override;
 private:
 	mutable GLuint currentprogram = 0;
+	bool initVulkan();
+	void cleanupVulkan();
+	gVKContext* vkcontext = nullptr;
 	void updatePackUnpackAlignment(int i) override;
 };
 


### PR DESCRIPTION
Vulkan is currently optional for all platforms since it is still under development on the engine.

Initialize Vulkan: instance, surface, device and queues behind the VK backend

gVKRenderEngine now performs a real Vulkan bootstrap: instance -> debug messenger (DEBUG only) -> surface -> physical device -> logical device and queues, with reverse-order teardown in cleanup()
Vulkan handles are hidden behind an opaque gVKContext (PIMPL), so <vulkan/vulkan.h> stays out of the engine headers
gGLFWWindow: single backend decision point with a glfwVulkanSupported() probe and OpenGL fallback; GLFW_NO_API window with no GL context or GLEW under Vulkan; getGLFWWindow() exposes the handle for surface creation
gAppManager: skip the OpenGL-only startup and frame paths while the Vulkan backend has no rendering path, so selecting VK no longer runs GL code without a context; event handlers now null-check guimanager
macOS portability bits (VK_KHR_portability_enumeration, ICD/layer environment) are guarded by APPLE, and the validation layer is requested only when it is actually installed
Link vulkan-1 on Windows
The OpenGL backend is unchanged and remains the default. Vulkan rendering is not implemented yet: selecting G_RENDERER_VK initializes Vulkan and logs the device, but nothing is drawn.