### PR TITLE
gGUIButton: Fixed text rendering offset when button is pressed to ensure

### DIFF
--- a/engine/ui/gGUIButton.cpp
+++ b/engine/ui/gGUIButton.cpp
@@ -87,6 +87,9 @@ void gGUIButton::draw() {
 	gColor* oldcolor = renderer->getColor();
 	const int drawleft = getButtonDrawLeft();
 	const int drawtop = getButtonDrawTop();
+
+	int pressedOffset = ispressed ? 2 : 0;
+
 	if(fillbackground) {
 		if(isdisabled) renderer->setColor(&disabledbcolor);
 		else {
@@ -95,7 +98,7 @@ void gGUIButton::draw() {
 			else renderer->setColor(&bcolor);
 		}
 	//	renderer->setColor(gColor(0.1f, 0.45f, 0.87f));
-		gDrawRectangle(drawleft, drawtop + ispressed, buttonw, buttonh, true);
+		gDrawRectangle(drawleft, drawtop + pressedOffset, buttonw, buttonh, true);
 	}
 
 	if(istextvisible) {
@@ -107,7 +110,7 @@ void gGUIButton::draw() {
 
 	    resetTitlePosition();
 
-	    font->drawText(title, drawleft + tx, drawtop + buttonh - ty + ispressed - 2);
+	    font->drawText(title, drawleft + tx, drawtop + buttonh - ty + pressedOffset - 2);
 	}
 	renderer->setColor(oldcolor);
 }


### PR DESCRIPTION
text moves in sync with the button background.