### PR TITLE
Feature/vulkan m1

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -210,6 +210,11 @@ set(SRC_FILES
 	${ENGINE_DIR}/core/gRenderer.cpp
 	${ENGINE_DIR}/core/gGLRenderEngine.cpp
 	${ENGINE_DIR}/core/gVKRenderEngine.cpp
+	${ENGINE_DIR}/core/gVKSwapchain.cpp
+	${ENGINE_DIR}/core/gVKRenderTarget.cpp
+	${ENGINE_DIR}/core/gVKCommands.cpp
+	${ENGINE_DIR}/core/gVKSync.cpp
+	${ENGINE_DIR}/core/gVKFrame.cpp
 	${ENGINE_DIR}/core/gRenderObject.cpp
 	${ENGINE_DIR}/core/gGUIActionManager.cpp
 	${ENGINE_DIR}/graphics/gTexture.cpp

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -591,6 +591,13 @@ elseif(WIN32)
 	if(EXISTS "${MINGW64_DIR}/include/vulkan/vulkan.h" AND GLIST_VULKAN_LIBRARY)
 		set(Lib_Vulkan "${GLIST_VULKAN_LIBRARY}")
 		target_compile_definitions(GlistEngine PRIVATE GLIST_HAS_VULKAN)
+		# The validation layer ships with zbin, but its manifest does not sit in a
+		# directory the loader searches on its own. Passing the path to the engine
+		# keeps the layer usable on machines that have no Vulkan SDK installed.
+		if(EXISTS "${MINGW64_DIR}/bin/VkLayer_khronos_validation.json")
+			target_compile_definitions(GlistEngine PRIVATE
+				GLIST_VK_LAYER_PATH="${MINGW64_DIR}/bin")
+		endif()
 	else()
 		message(STATUS "Vulkan development files not found in zbin; Vulkan backend disabled")
 	endif()

--- a/engine/core/gAppManager.cpp
+++ b/engine/core/gAppManager.cpp
@@ -554,10 +554,14 @@ void gAppManager::tick() {
         return;
     }
 
-    // The Vulkan backend initialises only: there is no GL context and no Vulkan
-    // frame path yet, so the frame body is skipped. Events are still polled so the
-    // window stays responsive and closable.
+    // The Vulkan backend presents a cleared frame of its own. The engine's drawing
+    // code is still OpenGL only, so nothing is recorded between the two calls yet
+    // and the rest of the frame body stays skipped.
     if(renderengine == G_RENDERER_VK) {
+        if(renderer != nullptr && renderer->beginFrame()) {
+            renderer->endFrame();
+            totaldraws++;
+        }
         if(inputmanager) inputmanager->update();
         window->update();
         executeQueue();

--- a/engine/core/gGLFWWindow.cpp
+++ b/engine/core/gGLFWWindow.cpp
@@ -362,11 +362,15 @@ bool gGLFWWindow::getShouldClose() {
 void gGLFWWindow::update() {
 	G_PROFILE_ZONE_SCOPED_N("gGLFWWindow::update()");
 	// End window drawing. A GLFW_NO_API window (Vulkan) owns no buffers to swap,
-	// and asking GLFW to swap them raises GLFW_NO_WINDOW_CONTEXT.
+	// and asking GLFW to swap them raises GLFW_NO_WINDOW_CONTEXT. The GL error
+	// checks are skipped along with it: without a context every glGetError call
+	// reports GL_INVALID_OPERATION, which would flood the log in debug builds.
 	if(appmanager == nullptr || appmanager->getRenderEngine() != G_RENDERER_VK) {
 		G_CHECK_GL(glfwSwapBuffers(window));
+		G_CHECK_GL(glfwPollEvents());
+	} else {
+		glfwPollEvents();
 	}
-	G_CHECK_GL(glfwPollEvents());
 }
 
 void gGLFWWindow::close() {

--- a/engine/core/gRenderer.h
+++ b/engine/core/gRenderer.h
@@ -245,6 +245,16 @@ public:
 	void setColor(gColor* color);
 	gColor* getColor();
 
+	/*
+	 * Backends that have to bracket a frame explicitly, like Vulkan, prepare it in
+	 * beginFrame and submit and present it in endFrame. A false return means the
+	 * frame has to be skipped, for example while the swapchain is rebuilt after a
+	 * resize; endFrame must not be called in that case. OpenGL draws immediately
+	 * and needs neither, so both are no-ops there.
+	 */
+	virtual bool beginFrame() { return true; }
+	virtual void endFrame() {}
+
 	virtual void clear() = 0;
 	virtual void clearColor(int r, int g, int b, int a = 255) = 0;
 	virtual void clearColor(gColor color) = 0;

--- a/engine/core/gVKCommands.cpp
+++ b/engine/core/gVKCommands.cpp
@@ -1,8 +1,8 @@
 /*
  * gVKCommands.cpp
  *
- * Skeleton created in phase 0. The bodies are filled in by the owner of this
- * module (Efe); see VULKAN_RENDERING_GOREV_DAGILIMI.md section 5.2.
+ * Command pool and command buffers of the Vulkan backend.
+ * See VULKAN_RENDERING_GOREV_DAGILIMI.md section 5.2 for the locked decisions.
  */
 
 #include "gVKCommands.h"
@@ -12,16 +12,62 @@
 #include "gUtils.h"
 
 bool gvkCreateCommandResources(gVKContext& ctx) {
-	// TODO: create the command pool on ctx.graphicsfamily with the
-	// RESET_COMMAND_BUFFER flag, then allocate GVK_MAX_FRAMES_IN_FLIGHT primary
-	// command buffers in a single call.
-	gLoge("gVKCommands") << "gvkCreateCommandResources is not implemented yet.";
-	return false;
+	if(ctx.device == VK_NULL_HANDLE) {
+		gLoge("gVKCommands") << "Cannot create the command resources before the device exists.";
+		return false;
+	}
+
+	VkCommandPoolCreateInfo poolinfo{};
+	poolinfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+	// Drawing commands are submitted on the graphics queue, so the pool has to
+	// belong to that family.
+	poolinfo.queueFamilyIndex = ctx.graphicsfamily;
+	// Every frame records its command buffer again from scratch. Without this flag
+	// resetting an individual buffer is not allowed and the whole pool would have
+	// to be reset instead.
+	poolinfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+
+	VkResult result = vkCreateCommandPool(ctx.device, &poolinfo, nullptr, &ctx.commandpool);
+	if(result != VK_SUCCESS) {
+		gLoge("gVKCommands") << "vkCreateCommandPool failed! VkResult: " << result;
+		ctx.commandpool = VK_NULL_HANDLE;
+		return false;
+	}
+
+	// One buffer per frame in flight, so the frame being recorded never touches the
+	// buffer the GPU is still reading from.
+	ctx.commandbuffers.resize(GVK_MAX_FRAMES_IN_FLIGHT, VK_NULL_HANDLE);
+
+	VkCommandBufferAllocateInfo allocinfo{};
+	allocinfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+	allocinfo.commandPool = ctx.commandpool;
+	// Primary: submitted to a queue directly, as opposed to being called from
+	// another command buffer.
+	allocinfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+	allocinfo.commandBufferCount = static_cast<uint32_t>(ctx.commandbuffers.size());
+
+	result = vkAllocateCommandBuffers(ctx.device, &allocinfo, ctx.commandbuffers.data());
+	if(result != VK_SUCCESS) {
+		gLoge("gVKCommands") << "vkAllocateCommandBuffers failed! VkResult: " << result;
+		gvkDestroyCommandResources(ctx);
+		return false;
+	}
+
+	gLogi("gVKCommands") << "Command pool created with " << ctx.commandbuffers.size()
+			<< " primary command buffers on queue family " << ctx.graphicsfamily;
+	return true;
 }
 
 void gvkDestroyCommandResources(gVKContext& ctx) {
-	// TODO: destroying the pool frees its command buffers as well, so only
-	// vkDestroyCommandPool is needed here. Clear the vector afterwards.
+	if(ctx.device == VK_NULL_HANDLE) return;
+
+	// Destroying the pool frees every command buffer allocated from it, so calling
+	// vkFreeCommandBuffers beforehand would be redundant.
+	if(ctx.commandpool != VK_NULL_HANDLE) {
+		vkDestroyCommandPool(ctx.device, ctx.commandpool, nullptr);
+		ctx.commandpool = VK_NULL_HANDLE;
+	}
+	ctx.commandbuffers.clear();
 }
 
 #endif /* GVK_DESKTOP_GLFW */

--- a/engine/core/gVKCommands.cpp
+++ b/engine/core/gVKCommands.cpp
@@ -1,0 +1,27 @@
+/*
+ * gVKCommands.cpp
+ *
+ * Skeleton created in phase 0. The bodies are filled in by the owner of this
+ * module (Efe); see VULKAN_RENDERING_GOREV_DAGILIMI.md section 5.2.
+ */
+
+#include "gVKCommands.h"
+
+#ifdef GVK_DESKTOP_GLFW
+
+#include "gUtils.h"
+
+bool gvkCreateCommandResources(gVKContext& ctx) {
+	// TODO: create the command pool on ctx.graphicsfamily with the
+	// RESET_COMMAND_BUFFER flag, then allocate GVK_MAX_FRAMES_IN_FLIGHT primary
+	// command buffers in a single call.
+	gLoge("gVKCommands") << "gvkCreateCommandResources is not implemented yet.";
+	return false;
+}
+
+void gvkDestroyCommandResources(gVKContext& ctx) {
+	// TODO: destroying the pool frees its command buffers as well, so only
+	// vkDestroyCommandPool is needed here. Clear the vector afterwards.
+}
+
+#endif /* GVK_DESKTOP_GLFW */

--- a/engine/core/gVKCommands.h
+++ b/engine/core/gVKCommands.h
@@ -1,0 +1,33 @@
+/*
+ * gVKCommands.h
+ *
+ * Command pool and command buffers of the Vulkan backend. Vulkan never executes a
+ * command directly: commands are recorded into a command buffer and submitted to a
+ * queue as a batch.
+ * Owner: Efe.
+ */
+
+#pragma once
+
+#ifndef CORE_GVKCOMMANDS_H
+#define CORE_GVKCOMMANDS_H
+
+#include "gVKContext.h"
+
+#ifdef GVK_DESKTOP_GLFW
+
+/*
+ * Creates the command pool on the graphics queue family and allocates
+ * GVK_MAX_FRAMES_IN_FLIGHT primary command buffers from it. The pool is created
+ * with the reset flag because every frame re-records its buffer.
+ */
+bool gvkCreateCommandResources(gVKContext& ctx);
+
+/*
+ * Destroys the pool, which frees the command buffers with it. Safe to call twice.
+ */
+void gvkDestroyCommandResources(gVKContext& ctx);
+
+#endif /* GVK_DESKTOP_GLFW */
+
+#endif /* CORE_GVKCOMMANDS_H */

--- a/engine/core/gVKContext.h
+++ b/engine/core/gVKContext.h
@@ -1,0 +1,86 @@
+/*
+ * gVKContext.h
+ *
+ * Shared state of the Vulkan render backend. Every gVK* module reads from and
+ * writes to this single structure, so no module has to include another module's
+ * header. The comments mark which module owns which block.
+ */
+
+#pragma once
+
+#ifndef CORE_GVKCONTEXT_H
+#define CORE_GVKCONTEXT_H
+
+// TARGET_OS_IPHONE only exists once TargetConditionals.h has been included, so it
+// has to be pulled in before the guard below is evaluated.
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+
+// Vulkan is an optional dependency of this engine: engine/CMakeLists.txt defines
+// GLIST_HAS_VULKAN only when the development files are actually present, which is
+// not the case on every machine or CI runner. Every gVK* module guards its body
+// with GVK_DESKTOP_GLFW so those translation units stay empty when Vulkan is not
+// available, and the engine still builds.
+#if defined(GLIST_HAS_VULKAN) && !defined(ANDROID) && !defined(EMSCRIPTEN) && !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
+#define GVK_DESKTOP_GLFW 1
+#endif
+
+#ifdef GVK_DESKTOP_GLFW
+
+#include <vulkan/vulkan.h>
+#include <vector>
+
+// How many frames the CPU may prepare while the GPU is still busy with earlier ones.
+inline constexpr int GVK_MAX_FRAMES_IN_FLIGHT = 2;
+
+// Every Vulkan handle of the backend lives here. All members start out empty,
+// which is what makes the "destroy only if non null" teardown correct even when
+// initialisation fails half way through.
+struct gVKContext {
+	/* ---------------- created by the init phase, do not modify ---------------- */
+	VkInstance instance = VK_NULL_HANDLE;
+	VkDebugUtilsMessengerEXT debugmessenger = VK_NULL_HANDLE;
+	VkSurfaceKHR surface = VK_NULL_HANDLE;
+	VkPhysicalDevice physicaldevice = VK_NULL_HANDLE;
+	VkDevice device = VK_NULL_HANDLE;
+	VkQueue graphicsqueue = VK_NULL_HANDLE;
+	VkQueue presentqueue = VK_NULL_HANDLE;
+	uint32_t graphicsfamily = 0;
+	uint32_t presentfamily = 0;
+
+	/* ---------------- gVKSwapchain ---------------- */
+	VkSwapchainKHR swapchain = VK_NULL_HANDLE;
+	std::vector<VkImage> swapchainimages;
+	std::vector<VkImageView> swapchainimageviews;
+	VkFormat swapchainformat = VK_FORMAT_UNDEFINED;
+	VkExtent2D swapchainextent = {0, 0};
+
+	/* ---------------- gVKRenderTarget ---------------- */
+	VkRenderPass renderpass = VK_NULL_HANDLE;
+	// One framebuffer per swapchain image view.
+	std::vector<VkFramebuffer> framebuffers;
+
+	/* ---------------- gVKCommands ---------------- */
+	VkCommandPool commandpool = VK_NULL_HANDLE;
+	// GVK_MAX_FRAMES_IN_FLIGHT entries, indexed by currentframe.
+	std::vector<VkCommandBuffer> commandbuffers;
+
+	/* ---------------- gVKSync ---------------- */
+	// GVK_MAX_FRAMES_IN_FLIGHT entries, indexed by currentframe.
+	std::vector<VkSemaphore> imageavailablesemaphores;
+	std::vector<VkFence> inflightfences;
+	// One per swapchain image, indexed by currentimageindex.
+	std::vector<VkSemaphore> renderfinishedsemaphores;
+
+	/* ---------------- gVKFrame ---------------- */
+	uint32_t currentframe = 0;
+	uint32_t currentimageindex = 0;
+	bool frameactive = false;
+	// Cornflower blue. gVKRenderEngine::clearColor writes into this value.
+	VkClearValue clearvalue = {{{0.39f, 0.58f, 0.93f, 1.0f}}};
+};
+
+#endif /* GVK_DESKTOP_GLFW */
+
+#endif /* CORE_GVKCONTEXT_H */

--- a/engine/core/gVKContext.h
+++ b/engine/core/gVKContext.h
@@ -31,6 +31,8 @@
 #include <vulkan/vulkan.h>
 #include <vector>
 
+struct GLFWwindow;
+
 // How many frames the CPU may prepare while the GPU is still busy with earlier ones.
 inline constexpr int GVK_MAX_FRAMES_IN_FLIGHT = 2;
 
@@ -48,6 +50,10 @@ struct gVKContext {
 	VkQueue presentqueue = VK_NULL_HANDLE;
 	uint32_t graphicsfamily = 0;
 	uint32_t presentfamily = 0;
+
+	// The window the surface was created from. The frame loop needs it to notice
+	// resizes and to rebuild the swapchain.
+	GLFWwindow* window = nullptr;
 
 	/* ---------------- gVKSwapchain ---------------- */
 	VkSwapchainKHR swapchain = VK_NULL_HANDLE;

--- a/engine/core/gVKFrame.cpp
+++ b/engine/core/gVKFrame.cpp
@@ -1,8 +1,8 @@
 /*
  * gVKFrame.cpp
  *
- * Skeleton created in phase 0. The bodies are filled in by the owner of this
- * module (Mehmet); see VULKAN_RENDERING_GOREV_DAGILIMI.md section 5.5.
+ * The Vulkan frame loop: acquire an image, record the render pass, submit and
+ * present. See VULKAN_RENDERING_GOREV_DAGILIMI.md section 5.5.
  */
 
 #include "gVKFrame.h"
@@ -14,18 +14,135 @@
 #include <GLFW/glfw3.h>
 
 bool gvkBeginFrame(gVKContext& ctx, GLFWwindow* window) {
-	// TODO: wait on the fence of this frame slot, acquire the next swapchain
-	// image, reset the fence and the command buffer, then begin recording and
-	// begin the render pass with ctx.clearvalue. Rebuild the swapchain and skip
-	// the frame when the acquire reports that it is out of date.
-	return false;
+	if(ctx.device == VK_NULL_HANDLE || ctx.swapchain == VK_NULL_HANDLE || window == nullptr) {
+		return false;
+	}
+	if(ctx.frameactive) {
+		gLoge("gVKFrame") << "gvkBeginFrame was called while a frame was already active.";
+		return false;
+	}
+
+	// A resized window makes the current swapchain the wrong size. Rebuilding it
+	// here keeps the check in one place instead of relying on a resize callback.
+	int width = 0, height = 0;
+	glfwGetFramebufferSize(window, &width, &height);
+	if(width <= 0 || height <= 0) {
+		// Minimised: there is nothing to render into.
+		return false;
+	}
+	if(static_cast<uint32_t>(width) != ctx.swapchainextent.width ||
+			static_cast<uint32_t>(height) != ctx.swapchainextent.height) {
+		gvkRecreateSwapchain(ctx, window);
+		return false;
+	}
+
+	// Wait until the GPU is done with the previous use of this frame slot, so its
+	// command buffer and semaphores are free to be reused.
+	vkWaitForFences(ctx.device, 1, &ctx.inflightfences[ctx.currentframe], VK_TRUE, UINT64_MAX);
+
+	VkResult result = vkAcquireNextImageKHR(ctx.device, ctx.swapchain, UINT64_MAX,
+			ctx.imageavailablesemaphores[ctx.currentframe], VK_NULL_HANDLE, &ctx.currentimageindex);
+	if(result == VK_ERROR_OUT_OF_DATE_KHR) {
+		gvkRecreateSwapchain(ctx, window);
+		return false;
+	}
+	// Suboptimal still presents correctly, so the frame is drawn and the swapchain
+	// is rebuilt after presenting instead.
+	if(result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR) {
+		gLoge("gVKFrame") << "vkAcquireNextImageKHR failed! VkResult: " << result;
+		return false;
+	}
+
+	// Only reset the fence once it is certain that work will be submitted, other-
+	// wise an early return would leave it unsignalled and the next wait would hang.
+	vkResetFences(ctx.device, 1, &ctx.inflightfences[ctx.currentframe]);
+
+	VkCommandBuffer commandbuffer = ctx.commandbuffers[ctx.currentframe];
+	vkResetCommandBuffer(commandbuffer, 0);
+
+	VkCommandBufferBeginInfo begininfo{};
+	begininfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+	result = vkBeginCommandBuffer(commandbuffer, &begininfo);
+	if(result != VK_SUCCESS) {
+		gLoge("gVKFrame") << "vkBeginCommandBuffer failed! VkResult: " << result;
+		return false;
+	}
+
+	VkRenderPassBeginInfo renderpassinfo{};
+	renderpassinfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+	renderpassinfo.renderPass = ctx.renderpass;
+	renderpassinfo.framebuffer = ctx.framebuffers[ctx.currentimageindex];
+	renderpassinfo.renderArea.offset = {0, 0};
+	renderpassinfo.renderArea.extent = ctx.swapchainextent;
+	// The attachment uses a CLEAR load operation, so this is the value that ends up
+	// covering the screen.
+	renderpassinfo.clearValueCount = 1;
+	renderpassinfo.pClearValues = &ctx.clearvalue;
+	vkCmdBeginRenderPass(commandbuffer, &renderpassinfo, VK_SUBPASS_CONTENTS_INLINE);
+
+	ctx.frameactive = true;
+	return true;
 }
 
 bool gvkEndFrame(gVKContext& ctx, GLFWwindow* window) {
-	// TODO: end the render pass and the recording, submit the command buffer with
-	// the image available semaphore as the wait and the render finished semaphore
-	// of the acquired image as the signal, present, then advance ctx.currentframe.
-	return false;
+	if(!ctx.frameactive) return false;
+	ctx.frameactive = false;
+
+	VkCommandBuffer commandbuffer = ctx.commandbuffers[ctx.currentframe];
+	vkCmdEndRenderPass(commandbuffer);
+	VkResult result = vkEndCommandBuffer(commandbuffer);
+	if(result != VK_SUCCESS) {
+		gLoge("gVKFrame") << "vkEndCommandBuffer failed! VkResult: " << result;
+		return false;
+	}
+
+	// The image may still be owned by the presentation engine, so the submission
+	// waits for the acquire semaphore before it writes any colour.
+	const VkSemaphore waitsemaphores[] = {ctx.imageavailablesemaphores[ctx.currentframe]};
+	const VkPipelineStageFlags waitstages[] = {VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT};
+	// Signalled per image rather than per frame, because presentation picks the
+	// semaphore by the acquired image index.
+	const VkSemaphore signalsemaphores[] = {ctx.renderfinishedsemaphores[ctx.currentimageindex]};
+
+	VkSubmitInfo submitinfo{};
+	submitinfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+	submitinfo.waitSemaphoreCount = 1;
+	submitinfo.pWaitSemaphores = waitsemaphores;
+	submitinfo.pWaitDstStageMask = waitstages;
+	submitinfo.commandBufferCount = 1;
+	submitinfo.pCommandBuffers = &commandbuffer;
+	submitinfo.signalSemaphoreCount = 1;
+	submitinfo.pSignalSemaphores = signalsemaphores;
+
+	result = vkQueueSubmit(ctx.graphicsqueue, 1, &submitinfo, ctx.inflightfences[ctx.currentframe]);
+	if(result != VK_SUCCESS) {
+		gLoge("gVKFrame") << "vkQueueSubmit failed! VkResult: " << result;
+		return false;
+	}
+
+	VkPresentInfoKHR presentinfo{};
+	presentinfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
+	presentinfo.waitSemaphoreCount = 1;
+	presentinfo.pWaitSemaphores = signalsemaphores;
+	presentinfo.swapchainCount = 1;
+	presentinfo.pSwapchains = &ctx.swapchain;
+	presentinfo.pImageIndices = &ctx.currentimageindex;
+
+	result = vkQueuePresentKHR(ctx.presentqueue, &presentinfo);
+	if(result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR) {
+		gvkRecreateSwapchain(ctx, window);
+	} else if(result != VK_SUCCESS) {
+		gLoge("gVKFrame") << "vkQueuePresentKHR failed! VkResult: " << result;
+	}
+
+	static bool loggedfirstframe = false;
+	if(!loggedfirstframe) {
+		loggedfirstframe = true;
+		gLogi("gVKFrame") << "First frame presented";
+	}
+
+	ctx.currentframe = (ctx.currentframe + 1) % GVK_MAX_FRAMES_IN_FLIGHT;
+	return true;
 }
 
 #endif /* GVK_DESKTOP_GLFW */

--- a/engine/core/gVKFrame.cpp
+++ b/engine/core/gVKFrame.cpp
@@ -1,0 +1,31 @@
+/*
+ * gVKFrame.cpp
+ *
+ * Skeleton created in phase 0. The bodies are filled in by the owner of this
+ * module (Mehmet); see VULKAN_RENDERING_GOREV_DAGILIMI.md section 5.5.
+ */
+
+#include "gVKFrame.h"
+
+#ifdef GVK_DESKTOP_GLFW
+
+#include "gVKSwapchain.h"
+#include "gUtils.h"
+#include <GLFW/glfw3.h>
+
+bool gvkBeginFrame(gVKContext& ctx, GLFWwindow* window) {
+	// TODO: wait on the fence of this frame slot, acquire the next swapchain
+	// image, reset the fence and the command buffer, then begin recording and
+	// begin the render pass with ctx.clearvalue. Rebuild the swapchain and skip
+	// the frame when the acquire reports that it is out of date.
+	return false;
+}
+
+bool gvkEndFrame(gVKContext& ctx, GLFWwindow* window) {
+	// TODO: end the render pass and the recording, submit the command buffer with
+	// the image available semaphore as the wait and the render finished semaphore
+	// of the acquired image as the signal, present, then advance ctx.currentframe.
+	return false;
+}
+
+#endif /* GVK_DESKTOP_GLFW */

--- a/engine/core/gVKFrame.h
+++ b/engine/core/gVKFrame.h
@@ -1,0 +1,36 @@
+/*
+ * gVKFrame.h
+ *
+ * The Vulkan frame loop: acquire an image, record the command buffer, submit it
+ * and present the result. This is the module the engine's main loop drives.
+ * Owner: Mehmet.
+ */
+
+#pragma once
+
+#ifndef CORE_GVKFRAME_H
+#define CORE_GVKFRAME_H
+
+#include "gVKContext.h"
+
+#ifdef GVK_DESKTOP_GLFW
+
+struct GLFWwindow;
+
+/*
+ * Waits for the previous use of this frame slot, acquires a swapchain image and
+ * begins recording the render pass with ctx.clearvalue. Returns false when the
+ * frame has to be skipped, for example because the swapchain was rebuilt; the
+ * caller must not call gvkEndFrame in that case.
+ */
+bool gvkBeginFrame(gVKContext& ctx, GLFWwindow* window);
+
+/*
+ * Ends the render pass, submits the command buffer and presents the image, then
+ * advances to the next frame slot.
+ */
+bool gvkEndFrame(gVKContext& ctx, GLFWwindow* window);
+
+#endif /* GVK_DESKTOP_GLFW */
+
+#endif /* CORE_GVKFRAME_H */

--- a/engine/core/gVKRenderEngine.cpp
+++ b/engine/core/gVKRenderEngine.cpp
@@ -12,18 +12,15 @@
 #include "gShader.h"
 #include "gTracy.h"
 
-// Vulkan is only wired up on the desktop GLFW platforms. This file is compiled
-// everywhere, but gGLFWWindow.cpp is desktop only, so the guard below mirrors
-// the CMake condition exactly. <vulkan/vulkan.h> must be included before GLFW
-// so that glfwCreateWindowSurface / glfwGetRequiredInstanceExtensions become
-// visible.
-#if defined(__APPLE__)
-#include <TargetConditionals.h>
-#endif
-#if defined(GLIST_HAS_VULKAN) && !defined(ANDROID) && !defined(EMSCRIPTEN) && !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
-	#define GVK_DESKTOP_GLFW 1
+// Vulkan is only wired up on the desktop GLFW platforms and only when the Vulkan
+// development files are available. gVKContext.h evaluates that condition, defines
+// GVK_DESKTOP_GLFW accordingly and holds the shared state of the backend.
+#include "gVKContext.h"
+
+#ifdef GVK_DESKTOP_GLFW
+	// GLFW_INCLUDE_VULKAN has to be defined before GLFW is pulled in, otherwise
+	// glfwCreateWindowSurface and glfwGetRequiredInstanceExtensions stay hidden.
 	#define GLFW_INCLUDE_VULKAN
-	#include <vulkan/vulkan.h>
 	#include "gGLFWWindow.h"
 	#include "gAppManager.h"
 	#include <vector>
@@ -697,20 +694,8 @@ void gVKRenderEngine::popMatrix() {
 
 #ifdef GVK_DESKTOP_GLFW
 
-// Every Vulkan handle lives here so the header stays Vulkan free. All members
-// start as VK_NULL_HANDLE, which is what makes the "destroy only if non null"
-// teardown correct even when initialisation fails half way through.
-struct gVKContext {
-	VkInstance instance = VK_NULL_HANDLE;
-	VkDebugUtilsMessengerEXT debugmessenger = VK_NULL_HANDLE;
-	VkSurfaceKHR surface = VK_NULL_HANDLE;
-	VkPhysicalDevice physicaldevice = VK_NULL_HANDLE;
-	VkDevice device = VK_NULL_HANDLE;
-	VkQueue graphicsqueue = VK_NULL_HANDLE;
-	VkQueue presentqueue = VK_NULL_HANDLE;
-	uint32_t graphicsfamily = 0;
-	uint32_t presentfamily = 0;
-};
+// The gVKContext structure itself now lives in gVKContext.h so that every gVK*
+// module can share it.
 
 // Validation layers cost performance, so they follow the same DEBUG condition
 // the OpenGL debug output already uses in this engine.

--- a/engine/core/gVKRenderEngine.cpp
+++ b/engine/core/gVKRenderEngine.cpp
@@ -27,6 +27,7 @@
 	#include <vector>
 	#include <set>
 	#include <cstring>
+	#include <cstdlib>
 #endif
 
 gVKRenderEngine::~gVKRenderEngine() {
@@ -723,6 +724,18 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL gvkDebugCallback(
 	return VK_FALSE;
 }
 
+// Hands the loader a search path, but never overrides a value the developer
+// exported themselves, so pointing the engine at a different driver or layer
+// build stays possible without touching the code.
+static void gvkSetEnvIfUnset(const char* name, const char* value) {
+	if(getenv(name) != nullptr) return;
+#if defined(_WIN32)
+	_putenv_s(name, value);
+#else
+	setenv(name, value, 0);
+#endif
+}
+
 static bool gvkHasLayer(const char* name) {
 	uint32_t count = 0;
 	if(vkEnumerateInstanceLayerProperties(&count, nullptr) != VK_SUCCESS || count == 0) return false;
@@ -756,16 +769,15 @@ bool gVKRenderEngine::initVulkan() {
 	vkcontext = new gVKContext();
 	gVKContext* ctx = vkcontext;
 
-#if defined(__APPLE__)
-	// MoltenVK (the macOS driver) and the Homebrew validation layers are not on
-	// the loader's default search path. The trailing 0 means "do not overwrite",
-	// so an explicitly exported value always wins.
+	// The driver manifest on macOS and the validation layer manifest on both
+	// desktop platforms live outside the directories the loader searches by
+	// itself, so their locations arrive as build definitions. Whether they are
+	// defined at all is decided per platform in engine/CMakeLists.txt.
 #ifdef GLIST_VK_ICD_FILE
-	setenv("VK_ICD_FILENAMES", GLIST_VK_ICD_FILE, 0);
+	gvkSetEnvIfUnset("VK_ICD_FILENAMES", GLIST_VK_ICD_FILE);
 #endif
 #ifdef GLIST_VK_LAYER_PATH
-	setenv("VK_LAYER_PATH", GLIST_VK_LAYER_PATH, 0);
-#endif
+	gvkSetEnvIfUnset("VK_LAYER_PATH", GLIST_VK_LAYER_PATH);
 #endif
 
 	gGLFWWindow* glfwwindow = dynamic_cast<gGLFWWindow*>(appmanager != nullptr ? appmanager->getWindow() : nullptr);

--- a/engine/core/gVKRenderEngine.cpp
+++ b/engine/core/gVKRenderEngine.cpp
@@ -24,10 +24,26 @@
 	#include "gGLFWWindow.h"
 	#include "gAppManager.h"
 	#include "gVKSwapchain.h"
+	#include "gVKRenderTarget.h"
+	#include "gVKCommands.h"
+	#include "gVKFrame.h"
+	#include "gVKSync.h"
 	#include <vector>
 	#include <set>
 	#include <cstring>
 	#include <cstdlib>
+#endif
+
+#ifdef GVK_DESKTOP_GLFW
+// Unlike OpenGL, clearing is not an immediate operation here: the colour is kept
+// and the render pass writes it when the next frame begins.
+static void gvkStoreClearColor(gVKContext* ctx, float r, float g, float b, float a) {
+	if(ctx == nullptr) return;
+	ctx->clearvalue.color.float32[0] = r;
+	ctx->clearvalue.color.float32[1] = g;
+	ctx->clearvalue.color.float32[2] = b;
+	ctx->clearvalue.color.float32[3] = a;
+}
 #endif
 
 gVKRenderEngine::~gVKRenderEngine() {
@@ -51,19 +67,20 @@ static void flipVertically(unsigned char* pixelData, int width, int height, int 
 }
 
 void gVKRenderEngine::clear() {
-	G_CHECK_GL(glClearColor(0.0f, 0.0f, 0.0f, 1.0f));
-	G_CHECK_GL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+	// The render pass clears the attachment at the start of every frame, so there
+	// is nothing to do at the moment this is called.
 }
 
 void gVKRenderEngine::clearColor(int r, int g, int b, int a) {
-	//    glBindFramebuffer(GL_FRAMEBUFFER, gFbo::defaultfbo);
-	G_CHECK_GL(glClearColor((float)r / 255, (float)g / 255, (float)b / 255, (float)a / 255));
-	G_CHECK_GL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+#ifdef GVK_DESKTOP_GLFW
+	gvkStoreClearColor(vkcontext, r / 255.0f, g / 255.0f, b / 255.0f, a / 255.0f);
+#endif
 }
 
 void gVKRenderEngine::clearColor(gColor color) {
-	G_CHECK_GL(glClearColor(color.r, color.g, color.b, color.a));
-	G_CHECK_GL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+#ifdef GVK_DESKTOP_GLFW
+	gvkStoreClearColor(vkcontext, color.r, color.g, color.b, color.a);
+#endif
 }
 
 void gVKRenderEngine::enableDepthTest() {
@@ -792,6 +809,8 @@ bool gVKRenderEngine::initVulkan() {
 		cleanupVulkan();
 		return false;
 	}
+	// The frame loop reads this to react to resizes.
+	ctx->window = handle;
 
 	/* ---------------- instance ---------------- */
 	// Asking GLFW for the surface extensions keeps this portable instead of
@@ -1000,6 +1019,31 @@ bool gVKRenderEngine::initVulkan() {
 		cleanupVulkan();
 		return false;
 	}
+	if(!gvkCreateRenderPass(*ctx)) {
+		gLoge("gVKRenderEngine") << "Vulkan init: the render pass could not be created.";
+		cleanupVulkan();
+		return false;
+	}
+	if(!gvkCreateFramebuffers(*ctx)) {
+		gLoge("gVKRenderEngine") << "Vulkan init: the framebuffers could not be created.";
+		cleanupVulkan();
+		return false;
+	}
+	if(!gvkCreateCommandResources(*ctx)) {
+		gLoge("gVKRenderEngine") << "Vulkan init: the command resources could not be created.";
+		cleanupVulkan();
+		return false;
+	}
+	if(!gvkCreateFrameSyncObjects(*ctx)) {
+		gLoge("gVKRenderEngine") << "Vulkan init: the frame synchronisation objects could not be created.";
+		cleanupVulkan();
+		return false;
+	}
+	if(!gvkCreatePresentSemaphores(*ctx, static_cast<uint32_t>(ctx->swapchainimages.size()))) {
+		gLoge("gVKRenderEngine") << "Vulkan init: the present semaphores could not be created.";
+		cleanupVulkan();
+		return false;
+	}
 	return true;
 #endif
 }
@@ -1014,6 +1058,11 @@ void gVKRenderEngine::cleanupVulkan() {
 	if(ctx->device != VK_NULL_HANDLE) vkDeviceWaitIdle(ctx->device);
 	// Strict reverse creation order: Vulkan requires children to be destroyed
 	// before their parent, and the surface must die before its instance.
+	gvkDestroyPresentSemaphores(*ctx);
+	gvkDestroyFrameSyncObjects(*ctx);
+	gvkDestroyCommandResources(*ctx);
+	gvkDestroyFramebuffers(*ctx);
+	gvkDestroyRenderPass(*ctx);
 	gvkDestroySwapchain(*ctx);
 	if(ctx->device != VK_NULL_HANDLE) vkDestroyDevice(ctx->device, nullptr);
 	if(ctx->surface != VK_NULL_HANDLE) vkDestroySurfaceKHR(ctx->instance, ctx->surface, nullptr);
@@ -1026,6 +1075,23 @@ void gVKRenderEngine::cleanupVulkan() {
 	delete vkcontext;
 #endif
 	vkcontext = nullptr;
+}
+
+
+bool gVKRenderEngine::beginFrame() {
+#ifdef GVK_DESKTOP_GLFW
+	if(vkcontext == nullptr) return false;
+	return gvkBeginFrame(*vkcontext, vkcontext->window);
+#else
+	return false;
+#endif
+}
+
+void gVKRenderEngine::endFrame() {
+#ifdef GVK_DESKTOP_GLFW
+	if(vkcontext == nullptr) return;
+	gvkEndFrame(*vkcontext, vkcontext->window);
+#endif
 }
 
 

--- a/engine/core/gVKRenderEngine.cpp
+++ b/engine/core/gVKRenderEngine.cpp
@@ -23,6 +23,7 @@
 	#define GLFW_INCLUDE_VULKAN
 	#include "gGLFWWindow.h"
 	#include "gAppManager.h"
+	#include "gVKSwapchain.h"
 	#include <vector>
 	#include <set>
 	#include <cstring>
@@ -978,6 +979,15 @@ bool gVKRenderEngine::initVulkan() {
 			<< " | graphics family: " << ctx->graphicsfamily
 			<< " | present family: " << ctx->presentfamily
 			<< " | validation: " << (usevalidation ? "on" : "off");
+
+	/* ---------------- presentation resources ---------------- */
+	// The remaining modules of the frame path (render pass, framebuffers, command
+	// buffers and synchronisation) are hooked in here as they are implemented.
+	if(!gvkCreateSwapchain(*ctx, handle)) {
+		gLoge("gVKRenderEngine") << "Vulkan init: the swapchain could not be created.";
+		cleanupVulkan();
+		return false;
+	}
 	return true;
 #endif
 }
@@ -987,8 +997,12 @@ void gVKRenderEngine::cleanupVulkan() {
 #ifdef GVK_DESKTOP_GLFW
 	if(vkcontext == nullptr) return;
 	gVKContext* ctx = vkcontext;
+	// Destroying objects the GPU is still using is a validation error, so the
+	// device is drained first.
+	if(ctx->device != VK_NULL_HANDLE) vkDeviceWaitIdle(ctx->device);
 	// Strict reverse creation order: Vulkan requires children to be destroyed
 	// before their parent, and the surface must die before its instance.
+	gvkDestroySwapchain(*ctx);
 	if(ctx->device != VK_NULL_HANDLE) vkDestroyDevice(ctx->device, nullptr);
 	if(ctx->surface != VK_NULL_HANDLE) vkDestroySurfaceKHR(ctx->instance, ctx->surface, nullptr);
 	if(ctx->debugmessenger != VK_NULL_HANDLE) {

--- a/engine/core/gVKRenderEngine.h
+++ b/engine/core/gVKRenderEngine.h
@@ -19,6 +19,9 @@ public:
 	gVKRenderEngine() = default;
 	~gVKRenderEngine() override;
 
+	bool beginFrame() override;
+	void endFrame() override;
+
 	void clear() override;
 	void clearColor(int r, int g, int b, int a = 255) override;
 	void clearColor(gColor color) override;

--- a/engine/core/gVKRenderTarget.cpp
+++ b/engine/core/gVKRenderTarget.cpp
@@ -1,0 +1,37 @@
+/*
+ * gVKRenderTarget.cpp
+ *
+ * Skeleton created in phase 0. The bodies are filled in by the owner of this
+ * module (Anil); see VULKAN_RENDERING_GOREV_DAGILIMI.md section 5.3.
+ */
+
+#include "gVKRenderTarget.h"
+
+#ifdef GVK_DESKTOP_GLFW
+
+#include "gUtils.h"
+
+bool gvkCreateRenderPass(gVKContext& ctx) {
+	// TODO: one colour attachment in ctx.swapchainformat with a CLEAR load
+	// operation, a STORE store operation and PRESENT_SRC_KHR as its final layout,
+	// a single graphics subpass, and one external subpass dependency.
+	gLoge("gVKRenderTarget") << "gvkCreateRenderPass is not implemented yet.";
+	return false;
+}
+
+void gvkDestroyRenderPass(gVKContext& ctx) {
+	// TODO: destroy the render pass and reset the handle.
+}
+
+bool gvkCreateFramebuffers(gVKContext& ctx) {
+	// TODO: one framebuffer per entry of ctx.swapchainimageviews, sized with
+	// ctx.swapchainextent and attached to ctx.renderpass.
+	gLoge("gVKRenderTarget") << "gvkCreateFramebuffers is not implemented yet.";
+	return false;
+}
+
+void gvkDestroyFramebuffers(gVKContext& ctx) {
+	// TODO: destroy every framebuffer and clear the vector.
+}
+
+#endif /* GVK_DESKTOP_GLFW */

--- a/engine/core/gVKRenderTarget.cpp
+++ b/engine/core/gVKRenderTarget.cpp
@@ -1,8 +1,8 @@
 /*
  * gVKRenderTarget.cpp
  *
- * Skeleton created in phase 0. The bodies are filled in by the owner of this
- * module (Anil); see VULKAN_RENDERING_GOREV_DAGILIMI.md section 5.3.
+ * Render pass and framebuffers of the Vulkan backend.
+ * See VULKAN_RENDERING_GOREV_DAGILIMI.md section 5.3 for the locked decisions.
  */
 
 #include "gVKRenderTarget.h"
@@ -12,26 +12,124 @@
 #include "gUtils.h"
 
 bool gvkCreateRenderPass(gVKContext& ctx) {
-	// TODO: one colour attachment in ctx.swapchainformat with a CLEAR load
-	// operation, a STORE store operation and PRESENT_SRC_KHR as its final layout,
-	// a single graphics subpass, and one external subpass dependency.
-	gLoge("gVKRenderTarget") << "gvkCreateRenderPass is not implemented yet.";
-	return false;
+	if(ctx.device == VK_NULL_HANDLE || ctx.swapchainformat == VK_FORMAT_UNDEFINED) {
+		gLoge("gVKRenderTarget") << "Cannot create the render pass before the swapchain exists.";
+		return false;
+	}
+
+	VkAttachmentDescription colorattachment{};
+	// The attachment has to match the images it will be used with.
+	colorattachment.format = ctx.swapchainformat;
+	colorattachment.samples = VK_SAMPLE_COUNT_1_BIT;
+	// This is what paints the screen: the clear value handed to
+	// vkCmdBeginRenderPass is written over the whole attachment by the GPU.
+	colorattachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+	// The result is kept, because it is what gets presented.
+	colorattachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+	colorattachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+	colorattachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+	// The previous contents are cleared anyway, so there is nothing worth keeping.
+	colorattachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+	// Handover point to the presentation engine.
+	colorattachment.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+
+	VkAttachmentReference colorattachmentref{};
+	colorattachmentref.attachment = 0;
+	colorattachmentref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+	VkSubpassDescription subpass{};
+	subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+	subpass.colorAttachmentCount = 1;
+	subpass.pColorAttachments = &colorattachmentref;
+
+	// Without this the layout transition of the attachment is not ordered against
+	// the work of the subpass, which the validation layers report as an error.
+	VkSubpassDependency dependency{};
+	dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
+	dependency.dstSubpass = 0;
+	dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+	dependency.srcAccessMask = 0;
+	dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+	dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+
+	VkRenderPassCreateInfo renderpassinfo{};
+	renderpassinfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+	renderpassinfo.attachmentCount = 1;
+	renderpassinfo.pAttachments = &colorattachment;
+	renderpassinfo.subpassCount = 1;
+	renderpassinfo.pSubpasses = &subpass;
+	renderpassinfo.dependencyCount = 1;
+	renderpassinfo.pDependencies = &dependency;
+
+	VkResult result = vkCreateRenderPass(ctx.device, &renderpassinfo, nullptr, &ctx.renderpass);
+	if(result != VK_SUCCESS) {
+		gLoge("gVKRenderTarget") << "vkCreateRenderPass failed! VkResult: " << result;
+		ctx.renderpass = VK_NULL_HANDLE;
+		return false;
+	}
+
+	gLogi("gVKRenderTarget") << "Render pass created with one cleared colour attachment";
+	return true;
 }
 
 void gvkDestroyRenderPass(gVKContext& ctx) {
-	// TODO: destroy the render pass and reset the handle.
+	if(ctx.device == VK_NULL_HANDLE) return;
+
+	if(ctx.renderpass != VK_NULL_HANDLE) {
+		vkDestroyRenderPass(ctx.device, ctx.renderpass, nullptr);
+		ctx.renderpass = VK_NULL_HANDLE;
+	}
 }
 
 bool gvkCreateFramebuffers(gVKContext& ctx) {
-	// TODO: one framebuffer per entry of ctx.swapchainimageviews, sized with
-	// ctx.swapchainextent and attached to ctx.renderpass.
-	gLoge("gVKRenderTarget") << "gvkCreateFramebuffers is not implemented yet.";
-	return false;
+	if(ctx.device == VK_NULL_HANDLE || ctx.renderpass == VK_NULL_HANDLE) {
+		gLoge("gVKRenderTarget") << "Cannot create the framebuffers before the render pass exists.";
+		return false;
+	}
+	if(ctx.swapchainimageviews.empty()) {
+		gLoge("gVKRenderTarget") << "Cannot create the framebuffers without swapchain image views.";
+		return false;
+	}
+
+	ctx.framebuffers.resize(ctx.swapchainimageviews.size(), VK_NULL_HANDLE);
+
+	for(size_t i = 0; i < ctx.swapchainimageviews.size(); i++) {
+		// One framebuffer per swapchain image, because the frame loop does not know
+		// in advance which image it will be handed.
+		VkImageView attachments[] = {ctx.swapchainimageviews[i]};
+
+		VkFramebufferCreateInfo framebufferinfo{};
+		framebufferinfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+		framebufferinfo.renderPass = ctx.renderpass;
+		framebufferinfo.attachmentCount = 1;
+		framebufferinfo.pAttachments = attachments;
+		framebufferinfo.width = ctx.swapchainextent.width;
+		framebufferinfo.height = ctx.swapchainextent.height;
+		framebufferinfo.layers = 1;
+
+		VkResult result = vkCreateFramebuffer(ctx.device, &framebufferinfo, nullptr, &ctx.framebuffers[i]);
+		if(result != VK_SUCCESS) {
+			gLoge("gVKRenderTarget") << "vkCreateFramebuffer failed for swapchain image " << i
+					<< "! VkResult: " << result;
+			gvkDestroyFramebuffers(ctx);
+			return false;
+		}
+	}
+
+	gLogi("gVKRenderTarget") << "Framebuffers created: " << ctx.framebuffers.size()
+			<< " at " << ctx.swapchainextent.width << "x" << ctx.swapchainextent.height;
+	return true;
 }
 
 void gvkDestroyFramebuffers(gVKContext& ctx) {
-	// TODO: destroy every framebuffer and clear the vector.
+	if(ctx.device == VK_NULL_HANDLE) return;
+
+	// Kept separate from the render pass on purpose: a resize rebuilds these while
+	// the render pass stays valid, since the surface format does not change.
+	for(VkFramebuffer framebuffer : ctx.framebuffers) {
+		if(framebuffer != VK_NULL_HANDLE) vkDestroyFramebuffer(ctx.device, framebuffer, nullptr);
+	}
+	ctx.framebuffers.clear();
 }
 
 #endif /* GVK_DESKTOP_GLFW */

--- a/engine/core/gVKRenderTarget.h
+++ b/engine/core/gVKRenderTarget.h
@@ -1,0 +1,36 @@
+/*
+ * gVKRenderTarget.h
+ *
+ * Render pass and framebuffers of the Vulkan backend. The render pass is what
+ * actually clears the screen: its colour attachment uses a CLEAR load operation,
+ * so the clear value handed to vkCmdBeginRenderPass is written by the GPU.
+ * Owner: Anil.
+ */
+
+#pragma once
+
+#ifndef CORE_GVKRENDERTARGET_H
+#define CORE_GVKRENDERTARGET_H
+
+#include "gVKContext.h"
+
+#ifdef GVK_DESKTOP_GLFW
+
+/*
+ * Creates the single subpass render pass used by the backend. Depends on
+ * ctx.swapchainformat, so the swapchain has to exist first.
+ */
+bool gvkCreateRenderPass(gVKContext& ctx);
+void gvkDestroyRenderPass(gVKContext& ctx);
+
+/*
+ * Creates one framebuffer per swapchain image view. Kept separate from the render
+ * pass on purpose: a resize rebuilds the framebuffers while the render pass stays
+ * valid, because the surface format does not change.
+ */
+bool gvkCreateFramebuffers(gVKContext& ctx);
+void gvkDestroyFramebuffers(gVKContext& ctx);
+
+#endif /* GVK_DESKTOP_GLFW */
+
+#endif /* CORE_GVKRENDERTARGET_H */

--- a/engine/core/gVKSwapchain.cpp
+++ b/engine/core/gVKSwapchain.cpp
@@ -1,8 +1,8 @@
 /*
  * gVKSwapchain.cpp
  *
- * Skeleton created in phase 0. The bodies are filled in by the owner of this
- * module (Burak); see VULKAN_RENDERING_GOREV_DAGILIMI.md section 5.4.
+ * Swapchain, its image views and the resize path. Owner: Burak.
+ * See VULKAN_RENDERING_GOREV_DAGILIMI.md section 5.4 for the locked decisions.
  */
 
 #include "gVKSwapchain.h"
@@ -13,25 +13,199 @@
 #include "gVKSync.h"
 #include "gUtils.h"
 #include <GLFW/glfw3.h>
+#include <algorithm>
+
+// Picks the surface format. sRGB is preferred so the presented colours match what
+// the rest of the engine assumes; if the driver does not offer it the first
+// reported format is used, which is always valid.
+static VkSurfaceFormatKHR gvkPickSurfaceFormat(const std::vector<VkSurfaceFormatKHR>& formats) {
+	for(const auto& format : formats) {
+		if(format.format == VK_FORMAT_B8G8R8A8_SRGB &&
+				format.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
+			return format;
+		}
+	}
+	return formats[0];
+}
+
+// Resolves the size of the swapchain images. Most drivers dictate it through
+// currentExtent; the special value UINT32_MAX means the window system lets us
+// choose, in which case the framebuffer size is used and clamped to what the
+// surface supports.
+static VkExtent2D gvkPickExtent(const VkSurfaceCapabilitiesKHR& caps, GLFWwindow* window) {
+	if(caps.currentExtent.width != UINT32_MAX) {
+		return caps.currentExtent;
+	}
+	int width = 0, height = 0;
+	glfwGetFramebufferSize(window, &width, &height);
+	VkExtent2D extent{};
+	extent.width = std::clamp(static_cast<uint32_t>(width), caps.minImageExtent.width, caps.maxImageExtent.width);
+	extent.height = std::clamp(static_cast<uint32_t>(height), caps.minImageExtent.height, caps.maxImageExtent.height);
+	return extent;
+}
 
 bool gvkCreateSwapchain(gVKContext& ctx, GLFWwindow* window) {
-	// TODO: query the surface capabilities, formats and present modes, pick the
-	// format, FIFO present mode and extent, create the swapchain, fetch its images
-	// and build one image view per image.
-	gLoge("gVKSwapchain") << "gvkCreateSwapchain is not implemented yet.";
-	return false;
+	if(ctx.device == VK_NULL_HANDLE || ctx.surface == VK_NULL_HANDLE || window == nullptr) {
+		gLoge("gVKSwapchain") << "Cannot create the swapchain before the device and the surface exist.";
+		return false;
+	}
+
+	VkSurfaceCapabilitiesKHR caps{};
+	if(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(ctx.physicaldevice, ctx.surface, &caps) != VK_SUCCESS) {
+		gLoge("gVKSwapchain") << "Could not query the surface capabilities.";
+		return false;
+	}
+
+	uint32_t formatcount = 0;
+	vkGetPhysicalDeviceSurfaceFormatsKHR(ctx.physicaldevice, ctx.surface, &formatcount, nullptr);
+	if(formatcount == 0) {
+		gLoge("gVKSwapchain") << "The surface reports no usable format.";
+		return false;
+	}
+	std::vector<VkSurfaceFormatKHR> formats(formatcount);
+	vkGetPhysicalDeviceSurfaceFormatsKHR(ctx.physicaldevice, ctx.surface, &formatcount, formats.data());
+	const VkSurfaceFormatKHR surfaceformat = gvkPickSurfaceFormat(formats);
+
+	const VkExtent2D extent = gvkPickExtent(caps, window);
+	if(extent.width == 0 || extent.height == 0) {
+		// The window is minimised. Nothing can be presented, so the caller has to
+		// try again once it is restored.
+		return false;
+	}
+
+	// One image more than the driver's minimum, so the application can work on the
+	// next frame while an image is still being presented.
+	uint32_t imagecount = caps.minImageCount + 1;
+	if(caps.maxImageCount > 0 && imagecount > caps.maxImageCount) {
+		imagecount = caps.maxImageCount;
+	}
+
+	VkSwapchainCreateInfoKHR createinfo{};
+	createinfo.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
+	createinfo.surface = ctx.surface;
+	createinfo.minImageCount = imagecount;
+	createinfo.imageFormat = surfaceformat.format;
+	createinfo.imageColorSpace = surfaceformat.colorSpace;
+	createinfo.imageExtent = extent;
+	createinfo.imageArrayLayers = 1;
+	createinfo.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+
+	// When one family renders and another presents, the images are used by both, so
+	// they have to be shared. On the usual single family setup exclusive ownership
+	// is both valid and faster.
+	const uint32_t families[] = {ctx.graphicsfamily, ctx.presentfamily};
+	if(ctx.graphicsfamily != ctx.presentfamily) {
+		createinfo.imageSharingMode = VK_SHARING_MODE_CONCURRENT;
+		createinfo.queueFamilyIndexCount = 2;
+		createinfo.pQueueFamilyIndices = families;
+	} else {
+		createinfo.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
+	}
+
+	createinfo.preTransform = caps.currentTransform;
+	createinfo.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+	// FIFO is the only present mode the specification guarantees everywhere, and it
+	// is vsynced, so no tearing.
+	createinfo.presentMode = VK_PRESENT_MODE_FIFO_KHR;
+	createinfo.clipped = VK_TRUE;
+	createinfo.oldSwapchain = VK_NULL_HANDLE;
+
+	VkResult result = vkCreateSwapchainKHR(ctx.device, &createinfo, nullptr, &ctx.swapchain);
+	if(result != VK_SUCCESS) {
+		gLoge("gVKSwapchain") << "vkCreateSwapchainKHR failed! VkResult: " << result;
+		ctx.swapchain = VK_NULL_HANDLE;
+		return false;
+	}
+
+	// The driver decides how many images it actually creates, so the count is read
+	// back instead of assumed.
+	uint32_t createdcount = 0;
+	vkGetSwapchainImagesKHR(ctx.device, ctx.swapchain, &createdcount, nullptr);
+	ctx.swapchainimages.resize(createdcount);
+	vkGetSwapchainImagesKHR(ctx.device, ctx.swapchain, &createdcount, ctx.swapchainimages.data());
+
+	ctx.swapchainformat = surfaceformat.format;
+	ctx.swapchainextent = extent;
+
+	// A framebuffer cannot reference an image directly; it needs a view that tells
+	// Vulkan how the image is interpreted.
+	ctx.swapchainimageviews.resize(createdcount, VK_NULL_HANDLE);
+	for(uint32_t i = 0; i < createdcount; i++) {
+		VkImageViewCreateInfo viewinfo{};
+		viewinfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+		viewinfo.image = ctx.swapchainimages[i];
+		viewinfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+		viewinfo.format = ctx.swapchainformat;
+		viewinfo.components.r = VK_COMPONENT_SWIZZLE_IDENTITY;
+		viewinfo.components.g = VK_COMPONENT_SWIZZLE_IDENTITY;
+		viewinfo.components.b = VK_COMPONENT_SWIZZLE_IDENTITY;
+		viewinfo.components.a = VK_COMPONENT_SWIZZLE_IDENTITY;
+		viewinfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+		viewinfo.subresourceRange.baseMipLevel = 0;
+		viewinfo.subresourceRange.levelCount = 1;
+		viewinfo.subresourceRange.baseArrayLayer = 0;
+		viewinfo.subresourceRange.layerCount = 1;
+
+		result = vkCreateImageView(ctx.device, &viewinfo, nullptr, &ctx.swapchainimageviews[i]);
+		if(result != VK_SUCCESS) {
+			gLoge("gVKSwapchain") << "vkCreateImageView failed for swapchain image " << i
+					<< "! VkResult: " << result;
+			gvkDestroySwapchain(ctx);
+			return false;
+		}
+	}
+
+	gLogi("gVKSwapchain") << "Swapchain created: " << createdcount << " images, "
+			<< ctx.swapchainextent.width << "x" << ctx.swapchainextent.height
+			<< ", format " << ctx.swapchainformat << ", present mode FIFO";
+	return true;
 }
 
 void gvkDestroySwapchain(gVKContext& ctx) {
-	// TODO: destroy the image views, then the swapchain, then clear the vectors.
+	if(ctx.device == VK_NULL_HANDLE) return;
+
+	for(VkImageView view : ctx.swapchainimageviews) {
+		if(view != VK_NULL_HANDLE) vkDestroyImageView(ctx.device, view, nullptr);
+	}
+	ctx.swapchainimageviews.clear();
+
+	if(ctx.swapchain != VK_NULL_HANDLE) {
+		vkDestroySwapchainKHR(ctx.device, ctx.swapchain, nullptr);
+		ctx.swapchain = VK_NULL_HANDLE;
+	}
+	// The images belong to the swapchain and are freed with it, so only the handles
+	// are dropped here.
+	ctx.swapchainimages.clear();
 }
 
 bool gvkRecreateSwapchain(gVKContext& ctx, GLFWwindow* window) {
-	// TODO: bail out while the window is minimised, wait for the device to go idle,
-	// tear down the framebuffers, the present semaphores and the swapchain, then
-	// build them again in that order. The render pass stays valid.
-	gLoge("gVKSwapchain") << "gvkRecreateSwapchain is not implemented yet.";
-	return false;
+	if(window == nullptr || ctx.device == VK_NULL_HANDLE) return false;
+
+	int width = 0, height = 0;
+	glfwGetFramebufferSize(window, &width, &height);
+	if(width == 0 || height == 0) {
+		// Minimised: there is nothing to size the swapchain to. The frame is skipped
+		// and the loop tries again once the window comes back.
+		return false;
+	}
+
+	// Everything below is still referenced by work the GPU may not have finished.
+	vkDeviceWaitIdle(ctx.device);
+
+	// Reverse dependency order: the framebuffers point at the image views, and the
+	// present semaphores are one per image, so both go before the swapchain.
+	gvkDestroyFramebuffers(ctx);
+	gvkDestroyPresentSemaphores(ctx);
+	gvkDestroySwapchain(ctx);
+
+	if(!gvkCreateSwapchain(ctx, window)) return false;
+	if(!gvkCreateFramebuffers(ctx)) return false;
+	// The render pass survives: the surface format does not change with the size.
+	if(!gvkCreatePresentSemaphores(ctx, static_cast<uint32_t>(ctx.swapchainimages.size()))) return false;
+
+	gLogi("gVKSwapchain") << "Swapchain recreated for " << ctx.swapchainextent.width
+			<< "x" << ctx.swapchainextent.height;
+	return true;
 }
 
 #endif /* GVK_DESKTOP_GLFW */

--- a/engine/core/gVKSwapchain.cpp
+++ b/engine/core/gVKSwapchain.cpp
@@ -1,0 +1,37 @@
+/*
+ * gVKSwapchain.cpp
+ *
+ * Skeleton created in phase 0. The bodies are filled in by the owner of this
+ * module (Burak); see VULKAN_RENDERING_GOREV_DAGILIMI.md section 5.4.
+ */
+
+#include "gVKSwapchain.h"
+
+#ifdef GVK_DESKTOP_GLFW
+
+#include "gVKRenderTarget.h"
+#include "gVKSync.h"
+#include "gUtils.h"
+#include <GLFW/glfw3.h>
+
+bool gvkCreateSwapchain(gVKContext& ctx, GLFWwindow* window) {
+	// TODO: query the surface capabilities, formats and present modes, pick the
+	// format, FIFO present mode and extent, create the swapchain, fetch its images
+	// and build one image view per image.
+	gLoge("gVKSwapchain") << "gvkCreateSwapchain is not implemented yet.";
+	return false;
+}
+
+void gvkDestroySwapchain(gVKContext& ctx) {
+	// TODO: destroy the image views, then the swapchain, then clear the vectors.
+}
+
+bool gvkRecreateSwapchain(gVKContext& ctx, GLFWwindow* window) {
+	// TODO: bail out while the window is minimised, wait for the device to go idle,
+	// tear down the framebuffers, the present semaphores and the swapchain, then
+	// build them again in that order. The render pass stays valid.
+	gLoge("gVKSwapchain") << "gvkRecreateSwapchain is not implemented yet.";
+	return false;
+}
+
+#endif /* GVK_DESKTOP_GLFW */

--- a/engine/core/gVKSwapchain.h
+++ b/engine/core/gVKSwapchain.h
@@ -1,0 +1,40 @@
+/*
+ * gVKSwapchain.h
+ *
+ * Swapchain, its image views and the resize path of the Vulkan backend.
+ * Owner: Burak.
+ */
+
+#pragma once
+
+#ifndef CORE_GVKSWAPCHAIN_H
+#define CORE_GVKSWAPCHAIN_H
+
+#include "gVKContext.h"
+
+#ifdef GVK_DESKTOP_GLFW
+
+struct GLFWwindow;
+
+/*
+ * Creates the swapchain together with its images and image views, and fills in
+ * ctx.swapchainformat and ctx.swapchainextent. Present mode is FIFO, which the
+ * specification guarantees on every driver.
+ */
+bool gvkCreateSwapchain(gVKContext& ctx, GLFWwindow* window);
+
+/*
+ * Destroys the image views and the swapchain itself. Safe to call twice.
+ */
+void gvkDestroySwapchain(gVKContext& ctx);
+
+/*
+ * Rebuilds everything that depends on the window size after a resize or after the
+ * swapchain went out of date. Returns false when the window is minimised, in which
+ * case nothing is rebuilt and the caller has to skip the frame.
+ */
+bool gvkRecreateSwapchain(gVKContext& ctx, GLFWwindow* window);
+
+#endif /* GVK_DESKTOP_GLFW */
+
+#endif /* CORE_GVKSWAPCHAIN_H */

--- a/engine/core/gVKSync.cpp
+++ b/engine/core/gVKSync.cpp
@@ -1,0 +1,35 @@
+/*
+ * gVKSync.cpp
+ *
+ * Skeleton created in phase 0. The bodies are filled in by the owner of this
+ * module (Ozlem); see VULKAN_RENDERING_GOREV_DAGILIMI.md section 5.1.
+ */
+
+#include "gVKSync.h"
+
+#ifdef GVK_DESKTOP_GLFW
+
+#include "gUtils.h"
+
+bool gvkCreateFrameSyncObjects(gVKContext& ctx) {
+	// TODO: GVK_MAX_FRAMES_IN_FLIGHT image available semaphores and as many
+	// fences. The fences must use VK_FENCE_CREATE_SIGNALED_BIT.
+	gLoge("gVKSync") << "gvkCreateFrameSyncObjects is not implemented yet.";
+	return false;
+}
+
+void gvkDestroyFrameSyncObjects(gVKContext& ctx) {
+	// TODO: destroy the semaphores and fences, then clear both vectors.
+}
+
+bool gvkCreatePresentSemaphores(gVKContext& ctx, uint32_t imagecount) {
+	// TODO: one semaphore per swapchain image, not per frame in flight.
+	gLoge("gVKSync") << "gvkCreatePresentSemaphores is not implemented yet.";
+	return false;
+}
+
+void gvkDestroyPresentSemaphores(gVKContext& ctx) {
+	// TODO: destroy the semaphores and clear the vector.
+}
+
+#endif /* GVK_DESKTOP_GLFW */

--- a/engine/core/gVKSync.cpp
+++ b/engine/core/gVKSync.cpp
@@ -1,8 +1,8 @@
 /*
  * gVKSync.cpp
  *
- * Skeleton created in phase 0. The bodies are filled in by the owner of this
- * module (Ozlem); see VULKAN_RENDERING_GOREV_DAGILIMI.md section 5.1.
+ * Synchronisation primitives of the Vulkan frame loop.
+ * See VULKAN_RENDERING_GOREV_DAGILIMI.md section 5.1 for the locked decisions.
  */
 
 #include "gVKSync.h"
@@ -12,24 +12,94 @@
 #include "gUtils.h"
 
 bool gvkCreateFrameSyncObjects(gVKContext& ctx) {
-	// TODO: GVK_MAX_FRAMES_IN_FLIGHT image available semaphores and as many
-	// fences. The fences must use VK_FENCE_CREATE_SIGNALED_BIT.
-	gLoge("gVKSync") << "gvkCreateFrameSyncObjects is not implemented yet.";
-	return false;
+	if(ctx.device == VK_NULL_HANDLE) {
+		gLoge("gVKSync") << "Cannot create the frame synchronisation objects before the device exists.";
+		return false;
+	}
+
+	ctx.imageavailablesemaphores.resize(GVK_MAX_FRAMES_IN_FLIGHT, VK_NULL_HANDLE);
+	ctx.inflightfences.resize(GVK_MAX_FRAMES_IN_FLIGHT, VK_NULL_HANDLE);
+
+	VkSemaphoreCreateInfo semaphoreinfo{};
+	semaphoreinfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+
+	VkFenceCreateInfo fenceinfo{};
+	fenceinfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+	// Created already signalled: the first frame waits on this fence before it has
+	// ever submitted anything, and an unsignalled fence would block forever there.
+	fenceinfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
+
+	for(int i = 0; i < GVK_MAX_FRAMES_IN_FLIGHT; i++) {
+		VkResult result = vkCreateSemaphore(ctx.device, &semaphoreinfo, nullptr, &ctx.imageavailablesemaphores[i]);
+		if(result != VK_SUCCESS) {
+			gLoge("gVKSync") << "vkCreateSemaphore failed for the image available semaphore of frame "
+					<< i << "! VkResult: " << result;
+			gvkDestroyFrameSyncObjects(ctx);
+			return false;
+		}
+		result = vkCreateFence(ctx.device, &fenceinfo, nullptr, &ctx.inflightfences[i]);
+		if(result != VK_SUCCESS) {
+			gLoge("gVKSync") << "vkCreateFence failed for frame " << i << "! VkResult: " << result;
+			gvkDestroyFrameSyncObjects(ctx);
+			return false;
+		}
+	}
+
+	gLogi("gVKSync") << "Frame synchronisation objects created for "
+			<< GVK_MAX_FRAMES_IN_FLIGHT << " frames in flight";
+	return true;
 }
 
 void gvkDestroyFrameSyncObjects(gVKContext& ctx) {
-	// TODO: destroy the semaphores and fences, then clear both vectors.
+	if(ctx.device == VK_NULL_HANDLE) return;
+
+	for(VkSemaphore semaphore : ctx.imageavailablesemaphores) {
+		if(semaphore != VK_NULL_HANDLE) vkDestroySemaphore(ctx.device, semaphore, nullptr);
+	}
+	ctx.imageavailablesemaphores.clear();
+
+	for(VkFence fence : ctx.inflightfences) {
+		if(fence != VK_NULL_HANDLE) vkDestroyFence(ctx.device, fence, nullptr);
+	}
+	ctx.inflightfences.clear();
 }
 
 bool gvkCreatePresentSemaphores(gVKContext& ctx, uint32_t imagecount) {
-	// TODO: one semaphore per swapchain image, not per frame in flight.
-	gLoge("gVKSync") << "gvkCreatePresentSemaphores is not implemented yet.";
-	return false;
+	if(ctx.device == VK_NULL_HANDLE) {
+		gLoge("gVKSync") << "Cannot create the present semaphores before the device exists.";
+		return false;
+	}
+	if(imagecount == 0) {
+		gLoge("gVKSync") << "Cannot create present semaphores for an empty swapchain.";
+		return false;
+	}
+
+	ctx.renderfinishedsemaphores.resize(imagecount, VK_NULL_HANDLE);
+
+	VkSemaphoreCreateInfo semaphoreinfo{};
+	semaphoreinfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+
+	for(uint32_t i = 0; i < imagecount; i++) {
+		VkResult result = vkCreateSemaphore(ctx.device, &semaphoreinfo, nullptr, &ctx.renderfinishedsemaphores[i]);
+		if(result != VK_SUCCESS) {
+			gLoge("gVKSync") << "vkCreateSemaphore failed for the render finished semaphore of image "
+					<< i << "! VkResult: " << result;
+			gvkDestroyPresentSemaphores(ctx);
+			return false;
+		}
+	}
+
+	gLogi("gVKSync") << "Present semaphores created: " << imagecount << " (one per swapchain image)";
+	return true;
 }
 
 void gvkDestroyPresentSemaphores(gVKContext& ctx) {
-	// TODO: destroy the semaphores and clear the vector.
+	if(ctx.device == VK_NULL_HANDLE) return;
+
+	for(VkSemaphore semaphore : ctx.renderfinishedsemaphores) {
+		if(semaphore != VK_NULL_HANDLE) vkDestroySemaphore(ctx.device, semaphore, nullptr);
+	}
+	ctx.renderfinishedsemaphores.clear();
 }
 
 #endif /* GVK_DESKTOP_GLFW */

--- a/engine/core/gVKSync.h
+++ b/engine/core/gVKSync.h
@@ -1,0 +1,38 @@
+/*
+ * gVKSync.h
+ *
+ * Synchronisation primitives of the Vulkan frame loop. Semaphores order work
+ * between GPU operations, fences let the CPU wait for the GPU.
+ * Owner: Ozlem.
+ */
+
+#pragma once
+
+#ifndef CORE_GVKSYNC_H
+#define CORE_GVKSYNC_H
+
+#include "gVKContext.h"
+
+#ifdef GVK_DESKTOP_GLFW
+
+/*
+ * Creates the per frame primitives: GVK_MAX_FRAMES_IN_FLIGHT image available
+ * semaphores and the same number of fences. The fences must be created already
+ * signalled, otherwise the very first vkWaitForFences never returns and the
+ * application freezes on its first frame.
+ */
+bool gvkCreateFrameSyncObjects(gVKContext& ctx);
+void gvkDestroyFrameSyncObjects(gVKContext& ctx);
+
+/*
+ * Creates one render finished semaphore per swapchain image. These are per image
+ * rather than per frame on purpose: presentation waits on the semaphore selected
+ * by the acquired image index, and binding them to the frame index instead makes
+ * current validation layers report semaphore reuse. Recreated with the swapchain.
+ */
+bool gvkCreatePresentSemaphores(gVKContext& ctx, uint32_t imagecount);
+void gvkDestroyPresentSemaphores(gVKContext& ctx);
+
+#endif /* GVK_DESKTOP_GLFW */
+
+#endif /* CORE_GVKSYNC_H */


### PR DESCRIPTION
Builds the Vulkan frame path on top of the existing initialisation: swapchain and image views, a render pass whose colour attachment clears, one framebuffer per swapchain image, the command pool and its per frame buffers, the synchronisation primitives, and the loop that acquires an image, records the render pass, submits and presents it. Selecting `G_RENDERER_VK` now fills the window with the clear colour instead of leaving it blank.

**What changed outside the Vulkan backend**
- `gRenderer` gained `beginFrame()` / `endFrame()`. Both are empty for OpenGL, which keeps drawing immediately, so that path is untouched.
- `gAppManager` drives them on the Vulkan path and keeps skipping the OpenGL-only startup and frame work, since the engine's drawing code still needs a GL context.
- `gGLFWWindow::update()` skips the OpenGL error checks together with `glfwSwapBuffers` under Vulkan: with no context to query, every frame reported `GL_INVALID_OPERATION` in debug builds.
- The Windows build now passes the validation layer directory from zbin to the engine, so machines without a Vulkan SDK can enable validation. The engine points the loader at it without overriding a value the developer exported.

**On `gVKContext`**
The struct moved from the `.cpp` into `gVKContext.h`, because the frame path is split across several modules that all need the same contract. The accessor design is kept as is, those modules are befriended alongside `gVKRenderEngine`, and `gVKRenderEngine.h` still only forward declares the type, so including it pulls in no Vulkan headers.

**Verified**
- Windows (clang64/MinGW, RTX 3060): instance through present is clean, validation reports nothing in a debug build, three window resizes rebuild the swapchain and its dependents, and the presented image matches the clear colour once sRGB encoding is accounted for.
- macOS: confirmed working by @MemoryHearth.
- OpenGL: unchanged and still the default — `game_martyr` (Bullet plugin, SQLite options, fullscreen) renders and exits without a single error in both release and debug builds.

Vulkan rendering of actual engine content is not part of this: the drawing methods in `gVKRenderEngine` are still the copied OpenGL bodies and are not reached on the Vulkan path.