### PR TITLE
Match Vulkan color presentation with OpenGL

### DIFF
--- a/engine/core/gVKContext.h
+++ b/engine/core/gVKContext.h
@@ -401,8 +401,8 @@ private:
 	uint32_t currentframe = 0;
 	uint32_t currentimageindex = 0;
 	bool frameactive = false;
-	// Cornflower blue until clearColor() says otherwise.
-	VkClearValue clearvalue = {{{0.39f, 0.58f, 0.93f, 1.0f}}};
+	// Match gBaseCanvas::clearBackground(), the default used by the OpenGL path.
+	VkClearValue clearvalue = {{{0.0f, 0.0f, 30.0f / 255.0f, 0.0f}}};
 
 	// 2D draw path. Built after the frame path; VK_NULL_HANDLE / empty until then.
 	// renderpassactive tracks the lazily-begun render pass within a frame: geometry

--- a/engine/core/gVKRenderEngine.cpp
+++ b/engine/core/gVKRenderEngine.cpp
@@ -36,13 +36,38 @@
 	#include <string>
 	#include <cstring>
 	#include <cstdlib>
+	#include <algorithm>
+	#include <cmath>
 #endif
 
 #ifdef GVK_DESKTOP_GLFW
+static bool gvkSwapchainUsesSrgb(gVKContext* ctx) {
+	if(ctx == nullptr) return false;
+	const VkFormat format = *ctx->getSwapchainFormat();
+	return format == VK_FORMAT_R8G8B8A8_SRGB ||
+			format == VK_FORMAT_B8G8R8A8_SRGB ||
+			format == VK_FORMAT_A8B8G8R8_SRGB_PACK32;
+}
+
+// Engine colours are authored as the values expected in OpenGL's default
+// framebuffer. An sRGB Vulkan attachment, however, expects linear clear values
+// and encodes them while storing. Decode first so the stored/displayed value
+// remains identical to OpenGL (for example 30 stays 30 instead of becoming 96).
+static float gvkSrgbToLinear(float value) {
+	value = std::clamp(value, 0.0f, 1.0f);
+	if(value <= 0.04045f) return value / 12.92f;
+	return std::pow((value + 0.055f) / 1.055f, 2.4f);
+}
+
 // Unlike OpenGL, clearing is not an immediate operation here: the colour is kept
 // and the render pass writes it when the next frame begins.
 static void gvkStoreClearColor(gVKContext* ctx, float r, float g, float b, float a) {
 	if(ctx == nullptr) return;
+	if(gvkSwapchainUsesSrgb(ctx)) {
+		r = gvkSrgbToLinear(r);
+		g = gvkSrgbToLinear(g);
+		b = gvkSrgbToLinear(b);
+	}
 	// Through the accessor rather than the member: this helper is a free function,
 	// not part of the context's friendship.
 	VkClearValue* clearvalue = ctx->getClearValue();

--- a/engine/core/gVKRenderEngine.cpp
+++ b/engine/core/gVKRenderEngine.cpp
@@ -36,38 +36,13 @@
 	#include <string>
 	#include <cstring>
 	#include <cstdlib>
-	#include <algorithm>
-	#include <cmath>
 #endif
 
 #ifdef GVK_DESKTOP_GLFW
-static bool gvkSwapchainUsesSrgb(gVKContext* ctx) {
-	if(ctx == nullptr) return false;
-	const VkFormat format = *ctx->getSwapchainFormat();
-	return format == VK_FORMAT_R8G8B8A8_SRGB ||
-			format == VK_FORMAT_B8G8R8A8_SRGB ||
-			format == VK_FORMAT_A8B8G8R8_SRGB_PACK32;
-}
-
-// Engine colours are authored as the values expected in OpenGL's default
-// framebuffer. An sRGB Vulkan attachment, however, expects linear clear values
-// and encodes them while storing. Decode first so the stored/displayed value
-// remains identical to OpenGL (for example 30 stays 30 instead of becoming 96).
-static float gvkSrgbToLinear(float value) {
-	value = std::clamp(value, 0.0f, 1.0f);
-	if(value <= 0.04045f) return value / 12.92f;
-	return std::pow((value + 0.055f) / 1.055f, 2.4f);
-}
-
 // Unlike OpenGL, clearing is not an immediate operation here: the colour is kept
 // and the render pass writes it when the next frame begins.
 static void gvkStoreClearColor(gVKContext* ctx, float r, float g, float b, float a) {
 	if(ctx == nullptr) return;
-	if(gvkSwapchainUsesSrgb(ctx)) {
-		r = gvkSrgbToLinear(r);
-		g = gvkSrgbToLinear(g);
-		b = gvkSrgbToLinear(b);
-	}
 	// Through the accessor rather than the member: this helper is a free function,
 	// not part of the context's friendship.
 	VkClearValue* clearvalue = ctx->getClearValue();

--- a/engine/core/gVKRenderEngine.cpp
+++ b/engine/core/gVKRenderEngine.cpp
@@ -894,6 +894,13 @@ bool gVKRenderEngine::initVulkan() {
 	std::vector<const char*>& extensions = ctx->enabledinstanceextensions;
 	extensions.assign(glfwexts, glfwexts + glfwextcount);
 
+	// OpenGL's default framebuffer is a linear, pass-through target. When the
+	// presentation system exposes the matching Vulkan colour space, enable it so
+	// the compositor does not apply an extra sRGB colour-profile conversion.
+	if(gvkHasInstanceExtension(VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME)) {
+		extensions.push_back(VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME);
+	}
+
 #if defined(__APPLE__)
 	// MoltenVK is a portability driver: without these the loader does not even
 	// enumerate it and vkCreateInstance fails with VK_ERROR_INCOMPATIBLE_DRIVER.

--- a/engine/core/gVKSwapchain.cpp
+++ b/engine/core/gVKSwapchain.cpp
@@ -14,12 +14,21 @@
 #include <GLFW/glfw3.h>
 #include <algorithm>
 
-// Picks the surface format. sRGB is preferred so the presented colours match what
-// the rest of the engine assumes; if the driver does not offer it the first
-// reported format is used, which is always valid.
+// The OpenGL backend treats the engine's colour values as display-ready values.
+// Prefer an UNORM swapchain so Vulkan follows the same path without an implicit
+// linear-to-sRGB conversion on every clear and fragment output.
 static VkSurfaceFormatKHR gvkPickSurfaceFormat(const std::vector<VkSurfaceFormatKHR>& formats) {
+	if(formats.size() == 1 && formats[0].format == VK_FORMAT_UNDEFINED) {
+		return {VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR};
+	}
 	for(const auto& format : formats) {
-		if(format.format == VK_FORMAT_B8G8R8A8_SRGB &&
+		if(format.format == VK_FORMAT_B8G8R8A8_UNORM &&
+				format.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
+			return format;
+		}
+	}
+	for(const auto& format : formats) {
+		if(format.format == VK_FORMAT_R8G8B8A8_UNORM &&
 				format.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
 			return format;
 		}

--- a/engine/core/gVKSwapchain.cpp
+++ b/engine/core/gVKSwapchain.cpp
@@ -19,7 +19,19 @@
 // linear-to-sRGB conversion on every clear and fragment output.
 static VkSurfaceFormatKHR gvkPickSurfaceFormat(const std::vector<VkSurfaceFormatKHR>& formats) {
 	if(formats.size() == 1 && formats[0].format == VK_FORMAT_UNDEFINED) {
-		return {VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR};
+		return {VK_FORMAT_B8G8R8A8_UNORM, formats[0].colorSpace};
+	}
+	for(const auto& format : formats) {
+		if(format.format == VK_FORMAT_B8G8R8A8_UNORM &&
+				format.colorSpace == VK_COLOR_SPACE_PASS_THROUGH_EXT) {
+			return format;
+		}
+	}
+	for(const auto& format : formats) {
+		if(format.format == VK_FORMAT_R8G8B8A8_UNORM &&
+				format.colorSpace == VK_COLOR_SPACE_PASS_THROUGH_EXT) {
+			return format;
+		}
 	}
 	for(const auto& format : formats) {
 		if(format.format == VK_FORMAT_B8G8R8A8_UNORM &&
@@ -165,7 +177,8 @@ bool gvkCreateSwapchain(gVKContext& ctx, GLFWwindow* window) {
 
 	gLogi("gVKSwapchain") << "Swapchain created: " << createdcount << " images, "
 			<< ctx.swapchainextent.width << "x" << ctx.swapchainextent.height
-			<< ", format " << ctx.swapchainformat << ", present mode FIFO";
+			<< ", format " << ctx.swapchainformat << ", color space " << surfaceformat.colorSpace
+			<< ", present mode FIFO";
 	return true;
 }
 

--- a/engine/core/gVKTexture.cpp
+++ b/engine/core/gVKTexture.cpp
@@ -62,10 +62,9 @@ gVKTexture* gvkCreateTextureRGBA8(gVKContext& ctx, const void* rgbaPixels, int w
 	imageinfo.extent = {static_cast<uint32_t>(width), static_cast<uint32_t>(height), 1};
 	imageinfo.mipLevels = 1;
 	imageinfo.arrayLayers = 1;
-	// sRGB: the pixels come from ordinary image files (sRGB-encoded), so the sampler
-	// decodes them to linear for shading, and the sRGB swapchain re-encodes on write.
-	// Using a UNORM format here would double-encode and wash the image out.
-	imageinfo.format = VK_FORMAT_R8G8B8A8_SRGB;
+	// Keep file pixels as display-ready values, matching the OpenGL texture path
+	// and the UNORM swapchain. No implicit sRGB decode is performed while sampling.
+	imageinfo.format = VK_FORMAT_R8G8B8A8_UNORM;
 	imageinfo.tiling = VK_IMAGE_TILING_OPTIMAL;
 	imageinfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 	imageinfo.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
@@ -120,7 +119,7 @@ gVKTexture* gvkCreateTextureRGBA8(gVKContext& ctx, const void* rgbaPixels, int w
 	viewinfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
 	viewinfo.image = tex->image;
 	viewinfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
-	viewinfo.format = VK_FORMAT_R8G8B8A8_SRGB;
+	viewinfo.format = VK_FORMAT_R8G8B8A8_UNORM;
 	viewinfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 	viewinfo.subresourceRange.baseMipLevel = 0;
 	viewinfo.subresourceRange.levelCount = 1;


### PR DESCRIPTION
## Summary
- use UNORM swapchain and texture formats to match OpenGL's display-ready color values
- match Vulkan's default clear color to the OpenGL canvas default `(0, 0, 30, 0)`
- enable `VK_EXT_swapchain_colorspace` when available and prefer `VK_COLOR_SPACE_PASS_THROUGH_EXT`
- retain UNORM + sRGB nonlinear as a fallback when pass-through presentation is unavailable

## Root cause
OpenGL's default framebuffer is linear with framebuffer sRGB disabled, while Vulkan was presenting UNORM values through `VK_COLOR_SPACE_SRGB_NONLINEAR_KHR`. On macOS this let the compositor interpret the two windows through different presentation color spaces, producing slightly different visible tones even when their RGB values matched.

## Testing
- queried the OpenGL default framebuffer: `GL_LINEAR`, `GL_FRAMEBUFFER_SRGB` disabled
- built GlistApp-2 successfully
- ran GlistApp-2 with Vulkan on Apple M4 / MoltenVK
- confirmed `VK_FORMAT_B8G8R8A8_UNORM` with `VK_COLOR_SPACE_PASS_THROUGH_EXT`
- confirmed the first Vulkan frame was presented successfully