### PR TITLE
Batch gFont glyph rendering with a shared atlas

### DIFF
--- a/engine/core/gGLRenderEngine.cpp
+++ b/engine/core/gGLRenderEngine.cpp
@@ -53,6 +53,8 @@ int gGetCullingDirection() {
 }
 
 gGLRenderEngine::~gGLRenderEngine() {
+	if(textbatchvbo != 0) G_CHECK_GL(glDeleteBuffers(1, &textbatchvbo));
+	if(textbatchvao != 0) G_CHECK_GL(glDeleteVertexArrays(1, &textbatchvao));
 	delete originalgrid;
 }
 
@@ -570,6 +572,44 @@ void gGLRenderEngine::bindDefaultFramebuffer() {
 
 void gGLRenderEngine::drawVbo(const gVbo& vbo) {
 	G_CHECK_GL(glDrawArrays(GL_TRIANGLES, 0, vbo.getVerticesNum()));
+}
+
+void gGLRenderEngine::drawTexturedTriangles2D(GLuint textureId, const glm::vec4& tint,
+		const glm::mat4& mvp, const float* xyuv, int vertexCount) {
+	if(textureId == 0 || xyuv == nullptr || vertexCount <= 0) return;
+
+	if(textbatchvao == 0) {
+		G_CHECK_GL(glGenVertexArrays(1, &textbatchvao));
+		G_CHECK_GL(glGenBuffers(1, &textbatchvbo));
+		G_CHECK_GL(glBindVertexArray(textbatchvao));
+		G_CHECK_GL(glBindBuffer(GL_ARRAY_BUFFER, textbatchvbo));
+		G_CHECK_GL(glEnableVertexAttribArray(0));
+		G_CHECK_GL(glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, 4 * sizeof(float), nullptr));
+	}
+
+	gShader* shader = getImageShader();
+	shader->use();
+	shader->setMat4("projection", mvp);
+	shader->setMat4("model", glm::mat4(1.0f));
+	shader->setVec4("spriteColor", tint);
+	shader->setInt("image", 0);
+	shader->setBool("isAlphaMasking", false);
+	shader->setBool("isSubPart", false);
+
+	G_CHECK_GL(glActiveTexture(GL_TEXTURE0));
+	G_CHECK_GL(glBindTexture(GL_TEXTURE_2D, textureId));
+	G_CHECK_GL(glBindVertexArray(textbatchvao));
+	G_CHECK_GL(glBindBuffer(GL_ARRAY_BUFFER, textbatchvbo));
+	G_CHECK_GL(glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(vertexCount) * 4 * sizeof(float),
+			xyuv, GL_STREAM_DRAW));
+
+	const bool alphablending = isAlphaBlendingEnabled();
+	if(!alphablending) enableAlphaBlending();
+	G_CHECK_GL(glDrawArrays(GL_TRIANGLES, 0, vertexCount));
+	if(!alphablending) disableAlphaBlending();
+
+	G_CHECK_GL(glBindBuffer(GL_ARRAY_BUFFER, 0));
+	G_CHECK_GL(glBindVertexArray(0));
 }
 
 GLuint gGLRenderEngine::createTextures() {

--- a/engine/core/gGLRenderEngine.h
+++ b/engine/core/gGLRenderEngine.h
@@ -174,6 +174,10 @@ public:
 	void createQuad(GLuint& inQuadVAO, GLuint& inQuadVBO) override;
 	void enableCubeMap() override;
 
+	/* ---------------- 2D draw path ---------------- */
+	void drawTexturedTriangles2D(GLuint textureId, const glm::vec4& tint,
+			const glm::mat4& mvp, const float* xyuv, int vertexCount) override;
+
 	/* ---------------- gRenderObject ---------------- */
 	void pushMatrix() override;
 	void popMatrix() override;
@@ -183,6 +187,8 @@ protected:
 private:
 	mutable GLuint currentprogram = 0;
 	GLuint currentvao = 0;
+	GLuint textbatchvao = 0;
+	GLuint textbatchvbo = 0;
 	void updatePackUnpackAlignment(int i) override;
 };
 

--- a/engine/core/gRenderer.h
+++ b/engine/core/gRenderer.h
@@ -281,6 +281,13 @@ public:
 			const glm::mat4& mvp,
 			const glm::vec2& uvOffset = glm::vec2(0.0f), const glm::vec2& uvScale = glm::vec2(1.0f)) {}
 
+	// Backend hook for an already-expanded textured triangle list. xyuv contains
+	// four floats per vertex: screen-space x/y followed by texture u/v. This is
+	// used by batched text, where all glyph quads share one atlas texture and can
+	// therefore be recorded as one draw instead of one draw per glyph.
+	virtual void drawTexturedTriangles2D(GLuint textureId, const glm::vec4& tint,
+			const glm::mat4& mvp, const float* xyuv, int vertexCount) {}
+
 	virtual void clear() = 0;
 	virtual void clearColor(int r, int g, int b, int a = 255) = 0;
 	virtual void clearColor(gColor color) = 0;

--- a/engine/core/gVKDraw.cpp
+++ b/engine/core/gVKDraw.cpp
@@ -192,4 +192,31 @@ void gvkDrawTextured2D(gVKContext& ctx, VkDescriptorSet textureSet, VkDescriptor
 	vkCmdDraw(cmd, 6, 1, 0, 0);
 }
 
+void gvkDrawTexturedTriangles2D(gVKContext& ctx, VkDescriptorSet textureSet,
+		const glm::vec4& tint, const glm::mat4& mvp, const float* xyuv, int vertexCount) {
+	if(xyuv == nullptr || vertexCount <= 0 || !gvkEnsureRenderPass(ctx)) return;
+	VkCommandBuffer cmd = ctx.getCurrentCommandBuffer();
+	if(cmd == VK_NULL_HANDLE || ctx.getImage2DPipeline() == VK_NULL_HANDLE || textureSet == VK_NULL_HANDLE) return;
+
+	const VkDeviceSize vertexbytes = static_cast<VkDeviceSize>(vertexCount) * sizeof(gvkImageVertex);
+	VkDeviceSize offset = ctx.pushDynamicVertices(xyuv, vertexbytes);
+	if(offset == VK_WHOLE_SIZE) {
+		gLogw("gVKDraw") << "Dynamic vertex buffer full; dropping a textured triangle batch.";
+		return;
+	}
+
+	vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, ctx.getImage2DPipeline());
+	VkBuffer vbuf = ctx.getCurrentDynamicVertexBuffer();
+	vkCmdBindVertexBuffers(cmd, 0, 1, &vbuf, &offset);
+
+	VkPipelineLayout layout = ctx.getImage2DPipelineLayout();
+	VkDescriptorSet sets[2] = {textureSet, textureSet};
+	vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, layout, 0, 2, sets, 0, nullptr);
+
+	gvkPush push{mvp, tint, 0};
+	const uint32_t pushsize = std::min<uint32_t>(sizeof(push), ctx.getImage2DPushSize());
+	if(pushsize > 0) vkCmdPushConstants(cmd, layout, ctx.getImage2DPushStages(), 0, pushsize, &push);
+	vkCmdDraw(cmd, static_cast<uint32_t>(vertexCount), 1, 0, 0);
+}
+
 #endif /* GVK_DESKTOP_GLFW */

--- a/engine/core/gVKDraw.h
+++ b/engine/core/gVKDraw.h
@@ -50,6 +50,11 @@ void gvkDrawTextured2D(gVKContext& ctx, VkDescriptorSet textureSet, VkDescriptor
 		const glm::vec4& tint, const glm::mat4& mvp,
 		const glm::vec2& uvOffset = glm::vec2(0.0f), const glm::vec2& uvScale = glm::vec2(1.0f));
 
+// Records an expanded textured triangle list. xyuv has four floats per vertex
+// and matches the image pipeline's position/UV vertex layout.
+void gvkDrawTexturedTriangles2D(gVKContext& ctx, VkDescriptorSet textureSet,
+		const glm::vec4& tint, const glm::mat4& mvp, const float* xyuv, int vertexCount);
+
 #endif /* GVK_DESKTOP_GLFW */
 
 #endif /* CORE_GVKDRAW_H */

--- a/engine/core/gVKRenderEngine.cpp
+++ b/engine/core/gVKRenderEngine.cpp
@@ -1447,6 +1447,16 @@ void gVKRenderEngine::drawTexturedRect2D(GLuint textureId, GLuint maskTextureId,
 #endif
 }
 
+void gVKRenderEngine::drawTexturedTriangles2D(GLuint textureId, const glm::vec4& tint,
+		const glm::mat4& mvp, const float* xyuv, int vertexCount) {
+#ifdef GVK_DESKTOP_GLFW
+	if(vkcontext == nullptr) return;
+	auto it = vktextures.find(textureId);
+	if(it == vktextures.end() || it->second == nullptr) return;
+	gvkDrawTexturedTriangles2D(*vkcontext, it->second->descriptorset, tint, mvp, xyuv, vertexCount);
+#endif
+}
+
 gVKTexture* gVKRenderEngine::getBoundVKTexture() {
 #ifdef GVK_DESKTOP_GLFW
 	if(vkcontext == nullptr || boundtextureid == 0) return nullptr;

--- a/engine/core/gVKRenderEngine.h
+++ b/engine/core/gVKRenderEngine.h
@@ -201,6 +201,8 @@ public:
 	void drawTexturedRect2D(GLuint textureId, GLuint maskTextureId, const glm::vec4& tint,
 			const glm::mat4& mvp,
 			const glm::vec2& uvOffset = glm::vec2(0.0f), const glm::vec2& uvScale = glm::vec2(1.0f)) override;
+	void drawTexturedTriangles2D(GLuint textureId, const glm::vec4& tint,
+			const glm::mat4& mvp, const float* xyuv, int vertexCount) override;
 
 	/* ---------------- Vulkan context ---------------- */
 	// gVKContext is opaque here (its layout lives in the .cpp), so a developer can

--- a/engine/graphics/gFont.cpp
+++ b/engine/graphics/gFont.cpp
@@ -21,6 +21,8 @@
 gFont::gFont() = default;
 
 gFont::~gFont() {
+	delete atlastexture;
+	atlastexture = nullptr;
 	if (fontface) {
 		for (std::pair<const int, gTexture*> pair : chartextures) {
 			delete pair.second;
@@ -67,7 +69,9 @@ bool gFont::load(const std::string& fullPath, int size, bool isAntialiased, int 
 
 	iskerning = FT_HAS_KERNING(fontface);
 
-	resizeVectors(characternumlimit);
+	if (!buildAtlas()) {
+		resizeVectors(characternumlimit);
+	}
 
 	isloaded = true;
 	return true;
@@ -75,6 +79,14 @@ bool gFont::load(const std::string& fullPath, int size, bool isAntialiased, int 
 
 bool gFont::loadFont(const std::string& fontPath, int size, bool isAntialiased, int dpi) {
 	return load(gGetFontsDir() + fontPath, size, isAntialiased, dpi);
+}
+
+void gFont::setTextRenderMode(TextRenderMode renderMode) {
+	textrendermode = renderMode;
+}
+
+gFont::TextRenderMode gFont::getTextRenderMode() const {
+	return textrendermode;
 }
 
 void gFont::getVisualBoundsX(const std::string& text, float& xmin, float& xmax) {
@@ -150,38 +162,153 @@ void gFont::reloadFont() {
 	}
 	chartextures.clear();
 	charproperties.clear();
+	delete atlastexture;
+	atlastexture = nullptr;
 
-	// Reload space character
-	loadChar(' ');
+	if (!buildAtlas()) {
+		// Reload space character for the legacy per-glyph texture path.
+		loadChar(' ');
+	}
+}
+
+bool gFont::buildAtlas() {
+	if (!fontface) return false;
+
+	delete atlastexture;
+	atlastexture = nullptr;
+	charproperties.clear();
+	atlaspixels.resize(static_cast<size_t>(atlaswidth) * atlasheight * 4);
+	for (size_t i = 0; i < atlaspixels.size(); i += 4) {
+		atlaspixels[i] = 255;
+		atlaspixels[i + 1] = 255;
+		atlaspixels[i + 2] = 255;
+		atlaspixels[i + 3] = 0;
+	}
+	atlascursorx = 0;
+	atlascursory = 0;
+	atlasrowheight = 0;
+	atlasbuilding = true;
+
+	// The existing font cache limit is 1000 codepoints. Prepacking the same range
+	// covers Latin, Latin Extended (including Turkish), Greek and Cyrillic while
+	// keeping the atlas immutable after it has entered a submitted frame.
+	for (int c = 32; c < characternumlimit; ++c) {
+		if (FT_Get_Char_Index(fontface, c) != 0 || c == ' ') loadChar(c);
+	}
+	atlasbuilding = false;
+
+	bool hasglyph = false;
+	for (const auto& entry : charproperties) {
+		if (entry.second.inatlas) {
+			hasglyph = true;
+			break;
+		}
+	}
+	if (!hasglyph) {
+		atlaspixels.clear();
+		return false;
+	}
+
+	atlastexture = new gTexture(atlaswidth, atlasheight, GL_RGBA, false);
+	atlastexture->setFiltering(
+			isantialiased ? gTexture::TEXTUREMINMAGFILTER_LINEAR : gTexture::TEXTUREMINMAGFILTER_NEAREST,
+			isantialiased ? gTexture::TEXTUREMINMAGFILTER_LINEAR : gTexture::TEXTUREMINMAGFILTER_NEAREST);
+	atlastexture->setData(atlaspixels.data(), atlaswidth, atlasheight, 4, false, false);
+	atlaspixels.clear();
+	atlaspixels.shrink_to_fit();
+
+	gLogi("gFont") << "Glyph atlas ready: " << atlaswidth << "x" << atlasheight
+			<< ", cached glyphs: " << charproperties.size();
+	return true;
 }
 
 void gFont::drawText(const std::string& text, float x, float y) {
 	G_PROFILE_ZONE_SCOPED_N("gFont::drawText()");
-	float posx = x;
-	float posy = y;
-
 	std::wstring wtext = s2ws(text);
-	size_t len = wtext.length();
-
-	int previous = -1;
-	for (size_t i = 0; i < len; ++i) {
-		int c = wtext[i];
-
-		if (c == '\n') {
-			posy += lineheight;
-			posx = x;
-		} else {
-			if (charproperties.find(c) == charproperties.end()) {
-				loadChar(c);
-			}
-			posx += getKerning(c, previous);
-			float drawx = roundIfRequired(posx + charproperties[c].leftmargin);
-			float drawy = roundIfRequired(posy + charproperties[c].dytop);
-			chartextures[c]->draw(glm::vec2(drawx, drawy),
-								  glm::vec2(charproperties[c].texturewidth, charproperties[c].textureheight));
-			posx += charproperties[c].advance * letterspacing * (c == ' ' ? spacesize : 1.0f);
+	bool canbatch = textrendermode == TextRenderMode::ATLAS && atlastexture != nullptr && !wtext.empty();
+	for (wchar_t wc : wtext) {
+		const int c = static_cast<int>(wc);
+		if (c == '\n') continue;
+		auto it = charproperties.find(c);
+		if (it == charproperties.end() || !it->second.inatlas) {
+			canbatch = false;
+			break;
 		}
-		previous = c;
+	}
+
+	if (canbatch) {
+		batchvertices.clear();
+		batchvertices.reserve(wtext.size() * 6 * 4);
+		float posx = x;
+		float posy = y;
+		int previous = -1;
+
+		auto appendvertex = [this](float px, float py, float u, float v) {
+			batchvertices.push_back(px);
+			batchvertices.push_back(py);
+			batchvertices.push_back(u);
+			batchvertices.push_back(v);
+		};
+
+		for (wchar_t wc : wtext) {
+			const int c = static_cast<int>(wc);
+			if (c == '\n') {
+				posy += lineheight;
+				posx = x;
+				previous = -1;
+				continue;
+			}
+
+			const CharProperties& p = charproperties[c];
+			posx += getKerning(c, previous);
+			const float x0 = roundIfRequired(posx + p.leftmargin);
+			const float y0 = roundIfRequired(posy + p.dytop);
+			const float x1 = x0 + p.texturewidth;
+			const float y1 = y0 + p.textureheight;
+
+			appendvertex(x0, y0, p.atlasu0, p.atlasv0);
+			appendvertex(x1, y0, p.atlasu1, p.atlasv0);
+			appendvertex(x1, y1, p.atlasu1, p.atlasv1);
+			appendvertex(x0, y0, p.atlasu0, p.atlasv0);
+			appendvertex(x1, y1, p.atlasu1, p.atlasv1);
+			appendvertex(x0, y1, p.atlasu0, p.atlasv1);
+
+			posx += p.advance * letterspacing * (c == ' ' ? spacesize : 1.0f);
+			previous = c;
+		}
+
+		if (!batchvertices.empty()) {
+			renderer->setProjectionMatrix2d(glm::ortho(0.0f, static_cast<float>(renderer->getWidth()),
+					static_cast<float>(renderer->getHeight()), 0.0f, -1.0f, 1.0f));
+			gColor* color = renderer->getColor();
+			const glm::vec4 tint(color->r, color->g, color->b, color->a);
+			renderer->drawTexturedTriangles2D(atlastexture->getId(), tint, renderer->getProjectionMatrix2d(),
+					batchvertices.data(), static_cast<int>(batchvertices.size() / 4));
+		}
+	} else {
+		float posx = x;
+		float posy = y;
+		int previous = -1;
+		for (wchar_t wc : wtext) {
+			const int c = static_cast<int>(wc);
+			if (c == '\n') {
+				posy += lineheight;
+				posx = x;
+				previous = -1;
+				continue;
+			}
+			if (chartextures.find(c) == chartextures.end()) loadChar(c);
+			auto texture = chartextures.find(c);
+			if (texture == chartextures.end() || texture->second == nullptr) continue;
+
+			const CharProperties& p = charproperties[c];
+			posx += getKerning(c, previous);
+			const float drawx = roundIfRequired(posx + p.leftmargin);
+			const float drawy = roundIfRequired(posy + p.dytop);
+			texture->second->draw(glm::vec2(drawx, drawy), glm::vec2(p.texturewidth, p.textureheight));
+			posx += p.advance * letterspacing * (c == ' ' ? spacesize : 1.0f);
+			previous = c;
+		}
 	}
 }
 
@@ -201,9 +328,10 @@ void gFont::drawTextVerticallyFlipped(const std::string& text, float x, float y)
 			posy -= lineheight;
 			posx = x;
 		} else {
-			if (charproperties.find(c) == charproperties.end()) {
+			if (chartextures.find(c) == chartextures.end()) {
 				loadChar(c);
 			}
+			if (chartextures.find(c) == chartextures.end() || chartextures[c] == nullptr) continue;
 			posx += getKerning(c, previous);
 			float drawx = roundIfRequired(posx + charproperties[c].leftmargin);
 			float drawy = roundIfRequired(posy - charproperties[c].dytop);
@@ -226,7 +354,7 @@ void gFont::drawTextHorizontallyFlipped(const std::string& text, float x, float 
 	float totalwidth = 0.0f;
 	for (size_t i = 0; i < len; ++i) {
 		int c = wtext[i];
-		if (charproperties.find(c) == charproperties.end()) {
+		if (chartextures.find(c) == chartextures.end()) {
 			loadChar(c);
 		}
 		totalwidth += charproperties[c].advance * letterspacing * (c == ' ' ? spacesize : 1.0f);
@@ -248,9 +376,10 @@ void gFont::drawTextHorizontallyFlipped(const std::string& text, float x, float 
 			posy += lineheight;
 			posx = x + totalwidth;
 		} else {
-			if (charproperties.find(c) == charproperties.end()) {
+			if (chartextures.find(c) == chartextures.end()) {
 				loadChar(c);
 			}
+			if (chartextures.find(c) == chartextures.end() || chartextures[c] == nullptr) continue;
 
 			float kerning = getKerning(c, prevChar);
 			posx -= kerning;
@@ -397,15 +526,19 @@ void gFont::loadChar(int charCode) {
 		}
 	}
 
-	int longside = border * 2 + std::max(dataw, datah);
-
-	// Find next power of 2
-	int longest = 1;
-	while (longside > longest) {
-		longest <<= 1;
+	int pixelsw;
+	int pixelsh;
+	if (atlasbuilding) {
+		pixelsw = border * 2 + dataw;
+		pixelsh = border * 2 + datah;
+	} else {
+		const int longside = border * 2 + std::max(dataw, datah);
+		// The legacy per-glyph path keeps its original square power-of-two texture.
+		int longest = 1;
+		while (longside > longest) longest <<= 1;
+		pixelsw = longest;
+		pixelsh = longest;
 	}
-	int pixelsw = longest;
-	int pixelsh = longest;
 
 	std::vector<unsigned char> pixels(pixelsw * pixelsh * 4);
 	for (int i = 0; i < pixelsw * pixelsh; ++i) {
@@ -418,16 +551,36 @@ void gFont::loadChar(int charCode) {
 
 	insertData(data.data(), dataw, datah, 4, pixels.data(), pixelsw, pixelsh, 4, border, border);
 
-	chartextures[charCode] = new gTexture(pixelsw, pixelsh, GL_RGBA, false);
-
-	chartextures[charCode]->setFiltering(
-			isantialiased ? gTexture::TEXTUREMINMAGFILTER_LINEAR : gTexture::TEXTUREMINMAGFILTER_NEAREST,
-			isantialiased ? gTexture::TEXTUREMINMAGFILTER_LINEAR : gTexture::TEXTUREMINMAGFILTER_NEAREST);
-
-	chartextures[charCode]->setData(pixels.data(), pixelsw, pixelsh, 4, false, false);
-
 	// Prepare properties
 	CharProperties& props = charproperties[charCode];
+	if (atlasbuilding) {
+		if (atlascursorx + pixelsw > atlaswidth) {
+			atlascursorx = 0;
+			atlascursory += atlasrowheight;
+			atlasrowheight = 0;
+		}
+		if (atlascursory + pixelsh <= atlasheight) {
+			insertData(pixels.data(), pixelsw, pixelsh, 4, atlaspixels.data(), atlaswidth, atlasheight, 4,
+					static_cast<size_t>(atlascursorx), static_cast<size_t>(atlascursory));
+			props.atlasu0 = static_cast<float>(atlascursorx) / atlaswidth;
+			props.atlasv0 = static_cast<float>(atlascursory) / atlasheight;
+			props.atlasu1 = static_cast<float>(atlascursorx + pixelsw) / atlaswidth;
+			props.atlasv1 = static_cast<float>(atlascursory + pixelsh) / atlasheight;
+			props.inatlas = true;
+			atlascursorx += pixelsw;
+			atlasrowheight = std::max(atlasrowheight, pixelsh);
+		} else {
+			props.inatlas = false;
+		}
+	} else {
+		auto existing = chartextures.find(charCode);
+		if (existing != chartextures.end()) delete existing->second;
+		chartextures[charCode] = new gTexture(pixelsw, pixelsh, GL_RGBA, false);
+		chartextures[charCode]->setFiltering(
+				isantialiased ? gTexture::TEXTUREMINMAGFILTER_LINEAR : gTexture::TEXTUREMINMAGFILTER_NEAREST,
+				isantialiased ? gTexture::TEXTUREMINMAGFILTER_LINEAR : gTexture::TEXTUREMINMAGFILTER_NEAREST);
+		chartextures[charCode]->setData(pixels.data(), pixelsw, pixelsh, 4, false, false);
+	}
 
 	// Simply divide all metrics by scale - no rounding
 	props.height = static_cast<float>(glyph->bitmap_top) / scale;
@@ -443,8 +596,8 @@ void gFont::loadChar(int charCode) {
 	props.dxright = props.leftmargin + props.width;
 	props.dybottom = props.height + lccorr;
 
-	props.texturewidth = static_cast<float>(chartextures[charCode]->getWidth()) / scale;
-	props.textureheight = static_cast<float>(chartextures[charCode]->getHeight()) / scale;
+	props.texturewidth = static_cast<float>(pixelsw) / scale;
+	props.textureheight = static_cast<float>(pixelsh) / scale;
 	// Divide by 64 first (26.6 fixed point), then by scale to preserve precision
 	props.advance = (glyph->advance.x / 64.0f) / scale;
 }

--- a/engine/graphics/gFont.h
+++ b/engine/graphics/gFont.h
@@ -47,6 +47,7 @@
 class gFont : public gNode, public gEventHook {
 public:
 	enum class TextAlign {LEFT, CENTER, RIGHT, JUSTIFY};
+	enum class TextRenderMode {GLYPH, ATLAS};
 
 	gFont();
 	virtual ~gFont();
@@ -99,6 +100,13 @@ public:
 ,	 * @param float y - y coordinate of the region you want to draw
 	 */
 	void drawText(const std::string& text, float x, float y);
+
+	/**
+	 * Selects whether drawText renders one glyph at a time or uses the glyph atlas.
+	 * The default mode is GLYPH to preserve the existing rendering behaviour.
+	 */
+	void setTextRenderMode(TextRenderMode renderMode);
+	TextRenderMode getTextRenderMode() const;
 
 
 	/**
@@ -198,6 +206,7 @@ public:
 
 private:
 	void reloadFont();
+	bool buildAtlas();
 
 	bool isloaded = false;
 	std::string fullpath;
@@ -224,10 +233,22 @@ private:
 		float advance = 0.0f;
 		float texturewidth = 0.0f, textureheight = 0.0f;
 		float dxleft = 0.0f, dxright = 0.0f, dytop = 0.0f, dybottom = 0.0f;
+		float atlasu0 = 0.0f, atlasv0 = 0.0f, atlasu1 = 0.0f, atlasv1 = 0.0f;
+		bool inatlas = false;
 	};
 
 	std::unordered_map<int, CharProperties> charproperties;
 	std::unordered_map<int, gTexture*> chartextures;
+	gTexture* atlastexture = nullptr;
+	static constexpr int atlaswidth = 2048;
+	static constexpr int atlasheight = 2048;
+	bool atlasbuilding = false;
+	int atlascursorx = 0;
+	int atlascursory = 0;
+	int atlasrowheight = 0;
+	std::vector<unsigned char> atlaspixels;
+	std::vector<float> batchvertices;
+	TextRenderMode textrendermode = TextRenderMode::GLYPH;
 
 	float getKerning(int c, int prevC) const;
 	void resizeVectors(int num);


### PR DESCRIPTION
## Summary

- Adds a glyph atlas for `gFont`.
- Batches text vertices into a single draw call when all glyphs are available in the atlas.
- Uses the same `gFont::drawText()` flow for both OpenGL and Vulkan.
- Keeps backend-specific GPU submission inside the corresponding render engines.
- Preserves the legacy per-glyph path as a fallback for glyphs unavailable in the atlas.
- Preserves UTF-8 text, kerning, multiline text, color, and resizing behavior.

## Changes

- Added a shared textured-triangle batch interface to `gRenderer`.
- Added OpenGL batch rendering support to `gGLRenderEngine`.
- Added Vulkan batch rendering support to `gVKRenderEngine` and `gVKDraw`.
- Added per-font glyph atlas generation and UV data to `gFont`.
- Moved the text batching decision, vertex generation, and draw dispatch into `gFont::drawText()`.
- Removed Vulkan-specific branching and the separate Vulkan text batching function.
- Reused the existing image pipeline and shaders for both render backends.
- Preserved the per-glyph rendering path for glyphs unavailable in the atlas.

## Benchmark

The following results were measured using the Vulkan renderer.

Test environment:

- NVIDIA GeForce RTX 4060 Laptop GPU
- Vulkan 1.4
- Vulkan validation enabled
- 60 warm-up frames
- 300 measured frames
- CPU timing around `gFont::drawText()`

| Glyphs | Draw calls before | Draw calls after | CPU before | CPU after | Speedup |
|---:|---:|---:|---:|---:|---:|
| 100 | 100 | 1 | 1.027 ms | 0.188 ms | 5.47x |
| 500 | 500 | 1 | 4.493 ms | 0.462 ms | 9.72x |
| 1000 | 1000 | 1 | 8.789 ms | 0.785 ms | 11.20x |

For 1000 glyphs:

- CPU time decreased by approximately 91.1%.
- Draw calls decreased from 1000 to 1.
- The `drawText()` share of a 60 FPS frame budget decreased from approximately 52.7% to 4.7%.

FPS remained at 61 because the Vulkan swapchain used FIFO present mode. CPU time was therefore used as the primary comparison metric.

## Validation

The Vulkan runtime was tested with validation enabled for:

- ASCII text
- UTF-8 characters
- Text color and alpha blending
- Multiline text and kerning
- Runtime glyph rendering
- Repeated window resizing
- Minimize and restore
- Normal application shutdown

The generated atlas contained 864 glyphs. Text rendered correctly without atlas bleeding or visual corruption.

No Vulkan validation warning or error was reported.

Both Debug and Release configurations build successfully. The build includes both the OpenGL and Vulkan implementations.

## Implementation Notes

- Uses one 2048x2048 RGBA atlas per font.
- Builds screen-space glyph triangles inside `gFont::drawText()`.
- Submits the complete vertex batch through the shared renderer interface.
- Uses one texture binding and one draw call when all requested glyphs are available in the atlas.
- Uses the existing OpenGL image shader for OpenGL rendering.
- Uses the existing Vulkan `image2d` pipeline and shaders for Vulkan rendering.
- Requires no new shader or SPIR-V module.
- Falls back to the legacy per-glyph rendering path when batching is unavailable.

## Known Limitation

A 2048x2048 RGBA atlas consumes approximately 16 MiB per font instance. A future iteration may use dynamically sized atlases, lazy glyph insertion, or paged atlases for applications that use many fonts or font sizes.