### PR TITLE
feat(renderer): add rotation angle parameter to gDrawRectangle

### DIFF
--- a/engine/core/gRenderer.cpp
+++ b/engine/core/gRenderer.cpp
@@ -88,9 +88,9 @@ void gDrawArrow(float x1, float y1, float length, float angle, float tipLength, 
 	gRenderObject::getRenderer()->drawArrow(x1, y1, length, angle, tipLength, tipAngle, thickness);
 }
 
-void gDrawRectangle(float x, float y, float w, float h, bool isFilled) {
+void gDrawRectangle(float x, float y, float w, float h, bool isFilled, float rotateAngle) {
 	G_PROFILE_ZONE_SCOPED_N("gDrawRectangle()");
-	gRenderObject::getRenderer()->drawRectangle(x, y, w, h, isFilled);
+	gRenderObject::getRenderer()->drawRectangle(x, y, w, h, isFilled, rotateAngle);
 }
 
 void gDrawRoundedRectangle(float x, float y, float w, float h, int radius, bool isFilled) {
@@ -1627,9 +1627,9 @@ void gRenderer::drawArrow(float x1, float y1, float length, float angle, float t
 	linemesh3->draw(wing2StartX, wing2StartY, wing2StartX + std::cos(gDegToRad(wing2Angle)) * tipLength, wing2StartY + std::sin(gDegToRad(wing2Angle)) * tipLength);
 }
 
-void gRenderer::drawRectangle(float x, float y, float w, float h, bool isFilled) {
+void gRenderer::drawRectangle(float x, float y, float w, float h, bool isFilled, float rotateAngle) {
 	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawRectangle()");
-	rectanglemesh->draw(x, y, w, h, isFilled);
+	rectanglemesh->draw(x, y, w, h, isFilled, rotateAngle);
 }
 
 void gRenderer::drawRoundedRectangle(float x, float y, float w, float h, int radius, bool isFilled) {

--- a/engine/core/gRenderer.h
+++ b/engine/core/gRenderer.h
@@ -86,7 +86,7 @@ void gDrawCircle(float xCenter, float yCenter, float radius, bool isFilled = fal
 void gDrawCross(float x, float y, float width, float height, float thickness, bool isFilled);
 void gDrawArc(float xCenter, float yCenter, float radius, bool isFilled = true, int numberOfSides = 60, float degree = 360.0f, float rotate = 360.0f);
 void gDrawArrow(float x1, float y1, float length, float angle, float tipLength, float tipAngle, float thickness = 1.0f);
-void gDrawRectangle(float x, float y, float w, float h, bool isFilled = false);
+void gDrawRectangle(float x, float y, float w, float h, bool isFilled = false, float rotateAngle = 0.0f);
 void gDrawRoundedRectangle(float x, float y, float w, float h, int radius, bool isFilled);
 void gDrawBox(float x, float y, float z, float w = 1.0f, float h = 1.0f, float d = 1.0f, bool isFilled = true);
 void gDrawBox(glm::mat4 transformationMatrix, bool isFilled = true);
@@ -544,7 +544,7 @@ public:
 	void drawCross(float x, float y, float width, float height, float thickness, bool isFilled);
 	void drawArc(float xCenter, float yCenter, float radius, bool isFilled = true, int numberOfSides = 60, float degree = 360.0f, float rotate = 360.0f);
 	void drawArrow(float x1, float y1, float length, float angle, float tipLength, float tipAngle, float thickness = 1.0f);
-	void drawRectangle(float x, float y, float w, float h, bool isFilled = false);
+	void drawRectangle(float x, float y, float w, float h, bool isFilled = false, float rotateAngle = 0.0f);
 	void drawRoundedRectangle(float x, float y, float w, float h, int radius, bool isFilled);
 	void drawBox(float x, float y, float z, float w = 1.0f, float h = 1.0f, float d = 1.0f, bool isFilled = true);
 	void drawBox(glm::mat4 transformationMatrix, bool isFilled = true);

--- a/engine/graphics/primitives/gRectangle.cpp
+++ b/engine/graphics/primitives/gRectangle.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "gRectangle.h"
+#include <cmath>
 
 /*
  * Draws a rectangle.
@@ -16,20 +17,21 @@
  * @param w Width of rectangle.
  * @param h Height of rectangle.
  * @param isFilled Specifies whether the rectangle is filled or empty.
+ * @param rotateAngle Rotation angle in radians, applied around the rectangle's center.
  */
 
 gRectangle::gRectangle() {
 
 }
 
-gRectangle::gRectangle(float x, float y, float w, float h, bool isFilled) {
+gRectangle::gRectangle(float x, float y, float w, float h, bool isFilled, float rotateAngle) {
 	isprojection2d = true;
-	setRectanglePoints(x, y, w, h, isFilled);
+	setRectanglePoints(x, y, w, h, isFilled, rotateAngle);
 }
 
-void gRectangle::setPoints(float x, float y, float w, float h, bool isFilled) {
+void gRectangle::setPoints(float x, float y, float w, float h, bool isFilled, float rotateAngle) {
 	isprojection2d = true;
-	setRectanglePoints(x, y, w, h, isFilled);
+	setRectanglePoints(x, y, w, h, isFilled, rotateAngle);
 }
 
 void gRectangle::draw() {
@@ -37,22 +39,38 @@ void gRectangle::draw() {
 	gMesh::draw();
 }
 
-void gRectangle::draw(float x, float y, float w, float h, bool isFilled) {
+void gRectangle::draw(float x, float y, float w, float h, bool isFilled, float rotateAngle) {
 	isprojection2d = true;
-	setRectanglePoints(x, y, w, h, isFilled);
+	setRectanglePoints(x, y, w, h, isFilled, rotateAngle);
 	gMesh::draw();
 }
 
-void gRectangle::setRectanglePoints(float x, float y, float w, float h, bool isFilled) {
+void gRectangle::setRectanglePoints(float x, float y, float w, float h, bool isFilled, float rotateAngle) {
 	if(!verticessb.empty()) {
 		verticessb.clear();
 		indicessb.clear();
 	}
 
-	verticessb.push_back({{x, y, 0.0f}});
-	verticessb.push_back({{x + w, y, 0.0f}});
-	verticessb.push_back({{x + w, y + h, 0.0f}});
-	verticessb.push_back({{x, y + h, 0.0f}});
+	// Rectangle's center, rotation pivot point
+	float cx = x + w * 0.5f;
+	float cy = y + h * 0.5f;
+
+	float cosA = std::cos(rotateAngle);
+	float sinA = std::sin(rotateAngle);
+
+	// Rotates a point around the rectangle's center by rotateAngle (radians)
+	auto rotatePoint = [&](float px, float py) -> glm::vec3 {
+		float dx = px - cx;
+		float dy = py - cy;
+		float rx = dx * cosA - dy * sinA;
+		float ry = dx * sinA + dy * cosA;
+		return glm::vec3(cx + rx, cy + ry, 0.0f);
+	};
+
+	verticessb.push_back({rotatePoint(x, y)});
+	verticessb.push_back({rotatePoint(x + w, y)});
+	verticessb.push_back({rotatePoint(x + w, y + h)});
+	verticessb.push_back({rotatePoint(x, y + h)});
 
 	if (isFilled) {
 		indicessb.push_back(0);

--- a/engine/graphics/primitives/gRectangle.h
+++ b/engine/graphics/primitives/gRectangle.h
@@ -13,20 +13,20 @@
 class gRectangle: public gMesh {
 public:
 	gRectangle();
-	gRectangle(float x, float y, float w, float h, bool isFilled, float rotateAngle);
+	gRectangle(float x, float y, float w, float h, bool isFilled, float rotateAngle = 0.0f);
 		~gRectangle() override;
 
-		void setPoints(float x, float y, float w, float h, bool isFilled, float rotateAngle);
+		void setPoints(float x, float y, float w, float h, bool isFilled, float rotateAngle = 0.0f);
 
 		void draw() override;
-		void draw(float x, float y, float w, float h, bool isFilled, float rotateAngle);
+		void draw(float x, float y, float w, float h, bool isFilled, float rotateAngle = 0.0f);
 
 private:
 	std::vector<gVertex> verticessb;
 	std::vector<gIndex> indicessb;
 
 private:
-	void setRectanglePoints(float x, float y, float w, float h, bool isFilled, float rotateAngle);
+	void setRectanglePoints(float x, float y, float w, float h, bool isFilled, float rotateAngle = 0.0f);
 };
 
 

--- a/engine/graphics/primitives/gRectangle.h
+++ b/engine/graphics/primitives/gRectangle.h
@@ -13,20 +13,20 @@
 class gRectangle: public gMesh {
 public:
 	gRectangle();
-	gRectangle(float x, float y, float w, float h, bool isFilled);
-	~gRectangle() override;
+	gRectangle(float x, float y, float w, float h, bool isFilled, float rotateAngle);
+		~gRectangle() override;
 
-	void setPoints(float x, float y, float w, float h, bool isFilled);
+		void setPoints(float x, float y, float w, float h, bool isFilled, float rotateAngle);
 
-	void draw() override;
-	void draw(float x, float y, float w, float h, bool isFilled);
+		void draw() override;
+		void draw(float x, float y, float w, float h, bool isFilled, float rotateAngle);
 
 private:
 	std::vector<gVertex> verticessb;
 	std::vector<gIndex> indicessb;
 
 private:
-	void setRectanglePoints(float x, float y, float w, float h, bool isFilled);
+	void setRectanglePoints(float x, float y, float w, float h, bool isFilled, float rotateAngle);
 };
 
 


### PR DESCRIPTION
- Added `rotateAngle` parameter (in radians) with default value `0.0f` to `gDrawRectangle` and `gRenderer::drawRectangle`
- Updated `gRectangle` signatures and implemented center-point rotation logic in `gRectangle.cpp`