### PR TITLE
Feat: Add custom hover color support to gGUIButton

### DIFF
--- a/engine/ui/gGUIButton.cpp
+++ b/engine/ui/gGUIButton.cpp
@@ -26,6 +26,7 @@ gGUIButton::gGUIButton() {
 //	gLogi("Button") << "r:" << bcolor.r << ", g:" << bcolor.g << ", b:" << bcolor.b;
 	pressedbcolor = *pressedbuttoncolor;
 	hcolor.set((pressedbcolor.r + bcolor.r) / 2, (pressedbcolor.g + bcolor.g) / 2, (pressedbcolor.b + bcolor.b) / 2);
+	customhovercolor = false;
 	disabledbcolor = *disabledbuttoncolor;
 	fcolor = *buttonfontcolor;
 	pressedfcolor = *pressedbuttonfontcolor;
@@ -186,12 +187,17 @@ void gGUIButton::resetTitlePosition() {
 
 void gGUIButton::setButtonColor(gColor color) {
 	bcolor = color;
-	hcolor.set((pressedbcolor.r + bcolor.r) / 2, (pressedbcolor.g + bcolor.g) / 2, (pressedbcolor.b + bcolor.b) / 2);
+	if(!customhovercolor) hcolor.set((pressedbcolor.r + bcolor.r) / 2, (pressedbcolor.g + bcolor.g) / 2, (pressedbcolor.b + bcolor.b) / 2);
 }
 
 void gGUIButton::setPressedButtonColor(gColor color) {
 	pressedbcolor = color;
-	hcolor.set((pressedbcolor.r + bcolor.r) / 2, (pressedbcolor.g + bcolor.g) / 2, (pressedbcolor.b + bcolor.b) / 2);
+	if(!customhovercolor) hcolor.set((pressedbcolor.r + bcolor.r) / 2, (pressedbcolor.g + bcolor.g) / 2, (pressedbcolor.b + bcolor.b) / 2);
+}
+
+void gGUIButton::setHoverButtonColor(gColor color) {
+	customhovercolor = true;
+	hcolor = color;
 }
 
 void gGUIButton::setDisabledButtonColor(gColor color) {
@@ -220,6 +226,10 @@ gColor* gGUIButton::getPressedButtonColor() {
 
 gColor* gGUIButton::getDisabledButtonColor() {
 	return &disabledbcolor;
+}
+
+gColor* gGUIButton::getHoverButtonColor() {
+	return &hcolor;
 }
 
 gColor* gGUIButton::getButtonFontColor() {

--- a/engine/ui/gGUIButton.h
+++ b/engine/ui/gGUIButton.h
@@ -31,12 +31,14 @@ public:
 	void setButtonColor(gColor color);
 	void setPressedButtonColor(gColor color);
 	void setDisabledButtonColor(gColor color);
+	void setHoverButtonColor(gColor color);
 	void setButtonFontColor(gColor color);
 	void setPressedButtonFontColor(gColor color);
 	void setDisabledButtonFontColor(gColor color);
 	gColor* getButtonColor();
 	gColor* getPressedButtonColor();
 	gColor* getDisabledButtonColor();
+	gColor* getHoverButtonColor();
 	gColor* getButtonFontColor();
 	gColor* getPressedButtonFontColor();
 	gColor* getDisabledButtonFontColor();
@@ -71,6 +73,7 @@ protected:
 	gColor bcolor, pressedbcolor, disabledbcolor;
 	gColor fcolor, pressedfcolor, disabledfcolor;
 	gColor hcolor;
+	bool customhovercolor;
 	bool fillbackground;
 	bool contentcentered;
 


### PR DESCRIPTION
- Introduced `setHoverButtonColor(gColor color)` to allow explicit configuration of hover colors on UI buttons.
- Previously, hover colors were strictly hardcoded as the mathematical midpoint between the normal button color and the pressed button color, which often resulted in washed-out visuals.
- Added a `customhovercolor` boolean flag to prevent auto-overwriting the hover color if a developer explicitly sets a custom one.
- This enhancement provides UI developers with full granular control over button interaction states without breaking legacy auto-calculation.