### PR TITLE
fix(gRenderer): fix arrow tip thickness and resolve vertex join gap

### DIFF
--- a/engine/.settings/language.settings.xml
+++ b/engine/.settings/language.settings.xml
@@ -5,12 +5,12 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="false" name="CDT GCC Build Output Parser" parameter="(g?cc)|([gc]\+\+)|(clang)" prefer-non-shared="true"/>
-			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="false" env-hash="400516204369" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="false" env-hash="17659577096" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="370595759025" id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot; -std=c++14" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-12260868248" id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot; -std=c++14" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -22,12 +22,12 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider copy-of="extension" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser"/>
-			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="false" env-hash="437445388273" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="false" env-hash="-601625399070399400" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="392766635793" id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot; -std=c++14" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-643025134586586440" id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot; -std=c++14" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/engine/core/gRenderer.cpp
+++ b/engine/core/gRenderer.cpp
@@ -83,9 +83,9 @@ void gDrawArc(float xCenter, float yCenter, float radius, bool isFilled, int num
 	gRenderObject::getRenderer()->drawArc(xCenter, yCenter, radius, isFilled, numberOfSides, degree, rotate);
 }
 
-void gDrawArrow(float x1, float y1, float length, float angle, float tipLength, float tipAngle) {
+void gDrawArrow(float x1, float y1, float length, float angle, float tipLength, float tipAngle, float thickness) {
 	G_PROFILE_ZONE_SCOPED_N("gDrawArrow()");
-	gRenderObject::getRenderer()->drawArrow(x1, y1, length, angle, tipLength, tipAngle);
+	gRenderObject::getRenderer()->drawArrow(x1, y1, length, angle, tipLength, tipAngle, thickness);
 }
 
 void gDrawRectangle(float x, float y, float w, float h, bool isFilled) {
@@ -1594,14 +1594,37 @@ void gRenderer::drawArc(float xCenter, float yCenter, float radius, bool isFille
 	arcmesh->draw(xCenter, yCenter, radius, isFilled, numberOfSides, degree, rotate);
 }
 
-void gRenderer::drawArrow(float x1, float y1, float length, float angle, float tipLength, float tipAngle) {
+void gRenderer::drawArrow(float x1, float y1, float length, float angle, float tipLength, float tipAngle, float thickness) {
 	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawArrow()");
-	float x2, y2;
-	x2 = x1 + std::cos(gDegToRad(angle)) * length;
-	y2 = y1 + std::sin(gDegToRad(angle)) * length;;
-	linemesh->draw(x2, y2, x1, y1);
-	linemesh2->draw(x1, y1, x1 + std::cos(gDegToRad(angle) - gDegToRad(tipAngle)) * tipLength, y1 + std::sin(gDegToRad(angle) - gDegToRad(tipAngle)) * tipLength);
-	linemesh3->draw(x1, y1, x1 + (std::cos(gDegToRad(angle) + gDegToRad(tipAngle)) * tipLength) , y1 + std::sin(gDegToRad(angle) + gDegToRad(tipAngle)) * tipLength);
+	float x2 = x1 + std::cos(gDegToRad(angle)) * length;
+	float y2 = y1 + std::sin(gDegToRad(angle)) * length;
+
+	linemesh->setThickness(thickness);
+	linemesh2->setThickness(thickness);
+	linemesh3->setThickness(thickness);
+
+	float halfThickness = thickness * 0.8f;
+
+	float upperTipAngle = tipAngle + 5.0f;
+	float lowerTipAngle = tipAngle + 5.0f;
+
+	float wing1Angle = angle - upperTipAngle;
+	float wing2Angle = angle + lowerTipAngle;
+
+	float wing1StartX = x1 - halfThickness * std::sin(gDegToRad(wing1Angle));
+	float wing1StartY = y1 + halfThickness * std::cos(gDegToRad(wing1Angle));
+
+	float wing2StartX = x1 + halfThickness * std::sin(gDegToRad(wing2Angle));
+	float wing2StartY = y1 - halfThickness * std::cos(gDegToRad(wing2Angle));
+
+	float shaftOffset = halfThickness / std::sin(gDegToRad(tipAngle));
+	float bodyStartX = x1 + std::cos(gDegToRad(angle)) * shaftOffset;
+	float bodyStartY = y1 + std::sin(gDegToRad(angle)) * shaftOffset;
+
+	linemesh->draw(bodyStartX, bodyStartY, x2, y2);
+
+	linemesh2->draw(wing1StartX, wing1StartY, wing1StartX + std::cos(gDegToRad(wing1Angle)) * tipLength, wing1StartY + std::sin(gDegToRad(wing1Angle)) * tipLength);
+	linemesh3->draw(wing2StartX, wing2StartY, wing2StartX + std::cos(gDegToRad(wing2Angle)) * tipLength, wing2StartY + std::sin(gDegToRad(wing2Angle)) * tipLength);
 }
 
 void gRenderer::drawRectangle(float x, float y, float w, float h, bool isFilled) {

--- a/engine/core/gRenderer.h
+++ b/engine/core/gRenderer.h
@@ -85,7 +85,7 @@ void gDrawTriangle(float px, float py, float qx, float qy, float rx, float ry, b
 void gDrawCircle(float xCenter, float yCenter, float radius, bool isFilled = false, float numberOfSides = 64.0f);
 void gDrawCross(float x, float y, float width, float height, float thickness, bool isFilled);
 void gDrawArc(float xCenter, float yCenter, float radius, bool isFilled = true, int numberOfSides = 60, float degree = 360.0f, float rotate = 360.0f);
-void gDrawArrow(float x1, float y1, float length, float angle, float tipLength, float tipAngle);
+void gDrawArrow(float x1, float y1, float length, float angle, float tipLength, float tipAngle, float thickness = 1.0f);
 void gDrawRectangle(float x, float y, float w, float h, bool isFilled = false);
 void gDrawRoundedRectangle(float x, float y, float w, float h, int radius, bool isFilled);
 void gDrawBox(float x, float y, float z, float w = 1.0f, float h = 1.0f, float d = 1.0f, bool isFilled = true);
@@ -543,7 +543,7 @@ public:
 	void drawCircle(float xCenter, float yCenter, float radius, bool isFilled = false, float numberOfSides = 64.0f);
 	void drawCross(float x, float y, float width, float height, float thickness, bool isFilled);
 	void drawArc(float xCenter, float yCenter, float radius, bool isFilled = true, int numberOfSides = 60, float degree = 360.0f, float rotate = 360.0f);
-	void drawArrow(float x1, float y1, float length, float angle, float tipLength, float tipAngle);
+	void drawArrow(float x1, float y1, float length, float angle, float tipLength, float tipAngle, float thickness = 1.0f);
 	void drawRectangle(float x, float y, float w, float h, bool isFilled = false);
 	void drawRoundedRectangle(float x, float y, float w, float h, int radius, bool isFilled);
 	void drawBox(float x, float y, float z, float w = 1.0f, float h = 1.0f, float d = 1.0f, bool isFilled = true);


### PR DESCRIPTION
- Apply thickness setting correctly to arrow wing line meshes (linemesh2/3)
- Add overlap offset to wing starting positions to eliminate vertex notch