### PR TITLE
Add mesh texture tiling

### DIFF
--- a/engine/graphics/gMesh.cpp
+++ b/engine/graphics/gMesh.cpp
@@ -45,6 +45,7 @@ gMesh::gMesh(const gMesh& other) {
 	name = other.name;
 	drawmode = DRAWMODE_TRIANGLES;
 	isprojection2d = false;
+    texturetiling = other.texturetiling;
 	setVertices(other.vertices, other.indices);
 	setTextures(other.textures);
 }
@@ -150,6 +151,18 @@ void gMesh::setTexture(gTexture* texture) {
 
 gTexture* gMesh::getTexture(gTexture::TextureType textureType) {
 	return textures[textureType];
+}
+
+void gMesh::setTextureTiling(float tilingX, float tilingY) {
+    texturetiling = glm::vec2(tilingX, tilingY);
+}
+
+void gMesh::setTextureTiling(float tiling) {
+    setTextureTiling(tiling, tiling);
+}
+
+const glm::vec2& gMesh::getTextureTiling() const {
+    return texturetiling;
 }
 
 void gMesh::setDrawMode(int drawMode) {
@@ -303,6 +316,7 @@ void gMesh::drawStart(bool isInstanced) {
 		if(!material.isPBR()) {
 			gShader& colorshader = *renderer->getColorShader();
 			colorshader.use();
+			colorshader.setVec2("textureTiling", texturetiling);
 			bindMaterialUniforms(colorshader);
 			bindMaterialTextures(colorshader);
 
@@ -316,6 +330,7 @@ void gMesh::drawStart(bool isInstanced) {
 		} else { // isPBR
 			gShader& pbrshader = *renderer->getPbrShader();
 			pbrshader.use();
+			pbrshader.setVec2("textureTiling", texturetiling);
 			pbrshader.setMat4("projection", renderer->getProjectionMatrix());
 			pbrshader.setMat4("view", renderer->getViewMatrix());
 			pbrshader.setMat4("model", localtransformationmatrix.back());

--- a/engine/graphics/gMesh.h
+++ b/engine/graphics/gMesh.h
@@ -41,10 +41,15 @@ public:
 	void setVertices(const std::vector<gVertex>& vertices);
 	void setVertices(std::shared_ptr<std::vector<gVertex>> vertices);
 	void setVertices(std::shared_ptr<std::vector<gVertex>> vertices, std::shared_ptr<std::vector<gIndex>> indices);
+
 	void setTextures(const std::vector<gTexture*>& textures);
 	void setTextures(const std::unordered_map<gTexture::TextureType, gTexture*>& textures);
 	void setTexture(gTexture* texture);
 	gTexture* getTexture(gTexture::TextureType type);
+
+	void setTextureTiling(float tilingX, float tilingY);
+	void setTextureTiling(float tiling);
+	const glm::vec2& getTextureTiling() const;
 
 	std::vector<gVertex>& getVertices();
 	std::vector<gIndex>& getIndices();
@@ -141,6 +146,7 @@ private:
 	};
 	int drawmode;
     gMaterial material;
+    glm::vec2 texturetiling{1.0f, 1.0f};
 
     gBoundingBox initialboundingbox;
     gBoundingBox boundingbox;

--- a/engine/graphics/primitives/gPlane.cpp
+++ b/engine/graphics/primitives/gPlane.cpp
@@ -8,61 +8,41 @@
 #include "gPlane.h"
 
 gPlane::gPlane() {
-	tilingx = 1.0f;
-	tilingy = 1.0f;
-	initializePlane();
+    std::vector<gVertex> vertices(4);
+    std::vector<gIndex> indices = {0, 3, 1, 1, 3, 2};
+
+	// All vertices share the same normal, tangent, and bitangent for a flat plane
+    const glm::vec3 normal(0.0f, 0.0f, 1.0f);
+    const glm::vec3 tangent(1.0f, 0.0f, 0.0f);
+    const glm::vec3 bitangent(0.0f, -1.0f, 0.0f);
+
+    // Top right
+    vertices[0].position = glm::vec3(1.0f, 1.0f, 0.0f);
+    vertices[0].texcoords = glm::vec2(1.0f, 0.0f);
+
+    // Bottom right
+    vertices[1].position = glm::vec3(1.0f, -1.0f, 0.0f);
+    vertices[1].texcoords = glm::vec2(1.0f, 1.0f);
+
+    // Bottom left
+    vertices[2].position = glm::vec3(-1.0f, -1.0f, 0.0f);
+    vertices[2].texcoords = glm::vec2(0.0f, 1.0f);
+
+    // Top left
+    vertices[3].position = glm::vec3(-1.0f, 1.0f, 0.0f);
+    vertices[3].texcoords = glm::vec2(0.0f, 0.0f);
+
+    for (gVertex& vertex : vertices) {
+        vertex.normal = normal;
+        vertex.tangent = tangent;
+        vertex.bitangent = bitangent;
+    }
+
+    setVertices(
+        std::make_shared<std::vector<gVertex>>(std::move(vertices)),
+        std::make_shared<std::vector<gIndex>>(std::move(indices))
+    );
 }
 
 gPlane::~gPlane() {
-}
-
-void gPlane::setTextureTiling(float tilingX, float tilingY) {
-	tilingx = tilingX;
-	tilingy = tilingY;
-	initializePlane();
-}
-
-void gPlane::setTextureTiling(float tiling) {
-	setTextureTiling(tiling, tiling);
-}
-
-void gPlane::initializePlane() {
-	std::vector<gVertex> vertices(4);
-	std::vector<gIndex> indices = {0, 1, 3, 1, 2, 3};
-
-	// All vertices share the same normal, tangent, and bitangent for a flat plane
-	glm::vec3 normal(0.0f, 0.0f, 1.0f);
-	glm::vec3 tangent(1.0f, 0.0f, 0.0f);
-	glm::vec3 bitangent(0.0f, -1.0f, 0.0f);
-
-	// Top right
-	vertices[0].position = glm::vec3(1.0f, 1.0f, 0.0f);
-	vertices[0].texcoords = glm::vec2(tilingx, 0.0f);
-	vertices[0].normal = normal;
-	vertices[0].tangent = tangent;
-	vertices[0].bitangent = bitangent;
-
-	// Bottom right
-	vertices[1].position = glm::vec3(1.0f, -1.0f, 0.0f);
-	vertices[1].texcoords = glm::vec2(tilingx, tilingy);
-	vertices[1].normal = normal;
-	vertices[1].tangent = tangent;
-	vertices[1].bitangent = bitangent;
-
-	// Bottom left
-	vertices[2].position = glm::vec3(-1.0f, -1.0f, 0.0f);
-	vertices[2].texcoords = glm::vec2(0.0f, tilingy);
-	vertices[2].normal = normal;
-	vertices[2].tangent = tangent;
-	vertices[2].bitangent = bitangent;
-
-	// Top left
-	vertices[3].position = glm::vec3(-1.0f, 1.0f, 0.0f);
-	vertices[3].texcoords = glm::vec2(0.0f, 0.0f);
-	vertices[3].normal = normal;
-	vertices[3].tangent = tangent;
-	vertices[3].bitangent = bitangent;
-
-	setVertices(std::make_shared<std::vector<gVertex>>(std::move(vertices)),
-				std::make_shared<std::vector<gIndex>>(std::move(indices)));
 }

--- a/engine/graphics/primitives/gPlane.h
+++ b/engine/graphics/primitives/gPlane.h
@@ -29,14 +29,7 @@
 class gPlane : public gMesh {
 public:
 	gPlane();
-	virtual ~gPlane();
-
-	void setTextureTiling(float tilingX, float tilingY);
-	void setTextureTiling(float tiling);
-
-private:
-	void initializePlane();
-	float tilingx, tilingy;
+	virtual ~gPlane() override;
 };
 
 #endif /* ENGINE_GRAPHICS_PRIMITIVES_GPLANE_H_ */

--- a/engine/graphics/shaders/color_vert.glsl
+++ b/engine/graphics/shaders/color_vert.glsl
@@ -51,6 +51,7 @@ uniform int aUseShadowMap;
 uniform mat4 model;
 uniform int useInstancing;
 uniform mat4 projection;
+uniform vec2 textureTiling;
 uniform vec3 lightPos;
 uniform mat4 lightMatrix;
 
@@ -71,7 +72,7 @@ void main() {
     mUseShadowMap = aUseShadowMap;
 	FragPos = vec3(modelMatrix * vec4(aPos, 1.0));
 	Normal = mat3(transpose(inverse(modelMatrix))) * aNormal;
-    TexCoords = aTexCoords;
+    TexCoords = aTexCoords * textureTiling;
     FragPosLightSpace = lightMatrix * vec4(FragPos, 1.0);
 
     if (material.useNormalMap > 0) {

--- a/engine/graphics/shaders/pbr_vert.glsl
+++ b/engine/graphics/shaders/pbr_vert.glsl
@@ -17,10 +17,11 @@ uniform mat4 projection;
 uniform mat4 view;
 uniform mat4 model;
 uniform int useInstancing;
+uniform vec2 textureTiling;
 
 void main() {
 	mat4 modelMatrix = useInstancing == 1 ? model * instanceModel : model;
-    TexCoords = aTexCoords;
+    TexCoords = aTexCoords * textureTiling;
 	WorldPos = vec3(modelMatrix * vec4(aPos, 1.0));
 	Normal = mat3(transpose(inverse(modelMatrix))) * aNormal;
 


### PR DESCRIPTION
## Summary

- Added texture tiling controls to `gMesh`.
- Applied UV tiling in the OpenGL color and PBR vertex shaders.
- Moved texture tiling support away from `gPlane`.
- Simplified `gPlane` vertex data with shared normal, tangent, and bitangent values.

## Usage

```
mesh.setTextureTiling(5.0f);
mesh.setTextureTiling(4.0f, 2.0f);
```
Texture wrapping must use TEXTUREWRAP_REPEAT for tiled UV coordinates.

## Notes

- The default tiling value is (1.0f, 1.0f), preserving existing rendering behavior.
- Vulkan rendering was not changed.