### PR TITLE
Add OpenGL instanced rendering

### DIFF
--- a/engine/core/gGLRenderEngine.cpp
+++ b/engine/core/gGLRenderEngine.cpp
@@ -266,6 +266,14 @@ void gGLRenderEngine::drawElements(int drawMode, int count) {
 	G_CHECK_GL(glDrawElements(drawMode, count, G_INDEX_SIZE, 0));
 }
 
+void gGLRenderEngine::drawArraysInstanced(int drawMode, int count, int instanceCount) {
+    G_CHECK_GL(glDrawArraysInstanced(drawMode, 0, count, instanceCount));
+}
+
+void gGLRenderEngine::drawElementsInstanced(int drawMode, int count, int instanceCount) {
+    G_CHECK_GL(glDrawElementsInstanced(drawMode, count, G_INDEX_SIZE, 0, instanceCount));
+}
+
 // ----- vertex attributes -----
 void gGLRenderEngine::enableVertexAttrib(int index) {
 	G_CHECK_GL(glEnableVertexAttribArray(index));
@@ -278,6 +286,10 @@ void gGLRenderEngine::disableVertexAttrib(int index) {
 void gGLRenderEngine::setVertexAttribPointer(int index, int size, int type, bool normalized, int stride,
                                              const void* pointer) {
 	G_CHECK_GL(glVertexAttribPointer(index, size, type, normalized ? GL_TRUE : GL_FALSE, stride, pointer));
+}
+
+void gGLRenderEngine::setVertexAttribDivisor(int index, int divisor) {
+    G_CHECK_GL(glVertexAttribDivisor(index, divisor));
 }
 
 void gGLRenderEngine::setViewport(int x, int y, int width, int height) {

--- a/engine/core/gGLRenderEngine.h
+++ b/engine/core/gGLRenderEngine.h
@@ -58,10 +58,13 @@ public:
 
 	void drawArrays(int drawMode, int count) override;
 	void drawElements(int drawMode, int count) override;
+	void drawArraysInstanced(int drawMode, int count, int instanceCount) override;
+	void drawElementsInstanced(int drawMode, int count, int instanceCount) override;
 
 	void enableVertexAttrib(int index) override;
 	void disableVertexAttrib(int index) override;
 	void setVertexAttribPointer(int index, int size, int type, bool normalized, int stride, const void* pointer) override;
+	void setVertexAttribDivisor(int index, int divisor) override;
 	void setViewport(int x, int y, int width, int height) override;
 
 	/* -------------- gFbo --------------- */

--- a/engine/core/gRenderer.h
+++ b/engine/core/gRenderer.h
@@ -409,10 +409,13 @@ public:
 
 	virtual void drawArrays(int drawMode, int count) = 0;
 	virtual void drawElements(int drawMode, int count) = 0;
+	virtual void drawArraysInstanced(int drawMode, int count, int instanceCount) = 0;
+	virtual void drawElementsInstanced(int drawMode, int count, int instanceCount) = 0;
 
 	virtual void enableVertexAttrib(int index) = 0;
 	virtual void disableVertexAttrib(int index) = 0;
 	virtual void setVertexAttribPointer(int index, int size, int type, bool normalized, int stride, const void* pointer) = 0;
+	virtual void setVertexAttribDivisor(int index, int divisor) = 0;
 
 	virtual void setViewport(int x, int y, int width, int height) = 0;
 	// Viewport that is currently set. Kept up to date by the render engines.

--- a/engine/core/gVKRenderEngine.cpp
+++ b/engine/core/gVKRenderEngine.cpp
@@ -230,6 +230,12 @@ void gVKRenderEngine::drawArrays(int drawMode, int count) {
 void gVKRenderEngine::drawElements(int drawMode, int count) {
 }
 
+void gVKRenderEngine::drawArraysInstanced(int drawMode, int count, int instanceCount) {
+}
+
+void gVKRenderEngine::drawElementsInstanced(int drawMode, int count, int instanceCount) {
+}
+
 // ----- vertex attributes -----
 void gVKRenderEngine::enableVertexAttrib(int index) {
 }
@@ -239,6 +245,9 @@ void gVKRenderEngine::disableVertexAttrib(int index) {
 
 void gVKRenderEngine::setVertexAttribPointer(int index, int size, int type, bool normalized, int stride,
                                              const void* pointer) {
+}
+
+void gVKRenderEngine::setVertexAttribDivisor(int index, int divisor) {
 }
 
 void gVKRenderEngine::setViewport(int x, int y, int width, int height) {

--- a/engine/core/gVKRenderEngine.h
+++ b/engine/core/gVKRenderEngine.h
@@ -66,10 +66,13 @@ public:
 
 	void drawArrays(int drawMode, int count) override;
 	void drawElements(int drawMode, int count) override;
+	void drawArraysInstanced(int drawMode, int count, int instanceCount) override;
+	void drawElementsInstanced(int drawMode, int count, int instanceCount) override;
 
 	void enableVertexAttrib(int index) override;
 	void disableVertexAttrib(int index) override;
 	void setVertexAttribPointer(int index, int size, int type, bool normalized, int stride, const void* pointer) override;
+	void setVertexAttribDivisor(int index, int divisor) override;
 	void setViewport(int x, int y, int width, int height) override;
 
 	/* -------------- gFbo --------------- */

--- a/engine/graphics/gMesh.cpp
+++ b/engine/graphics/gMesh.cpp
@@ -178,6 +178,18 @@ void gMesh::draw() {
 	drawEnd();
 }
 
+void gMesh::drawInstanced(const std::vector<glm::mat4>& instanceTransformations) {
+    G_PROFILE_ZONE_SCOPED_N("gMesh::drawInstanced()");
+
+    if (!isenabled || instanceTransformations.empty()) {
+        return;
+    }
+
+    drawStart(true);
+    drawVboInstanced(instanceTransformations);
+    drawEnd();
+}
+
 void gMesh::processTransformationMatrix() {
 	G_PROFILE_ZONE_SCOPED_N("gMesh::processTransformationMatrix()");
 	if (needsboundingboxrecalculation) {
@@ -269,11 +281,12 @@ void gMesh::bindMaterialTextures(gShader& shader) {
 	}
 }
 
-void gMesh::drawStart() {
+void gMesh::drawStart(bool isInstanced) {
 	G_PROFILE_ZONE_SCOPED_N("gMesh::drawStart()");
 		if(isshadowmappingenabled && renderpassno == 0) {
 			renderer->getShadowmapShader()->use();
 			renderer->getShadowmapShader()->setMat4("model", localtransformationmatrix.back());
+			renderer->getShadowmapShader()->setInt("useInstancing", isInstanced ? 1 : 0);
 			return;
 		}
 
@@ -289,12 +302,14 @@ void gMesh::drawStart() {
 				colorshader.setMat4("projection", renderer->getProjectionMatrix());
 			}
 			colorshader.setMat4("model", localtransformationmatrix.back());
+			colorshader.setInt("useInstancing", isInstanced ? 1 : 0);
 		} else { // isPBR
 			gShader& pbrshader = *renderer->getPbrShader();
 			pbrshader.use();
 			pbrshader.setMat4("projection", renderer->getProjectionMatrix());
 			pbrshader.setMat4("view", renderer->getViewMatrix());
 			pbrshader.setMat4("model", localtransformationmatrix.back());
+			pbrshader.setInt("useInstancing", isInstanced ? 1 : 0);
 			pbrshader.setVec3("camPos", renderer->getCameraPosition());
 			bindMaterialUniforms(pbrshader);
 			bindMaterialTextures(pbrshader);
@@ -312,6 +327,19 @@ void gMesh::drawVbo() {
     }
     vbo->unbind();
 //    vbo.clear();
+}
+
+void gMesh::drawVboInstanced(const std::vector<glm::mat4>& instanceTransformations) {
+    G_PROFILE_ZONE_SCOPED_N("gMesh::drawVboInstanced()");
+
+    vbo->setInstanceData(instanceTransformations.data(), static_cast<int>(instanceTransformations.size()));
+    vbo->bind();
+    if (vbo->isIndexDataAllocated()) {
+        renderer->drawElementsInstanced(drawmode, vbo->getIndicesNum(), static_cast<int>(instanceTransformations.size()));
+    } else {
+        renderer->drawArraysInstanced(drawmode,vbo->getVerticesNum(), static_cast<int>(instanceTransformations.size()));
+    }
+    vbo->unbind();
 }
 
 void gMesh::drawExtraShaders() {

--- a/engine/graphics/gMesh.h
+++ b/engine/graphics/gMesh.h
@@ -66,6 +66,7 @@ public:
 	gMaterial* getMaterial();
 
 	virtual void draw();
+	virtual void drawInstanced(const std::vector<glm::mat4>& instanceTransformations);
 
     const gBoundingBox& getInitialBoundingBox() const;
     bool intersectsTriangles(gRay* ray);
@@ -107,8 +108,9 @@ public:
 protected:
 	void processTransformationMatrix() override;
 
-    void drawStart();
+    void drawStart(bool isInstanced = false);
     void drawVbo();
+    void drawVboInstanced(const std::vector<glm::mat4>& instanceTransformations);
     void drawExtraShaders();
     void drawEnd();
     void bindMaterialUniforms(gShader& shader);

--- a/engine/graphics/gModel.cpp
+++ b/engine/graphics/gModel.cpp
@@ -117,6 +117,7 @@ void gModel::loadModelFile(const std::string& fullPath) {
     filename = fullPath.substr(fullPath.find_last_of('/') + 1, fullPath.length());
     animationnum = scene->mNumAnimations;
     isanimated = animationnum > 0;
+    staticmeshgroups.clear();
 
     // process ASSIMP's root node recursively
     processNode(scene->mRootNode, scene);
@@ -164,6 +165,7 @@ void gModel::loadModelFileWithOriginalVertices(const std::string &fullPath) {
     filename = fullPath.substr(fullPath.find_last_of('/') + 1, fullPath.length());
     animationnum = scene->mNumAnimations;
     isanimated = animationnum > 0;
+    staticmeshgroups.clear();
 
     // process ASSIMP's root node recursively
     processNode(scene->mRootNode, scene);
@@ -312,6 +314,12 @@ void gModel::setTransformationMatrix(const glm::mat4& transformationMatrix) {
 void gModel::draw() {
 	G_PROFILE_ZONE_SCOPED_N("gModel::draw()");
 	for(int i = 0; i < meshes.size(); i++) {
+		auto group = staticmeshgroups.find(meshindices[i]);
+		if (group != staticmeshgroups.end() &&
+		    group->second.instanceTransformations.size() > 1) {
+		    group->second.mesh->drawInstanced(group->second.instanceTransformations);
+		    continue;
+		}
 		if (isenablefrustumculling && renderer->getCamera() &&
 			!renderer->getCamera()->isInFrustum(meshes[i]->getBoundingBox())) {
 			continue;
@@ -322,13 +330,34 @@ void gModel::draw() {
 
 void gModel::drawInstanced(const std::vector<glm::mat4>& instanceTransformations) {
     G_PROFILE_ZONE_SCOPED_N("gModel::drawInstanced()");
-
     if (!isenabled || instanceTransformations.empty()) {
         return;
     }
 
-    for (gSkinnedMesh* mesh : meshes) {
-        mesh->drawInstanced(instanceTransformations);
+    for (size_t i = 0; i < meshes.size(); ++i) {
+        gSkinnedMesh* mesh = meshes[i];
+        const unsigned int meshIndex = meshindices[i];
+        auto group = staticmeshgroups.find(meshIndex);
+        if (group == staticmeshgroups.end() ||
+            group->second.instanceTransformations.size() == 1) {
+            mesh->drawInstanced(instanceTransformations);
+            continue;
+        }
+
+        std::vector<glm::mat4> combinedTransforms;
+        combinedTransforms.reserve(
+            instanceTransformations.size() *
+            group->second.instanceTransformations.size()
+        );
+        for (const glm::mat4& transformation : instanceTransformations) {
+            for (const glm::mat4& nodeTransformation :
+                 group->second.instanceTransformations) {
+                combinedTransforms.push_back(
+                    transformation * nodeTransformation
+                );
+            }
+        }
+        mesh->drawInstanced(combinedTransforms);
     }
 }
 
@@ -346,7 +375,7 @@ int gModel::getMeshNum() const {
 
 int gModel::getMeshNo(const std::string& meshName) const {
 	for(unsigned int i = 0; i < meshes.size(); i++) {
-		if (meshName == scene->mMeshes[i]->mName.C_Str()) return i;
+		if (meshName == scene->mMeshes[meshindices[i]]->mName.C_Str()) return i;
 	}
 	return -1;
 }
@@ -371,6 +400,20 @@ void gModel::processNode(aiNode* node, const aiScene* scene) {
 		// the scene contains all the data, node is just to keep stuff organized (like relations between nodes).
 		aiMesh* mesh = scene->mMeshes[meshIndex];
 		gLogi("gModel") << "Loading mesh:" << mesh->mName.C_Str() << ", vertexnum:" << mesh->mNumVertices << ", tm:" << node->mTransformation[0];
+		if (!isanimated && mesh->mNumBones == 0) {
+		    auto group = staticmeshgroups.find(meshIndex);
+
+		    if (group == staticmeshgroups.end()) {
+		        gSkinnedMesh* modelmesh = processMesh(mesh, scene, node->mTransformation);
+		        meshes.push_back(modelmesh);
+		        meshindices.push_back(meshIndex);
+		        modelmesh->setBaseMesh(modelmesh);
+		        group = staticmeshgroups.emplace(meshIndex, StaticMeshGroup{modelmesh, {}}).first;
+		    }
+		    group->second.instanceTransformations.push_back(getNodeTransformation(node));
+		    continue;
+		}
+
 		gSkinnedMesh* modelmesh = processMesh(mesh, scene, node->mTransformation);
 		meshes.push_back(modelmesh);
 		meshindices.push_back(meshIndex);
@@ -383,6 +426,21 @@ void gModel::processNode(aiNode* node, const aiScene* scene) {
 	for(unsigned int i = 0; i < node->mNumChildren; i++) {
 		processNode(node->mChildren[i], scene);
 	}
+}
+
+glm::mat4 gModel::getNodeTransformation(const aiNode* node) const {
+    glm::mat4 transformation(1.0f);
+
+    for (const aiNode* current = node;
+         current != nullptr;
+         current = current->mParent) {
+        transformation =
+            convertMatrix(current->mTransformation) * transformation;
+    }
+
+    return glm::inverse(
+        convertMatrix(scene->mRootNode->mTransformation)
+    ) * transformation;
 }
 
 gSkinnedMesh* gModel::processMesh(const aiMesh* mesh, const aiScene* scene, aiMatrix4x4 matrix) {
@@ -1015,7 +1073,7 @@ const gBoundingBox& gModel::getBoundingBox() {
 	return boundingbox;
 }
 
-glm::mat4 gModel::convertMatrix(const aiMatrix4x4 &aiMat) {
+glm::mat4 gModel::convertMatrix(const aiMatrix4x4 &aiMat) const {
 	return {
 	aiMat.a1, aiMat.b1, aiMat.c1, aiMat.d1,
 	aiMat.a2, aiMat.b2, aiMat.c2, aiMat.d2,

--- a/engine/graphics/gModel.cpp
+++ b/engine/graphics/gModel.cpp
@@ -320,6 +320,18 @@ void gModel::draw() {
 	}
 }
 
+void gModel::drawInstanced(const std::vector<glm::mat4>& instanceTransformations) {
+    G_PROFILE_ZONE_SCOPED_N("gModel::drawInstanced()");
+
+    if (!isenabled || instanceTransformations.empty()) {
+        return;
+    }
+
+    for (gSkinnedMesh* mesh : meshes) {
+        mesh->drawInstanced(instanceTransformations);
+    }
+}
+
 const std::string& gModel::getFilename() const {
 	return filename;
 }

--- a/engine/graphics/gModel.h
+++ b/engine/graphics/gModel.h
@@ -127,7 +127,12 @@ private:
 		std::shared_ptr<std::vector<gVertex>> vertices;
 		std::shared_ptr<std::vector<gIndex>> indices;
 	};
+	struct StaticMeshGroup {
+	    gSkinnedMesh* mesh;
+	    std::vector<glm::mat4> instanceTransformations;
+	};
 	std::unordered_map<const aiMesh*, SharedVertexIndex> mesh2svimap;
+	std::unordered_map<unsigned int, StaticMeshGroup> staticmeshgroups;
 
 	const aiScene* scene;
 	std::vector<const aiScene*> morphingtargetscenes;
@@ -136,6 +141,7 @@ private:
 	void loadMorphingTargetModelFile(const std::string& fullPath);
 	void processNode(aiNode* node, const aiScene* scene);
 	gSkinnedMesh* processMesh(const aiMesh* mesh, const aiScene* scene, aiMatrix4x4 matrix);
+	glm::mat4 getNodeTransformation(const aiNode* node) const;
 	void loadMaterialTextures(gSkinnedMesh* mesh, aiMaterial* mat, aiTextureType type, gTexture::TextureType textureType);
 	void processMorphingNode(const aiNode* node, const aiScene* scene);
 	gMesh* processMorphingMesh(const aiMesh* mesh, const aiScene* scene, aiMatrix4x4 matrix);
@@ -169,7 +175,7 @@ private:
 	std::unordered_map<std::string, aiNode*> nodemap;
 	std::vector<unsigned int> meshindices;
 
-    glm::mat4 convertMatrix(const aiMatrix4x4 &aiMat);
+	glm::mat4 convertMatrix(const aiMatrix4x4& aiMat) const;
     gBoundingBox initialboundingbox;
     gBoundingBox boundingbox;
 	bool isenablefrustumculling;

--- a/engine/graphics/gModel.h
+++ b/engine/graphics/gModel.h
@@ -47,6 +47,7 @@ public:
 	void loadMorphingTargetModel(const std::string& modelPath);
 	void load(const std::string& fullPath);
 	void draw();
+	void drawInstanced(const std::vector<glm::mat4>& instanceTransformations);
 
 	const std::string& getFilename() const;
 	const std::string getFullpath() const;

--- a/engine/graphics/gVbo.cpp
+++ b/engine/graphics/gVbo.cpp
@@ -14,6 +14,7 @@ gVbo::gVbo() {
 	vao = renderer->createVAO();
 	vbo = 0;
 	ebo = 0;
+	instancevbo = 0;
 	isenabled = true;
 	isvertexdataallocated = false;
 	vertexdatacoordnum = 0;
@@ -103,6 +104,27 @@ void gVbo::setIndexData(const gIndex* indices, int total) {
 	unbind();
 }
 
+void gVbo::setInstanceData(const glm::mat4* instanceTransformations, int instanceCount) {
+    if (instanceCount <= 0) {
+        return;
+    }
+
+    bind();
+    if (instancevbo == 0) {
+        instancevbo = renderer->genBuffers();
+    }
+    renderer->bindBuffer(GL_ARRAY_BUFFER, instancevbo);
+    renderer->setVertexBufferData(instancevbo, sizeof(glm::mat4) * instanceCount, instanceTransformations, GL_DYNAMIC_DRAW);
+    for (int i = 0; i < 4; ++i) {
+        const int attribute = 6 + i;
+        renderer->enableVertexAttrib(attribute);
+        renderer->setVertexAttribPointer(attribute, 4, GL_FLOAT, false, sizeof(glm::mat4), reinterpret_cast<const void*>(sizeof(glm::vec4) * i));
+        renderer->setVertexAttribDivisor(attribute, 1);
+    }
+
+    unbind();
+}
+
 void gVbo::clear() {
 	if(isvertexdataallocated) {
 		renderer->deleteBuffer(vbo);
@@ -112,6 +134,10 @@ void gVbo::clear() {
 		renderer->deleteBuffer(ebo);
 		isindexdataallocated = false;
     }
+	if (instancevbo != 0) {
+	    renderer->deleteBuffer(instancevbo);
+	    instancevbo = 0;
+	}
 	if (vao != GL_NONE) {
 		renderer->deleteVAO(vao);
 		vao = GL_NONE;

--- a/engine/graphics/gVbo.h
+++ b/engine/graphics/gVbo.h
@@ -37,6 +37,7 @@ public:
 
 	void setVertexData(const gVertex* vertices, int coordNum, int total);
 	void setIndexData(const gIndex* indices, int total);
+	void setInstanceData(const glm::mat4* instanceTransformations, int instanceCount);
 	void clear();
 
 	void bind() const;
@@ -67,7 +68,7 @@ public:
 
 private:
     GLuint vao;
-    GLuint vbo, ebo;
+    GLuint vbo, ebo, instancevbo;
     bool isenabled;
 
     bool isvertexdataallocated;

--- a/engine/graphics/shaders/color_vert.glsl
+++ b/engine/graphics/shaders/color_vert.glsl
@@ -12,6 +12,7 @@ layout (location = 2) in vec2 aTexCoords;
 layout (location = 3) in vec3 aTangent;
 layout (location = 4) in vec3 aBitangent;
 layout (location = 5) in vec3 color;
+layout (location = 6) in mat4 instanceModel;
 
 struct Material {
     vec4 ambient;
@@ -48,6 +49,7 @@ layout(std140) uniform Scene {
 uniform int aUseShadowMap;
 
 uniform mat4 model;
+uniform int useInstancing;
 uniform mat4 projection;
 uniform vec3 lightPos;
 uniform mat4 lightMatrix;
@@ -65,14 +67,15 @@ out mat3 TBN;
 flat out int mUseShadowMap;
 
 void main() {
+	mat4 modelMatrix = useInstancing == 1 ? model * instanceModel : model;
     mUseShadowMap = aUseShadowMap;
-    FragPos = vec3(model * vec4(aPos, 1.0));
-    Normal = mat3(transpose(inverse(model))) * aNormal;
+	FragPos = vec3(modelMatrix * vec4(aPos, 1.0));
+	Normal = mat3(transpose(inverse(modelMatrix))) * aNormal;
     TexCoords = aTexCoords;
     FragPosLightSpace = lightMatrix * vec4(FragPos, 1.0);
 
     if (material.useNormalMap > 0) {
-        mat3 normalMatrix = transpose(inverse(mat3(model)));
+		mat3 normalMatrix = transpose(inverse(mat3(modelMatrix)));
         vec3 T = normalize(normalMatrix * aTangent);
         vec3 N = normalize(normalMatrix * aNormal);
         T = normalize(T - dot(T, N) * N);
@@ -82,7 +85,7 @@ void main() {
         TangentFragPos = TBN * FragPos;
     }
 
-    mat4 modelViewMatrix = viewMatrix * model;
+	mat4 modelViewMatrix = viewMatrix * modelMatrix;
     mat4 projectedMatrix = projection * modelViewMatrix;
     vec4 aPosVec4 = vec4(aPos, 1.0);
     gl_Position = projectedMatrix * aPosVec4;

--- a/engine/graphics/shaders/pbr_vert.glsl
+++ b/engine/graphics/shaders/pbr_vert.glsl
@@ -7,6 +7,7 @@ precision highp float;
 layout (location = 0) in vec3 aPos;
 layout (location = 1) in vec3 aNormal;
 layout (location = 2) in vec2 aTexCoords;
+layout (location = 6) in mat4 instanceModel;
 
 out vec2 TexCoords;
 out vec3 WorldPos;
@@ -15,11 +16,13 @@ out vec3 Normal;
 uniform mat4 projection;
 uniform mat4 view;
 uniform mat4 model;
+uniform int useInstancing;
 
 void main() {
+	mat4 modelMatrix = useInstancing == 1 ? model * instanceModel : model;
     TexCoords = aTexCoords;
-    WorldPos = vec3(model * vec4(aPos, 1.0));
-    Normal = mat3(model) * aNormal;
+	WorldPos = vec3(modelMatrix * vec4(aPos, 1.0));
+	Normal = mat3(transpose(inverse(modelMatrix))) * aNormal;
 
     gl_Position =  projection * view * vec4(WorldPos, 1.0);
 }

--- a/engine/graphics/shaders/shadowmap_vert.glsl
+++ b/engine/graphics/shaders/shadowmap_vert.glsl
@@ -5,10 +5,12 @@ precision highp float;
 #version 330 core
 #endif
 layout (location = 0) in vec3 aPos;
+layout (location = 6) in mat4 instanceModel;
 
 uniform mat4 lightMatrix;
 uniform mat4 model;
+uniform int useInstancing;
 
 void main() {
-    gl_Position = lightMatrix * model * vec4(aPos, 1.0);
+    gl_Position = lightMatrix * (useInstancing == 1 ? model * instanceModel : model) * vec4(aPos, 1.0);
 }


### PR DESCRIPTION
### OpenGL Instanced Rendering
Adds instanced rendering support for gMesh and gModel.
Each instance uses a glm::mat4 transformation uploaded through a dedicated instance VBO. Indexed meshes use glDrawElementsInstanced, while non-indexed meshes use glDrawArraysInstanced.
Static Assimp nodes that share the same meshIndex are automatically grouped and rendered with a single instanced draw call through gModel::draw().
```
std::vector<glm::mat4> instanceTransformations;

mesh.drawInstanced(instanceTransformations);
model.drawInstanced(instanceTransformations);
```
Automatic Assimp grouping applies only to static meshes without bones. Animated, skinned, morphing, and extra/custom shader rendering continue to use their existing paths.