### PR TITLE
Wire clearColor through the Vulkan frame path

### DIFF
--- a/engine/core/gAppManager.cpp
+++ b/engine/core/gAppManager.cpp
@@ -178,14 +178,11 @@ void gAppManager::setup() {
     if(setupcomplete) {
         return;
     }
-    // App setup loads images, fonts and shaders through the OpenGL path. It is
-    // skipped while the Vulkan backend has no rendering path, otherwise it would
-    // call GL functions without a context.
-    if(renderengine == G_RENDERER_VK) {
-        gLogi("gAppManager") << "Vulkan backend: skipping app setup until the Vulkan rendering path is implemented.";
-        setupcomplete = true;
-        return;
-    }
+    // gApp::setup() only creates the canvas and hands it to the canvas manager, so
+    // it is backend agnostic and runs under Vulkan too. The canvas' own setup() -
+    // which loads images and other OpenGL resources - is still driven separately by
+    // the canvas manager, and stays the developer's responsibility to keep Vulkan
+    // safe until the Vulkan drawing path exists.
     app->setup();
     setupcomplete = true;
 }
@@ -554,10 +551,20 @@ void gAppManager::tick() {
         return;
     }
 
-    // The Vulkan backend presents a cleared frame of its own. The engine's drawing
-    // code is still OpenGL only, so nothing is recorded between the two calls yet
-    // and the rest of the frame body stays skipped.
+    // Under Vulkan the engine's OpenGL geometry path stays disabled, but the app's
+    // clearColor() is already wired through: it records the frame's clear colour
+    // into the Vulkan context, and the render pass applies that colour when the
+    // frame begins. So the canvas update/draw runs first - letting a clearColor()
+    // call inside draw() choose the colour - and then the frame is cleared to it
+    // and presented. Real geometry is not recorded between the two calls yet.
     if(renderengine == G_RENDERER_VK) {
+        if(canvasmanager) canvasmanager->update();
+        gBaseCanvas* vkcanvas = (canvasmanager && !isguiapp) ? canvasmanager->getCurrentCanvas() : nullptr;
+        if(!isguiapp) app->update();
+        if(vkcanvas) {
+            vkcanvas->update();
+            vkcanvas->draw();
+        }
         if(renderer != nullptr && renderer->beginFrame()) {
             renderer->endFrame();
             totaldraws++;

--- a/engine/core/gVKCommands.cpp
+++ b/engine/core/gVKCommands.cpp
@@ -2,7 +2,6 @@
  * gVKCommands.cpp
  *
  * Command pool and command buffers of the Vulkan backend.
- * See VULKAN_RENDERING_GOREV_DAGILIMI.md section 5.2 for the locked decisions.
  */
 
 #include "gVKCommands.h"

--- a/engine/core/gVKCommands.h
+++ b/engine/core/gVKCommands.h
@@ -4,7 +4,7 @@
  * Command pool and command buffers of the Vulkan backend. Vulkan never executes a
  * command directly: commands are recorded into a command buffer and submitted to a
  * queue as a batch.
- * Owner: Efe.
+ * Created by: Efe Arda Palali.
  */
 
 #pragma once

--- a/engine/core/gVKFrame.cpp
+++ b/engine/core/gVKFrame.cpp
@@ -2,7 +2,7 @@
  * gVKFrame.cpp
  *
  * The Vulkan frame loop: acquire an image, record the render pass, submit and
- * present. See VULKAN_RENDERING_GOREV_DAGILIMI.md section 5.5.
+ * present.
  */
 
 #include "gVKFrame.h"

--- a/engine/core/gVKFrame.h
+++ b/engine/core/gVKFrame.h
@@ -3,7 +3,7 @@
  *
  * The Vulkan frame loop: acquire an image, record the command buffer, submit it
  * and present the result. This is the module the engine's main loop drives.
- * Owner: Mehmet.
+ * Created by: Mehmet Fatih Okur.
  */
 
 #pragma once

--- a/engine/core/gVKRenderEngine.cpp
+++ b/engine/core/gVKRenderEngine.cpp
@@ -173,94 +173,72 @@ void gVKRenderEngine::takeScreenshot(gImage& img) {
 }
 
 
+// The buffer, VAO, vertex-attribute and draw entry points below are OpenGL only.
+// A Vulkan window is created with GLFW_NO_API, so there is no current GL context
+// and issuing these calls is undefined behaviour - on macOS/MoltenVK it hangs, the
+// same way glViewport did during window init. Until the Vulkan resource path is
+// implemented they are safe no-ops, which is what lets gTexture/gImage objects be
+// constructed and destroyed under the Vulkan backend (their setupRenderData() and
+// cleanupAll() run through here) without freezing. The "create" calls hand back 0,
+// a handle the matching delete calls already treat as nothing to free.
 GLuint gVKRenderEngine::genBuffers() {
-	GLuint buffer;
-	G_CHECK_GL(glGenBuffers(1, &buffer));
-	return buffer;
+	return 0;
 }
 
 void gVKRenderEngine::deleteBuffer(GLuint& buffer) {
-	if (buffer != 0) {
-		G_CHECK_GL(glDeleteBuffers(1, &buffer));
-	}
 }
 
 void gVKRenderEngine::bindBuffer(GLenum target, GLuint buffer) {
-	G_CHECK_GL(glBindBuffer(target, buffer));
 }
 
 void gVKRenderEngine::unbindBuffer(GLenum target) {
-	G_CHECK_GL(glBindBuffer(target, 0));
 }
 
 void gVKRenderEngine::bufSubData(GLuint buffer, int offset, int size, const void* data) {
-	bindBuffer(GL_UNIFORM_BUFFER, buffer);
-	G_CHECK_GL(glBufferSubData(GL_UNIFORM_BUFFER, offset, size, data));
-	unbindBuffer(GL_UNIFORM_BUFFER);
 }
 
 void gVKRenderEngine::setBufferData(GLuint buffer, const void* data, size_t size, int usage) {
-	bindBuffer(GL_UNIFORM_BUFFER, buffer);
-	G_CHECK_GL(glBufferData(GL_UNIFORM_BUFFER, size, data, usage));
-	unbindBuffer(GL_UNIFORM_BUFFER);
 }
 
 void gVKRenderEngine::setBufferRange(int index, GLuint buffer, int offset, int size) {
-	G_CHECK_GL(glBindBufferRange(GL_UNIFORM_BUFFER, index, buffer, offset, size));
 }
 
-// ----- VAO -----l
+// ----- VAO -----
 GLuint gVKRenderEngine::createVAO() {
-	GLuint vao;
-	G_CHECK_GL(glGenVertexArrays(1, &vao));
-	return vao;
+	return 0;
 }
 
 void gVKRenderEngine::deleteVAO(GLuint& vao) {
-	if(vao != 0) {
-		G_CHECK_GL(glDeleteVertexArrays(1, &vao));
-	}
 }
 
 void gVKRenderEngine::bindVAO(GLuint vao) {
-	G_CHECK_GL(glBindVertexArray(vao));
 }
 
 void gVKRenderEngine::unbindVAO() {
-	G_CHECK_GL(glBindVertexArray(0));
 }
 
 void gVKRenderEngine::setVertexBufferData(GLuint vbo, size_t size, const void* data, int usage) {
-	G_CHECK_GL(glBindBuffer(GL_ARRAY_BUFFER, vbo));
-	G_CHECK_GL(glBufferData(GL_ARRAY_BUFFER, size, data, usage));
 }
 
 void gVKRenderEngine::setIndexBufferData(GLuint ebo, size_t size, const void* data, int usage) {
-	G_CHECK_GL(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ebo));
-	G_CHECK_GL(glBufferData(GL_ELEMENT_ARRAY_BUFFER, size, data, usage));
 }
 
 // ----- Draw -----
 void gVKRenderEngine::drawArrays(int drawMode, int count) {
-	G_CHECK_GL(glDrawArrays(drawMode, 0, count));
 }
 
 void gVKRenderEngine::drawElements(int drawMode, int count) {
-	G_CHECK_GL(glDrawElements(drawMode, count, G_INDEX_SIZE, 0));
 }
 
 // ----- vertex attributes -----
 void gVKRenderEngine::enableVertexAttrib(int index) {
-	G_CHECK_GL(glEnableVertexAttribArray(index));
 }
 
 void gVKRenderEngine::disableVertexAttrib(int index) {
-	G_CHECK_GL(glDisableVertexAttribArray(index));
 }
 
 void gVKRenderEngine::setVertexAttribPointer(int index, int size, int type, bool normalized, int stride,
                                              const void* pointer) {
-	G_CHECK_GL(glVertexAttribPointer(index, size, type, normalized ? GL_TRUE : GL_FALSE, stride, pointer));
 }
 
 void gVKRenderEngine::setViewport(int x, int y, int width, int height) {

--- a/engine/core/gVKRenderTarget.cpp
+++ b/engine/core/gVKRenderTarget.cpp
@@ -2,7 +2,6 @@
  * gVKRenderTarget.cpp
  *
  * Render pass and framebuffers of the Vulkan backend.
- * See VULKAN_RENDERING_GOREV_DAGILIMI.md section 5.3 for the locked decisions.
  */
 
 #include "gVKRenderTarget.h"

--- a/engine/core/gVKRenderTarget.h
+++ b/engine/core/gVKRenderTarget.h
@@ -4,7 +4,7 @@
  * Render pass and framebuffers of the Vulkan backend. The render pass is what
  * actually clears the screen: its colour attachment uses a CLEAR load operation,
  * so the clear value handed to vkCmdBeginRenderPass is written by the GPU.
- * Owner: Anil.
+ * Created by: Anil Emre Akkoc.
  */
 
 #pragma once

--- a/engine/core/gVKSwapchain.cpp
+++ b/engine/core/gVKSwapchain.cpp
@@ -1,8 +1,7 @@
 /*
  * gVKSwapchain.cpp
  *
- * Swapchain, its image views and the resize path. Owner: Burak.
- * See VULKAN_RENDERING_GOREV_DAGILIMI.md section 5.4 for the locked decisions.
+ * Swapchain, its image views and the resize path. Created by: Veysel Burak Eroglu.
  */
 
 #include "gVKSwapchain.h"

--- a/engine/core/gVKSwapchain.h
+++ b/engine/core/gVKSwapchain.h
@@ -2,7 +2,7 @@
  * gVKSwapchain.h
  *
  * Swapchain, its image views and the resize path of the Vulkan backend.
- * Owner: Burak.
+ * Created by: Veysel Burak Eroglu.
  */
 
 #pragma once

--- a/engine/core/gVKSync.cpp
+++ b/engine/core/gVKSync.cpp
@@ -2,7 +2,6 @@
  * gVKSync.cpp
  *
  * Synchronisation primitives of the Vulkan frame loop.
- * See VULKAN_RENDERING_GOREV_DAGILIMI.md section 5.1 for the locked decisions.
  */
 
 #include "gVKSync.h"

--- a/engine/core/gVKSync.h
+++ b/engine/core/gVKSync.h
@@ -3,7 +3,7 @@
  *
  * Synchronisation primitives of the Vulkan frame loop. Semaphores order work
  * between GPU operations, fences let the CPU wait for the GPU.
- * Owner: Ozlem.
+ * Created by: Ozlem Tutuneken.
  */
 
 #pragma once


### PR DESCRIPTION
## Summary
  Under Vulkan, `clearColor()` called from `gCanvas::draw()` now paints the window,
  mirroring the OpenGL behaviour.

  - **gAppManager**: the Vulkan tick runs the canvas `update()`/`draw()` before
    presenting, so a `clearColor()` inside `draw()` sets the frame's clear colour;
    `app->setup()` also runs so the canvas is created.
  - **gVKRenderEngine**: the OpenGL-only buffer/VAO/vertex-attribute/draw stubs are
    now safe no-ops, letting `gTexture`/`gImage` objects be constructed and destroyed
    without a GL context instead of hanging on macOS/MoltenVK.
  - Tidied a few comments in the source code files.