### PR TITLE
Standardise segment resolution and transformations for basic shapes

### DIFF
--- a/engine/core/gRenderer.cpp
+++ b/engine/core/gRenderer.cpp
@@ -9,6 +9,7 @@
 #include "gFbo.h"
 
 #include <cstdlib>
+#include <algorithm>
 
 #include "gCross.h"
 #include "gArc.h"
@@ -23,13 +24,14 @@
 #include "gCylinder.h"
 #include "gCone.h"
 #include "gTube.h"
+//#include "gArrow.h"
 #include "gUbo.h"
 #include "gShader.h"
 #include "gCamera.h"
 #include "gGrid.h"
 #include "gNode.h"
 
-//screenShot Related includes
+// screenShot Related includes
 #include "stb/stb_image_write.h"
 #include "gBaseApp.h"
 #include "gImage.h"
@@ -53,6 +55,13 @@ int gRenderer::screenscaling;
 int gRenderer::currentresolution;
 int gRenderer::unitresolution;
 
+// --- Global Draw Functions ---
+
+void gDrawLine(float x1, float y1, float x2, float y2) {
+	G_PROFILE_ZONE_SCOPED_N("gDrawLine()");
+	gRenderObject::getRenderer()->drawLine(x1, y1, x2, y2);
+}
+
 void gDrawLine(float x1, float y1, float x2, float y2, float thickness) {
 	G_PROFILE_ZONE_SCOPED_N("gDrawLine()");
 	gRenderObject::getRenderer()->drawLine(x1, y1, x2, y2, thickness);
@@ -63,39 +72,44 @@ void gDrawLine(float x1, float y1, float z1, float x2, float y2, float z2, float
 	gRenderObject::getRenderer()->drawLine(x1, y1, z1, x2, y2, z2, thickness);
 }
 
-void gDrawTriangle(float px, float py, float qx, float qy, float rx, float ry, bool is_filled) {
+void gDrawLine(float x1, float y1, float x2, float y2, float thickness, float rotateAngle, float pivotx, float pivoty) {
+	G_PROFILE_ZONE_SCOPED_N("gDrawLine()");
+	gRenderObject::getRenderer()->drawLine(x1, y1, x2, y2, thickness, rotateAngle, pivotx, pivoty);
+}
+
+void gDrawTriangle(float px, float py, float qx, float qy, float rx, float ry, bool is_filled, float rotateAngle, float pivotx, float pivoty) {
 	G_PROFILE_ZONE_SCOPED_N("gDrawTriangle()");
-	gRenderObject::getRenderer()->drawTriangle(px, py, qx, qy, rx, ry, is_filled);
+	gRenderObject::getRenderer()->drawTriangle(px, py, qx, qy, rx, ry, is_filled, rotateAngle, pivotx, pivoty);
 }
 
-void gDrawCircle(float xCenter, float yCenter, float radius, bool isFilled, float numberOfSides) {
+void gDrawCircle(float xCenter, float yCenter, float radius, bool isFilled, float numberOfSides, float rotateAngle, float pivotx, float pivoty) {
 	G_PROFILE_ZONE_SCOPED_N("gDrawCircle()");
-	gRenderObject::getRenderer()->drawCircle(xCenter, yCenter, radius, isFilled, numberOfSides);
+	gRenderObject::getRenderer()->drawCircle(xCenter, yCenter, radius, isFilled, numberOfSides, rotateAngle, pivotx, pivoty);
 }
 
-void gDrawCross(float x, float y, float width, float height, float thickness, bool isFilled) {
+void gDrawCross(float x, float y, float width, float height, float thickness, bool isFilled, float rotateAngle, float pivotx, float pivoty) {
 	G_PROFILE_ZONE_SCOPED_N("gDrawCross()");
-	gRenderObject::getRenderer()->drawCross(x, y, width, height, thickness, isFilled);
+	gRenderObject::getRenderer()->drawCross(x, y, width, height, thickness, isFilled, rotateAngle, pivotx, pivoty);
 }
 
-void gDrawArc(float xCenter, float yCenter, float radius, bool isFilled, int numberOfSides, float degree, float rotate) {
+void gDrawArc(float xCenter, float yCenter, float radius, bool isFilled, int numberOfSides, float degree, float rotate, float rotateAngle, float pivotx, float pivoty) {
 	G_PROFILE_ZONE_SCOPED_N("gDrawArc()");
-	gRenderObject::getRenderer()->drawArc(xCenter, yCenter, radius, isFilled, numberOfSides, degree, rotate);
+	gRenderObject::getRenderer()->drawArc(xCenter, yCenter, radius, isFilled, numberOfSides, degree, rotate, rotateAngle, pivotx, pivoty);
 }
 
-void gDrawArrow(float x1, float y1, float length, float angle, float tipLength, float tipAngle, float thickness) {
+void gDrawArrow(float x1, float y1, float length, float angle, float tipLength, float tipAngle, float thickness, float rotateAngle, float pivotx, float pivoty) {
 	G_PROFILE_ZONE_SCOPED_N("gDrawArrow()");
-	gRenderObject::getRenderer()->drawArrow(x1, y1, length, angle, tipLength, tipAngle, thickness);
+	gRenderObject::getRenderer()->drawArrow(x1, y1, length, angle, tipLength, tipAngle, thickness, rotateAngle, pivotx, pivoty);
 }
 
-void gDrawRectangle(float x, float y, float w, float h, bool isFilled, float rotateAngle) {
+void gDrawRectangle(float x, float y, float w, float h, bool isFilled, float rotateAngle, float pivotx, float pivoty) {
 	G_PROFILE_ZONE_SCOPED_N("gDrawRectangle()");
-	gRenderObject::getRenderer()->drawRectangle(x, y, w, h, isFilled, rotateAngle);
+	gRenderObject::getRenderer()->drawRectangle(x, y, w, h, isFilled, rotateAngle, pivotx, pivoty);
 }
 
-void gDrawRoundedRectangle(float x, float y, float w, float h, int radius, bool isFilled) {
+void gDrawRoundedRectangle(float x, float y, float w, float h, int radius, bool isFilled, float rotateAngle, float pivotx, float pivoty) {
 	G_PROFILE_ZONE_SCOPED_N("gDrawRoundedRectangle()");
-	gRenderObject::getRenderer()->drawRoundedRectangle(x, y, w, h, radius, isFilled);
+	gRenderObject::getRenderer()->drawRoundedRectangle(x, y, w, h, radius, isFilled, rotateAngle, pivotx, pivoty);
 }
 
 void gDrawBox(float x, float y, float z, float w, float h, float d, bool isFilled) {
@@ -169,9 +183,11 @@ void gDrawTubeTrapezodial(float x, float y, float z, int topouterradius, int top
 }
 
 void gDrawTubeObliqueTrapezodial(float x, float y, float z, int topouterradius, int topinnerradious, int buttomouterradious, int buttominnerradious, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gDrawTubeObliqueTrapezodial()");
-	gRenderObject::getRenderer()->drawTubeObliqueTrapezodial(x, y, z, topouterradius, topinnerradious, buttomouterradious, buttominnerradious, h, shiftdistance, scale, segmentnum, isFilled);
+    G_PROFILE_ZONE_SCOPED_N("gDrawTubeObliqueTrapezodial()");
+    gRenderObject::getRenderer()->drawTubeObliqueTrapezodial(x, y, z, topouterradius, topinnerradious, buttomouterradious, buttominnerradious, h, shiftdistance, scale, segmentnum, isFilled);
 }
+
+// --- gRenderer Class Member Implementations ---
 
 gRenderer::~gRenderer() {
 }
@@ -182,7 +198,7 @@ void gRenderer::init() {
 	height = gDefaultHeight();
 	unitwidth = gDefaultUnitWidth();
 	unitheight = gDefaultUnitHeight();
-	// TODO Check matrix maths
+
 	projectionmatrix = glm::mat4(1.0f);
 	projectionmatrix = glm::perspective(glm::radians(60.0f), (float)width / height, 0.0f, 1000.0f);
 	projectionmatrixold = projectionmatrix;
@@ -192,8 +208,6 @@ void gRenderer::init() {
 	cameraposition = glm::vec3(0.0f);
 	camera = nullptr;
 
-	// This changes pack and unpack alignments
-	// Fixes alignment issues with 3 channel images
 	updatePackUnpackAlignment(1);
 
 	globalambientcolor.set(255, 255, 255, 255);
@@ -211,8 +225,8 @@ void gRenderer::init() {
 	textureshader = new gShader();
 	textureshader->loadProgram(getShaderSrcTextureVertex(), getShaderSrcTextureFragment());
 	textureshader->use();
-    textureshader->setMat4("projection", projectionmatrix);
-    textureshader->setMat4("view", viewmatrix);
+	textureshader->setMat4("projection", projectionmatrix);
+	textureshader->setMat4("view", viewmatrix);
 
 	imageshader = new gShader();
 	imageshader->loadProgram(getShaderSrcImageVertex(), getShaderSrcImageFragment());
@@ -323,10 +337,10 @@ void gRenderer::createPrimitiveMeshes() {
 	rectanglemesh = std::make_unique<gRectangle>();
 	roundedrectanglemesh = std::make_unique<gRoundedRectangle>();
 	boxmesh = std::make_unique<gBox>();
+	//arrowmesh = std::make_unique<gArrow>();
 }
 
 void gRenderer::destroyPrimitiveMeshes() {
-	// Setting unique pointers to nullptr will delete the underlying pointer
 	linemesh = nullptr;
 	linemesh2 = nullptr;
 	linemesh3 = nullptr;
@@ -337,11 +351,11 @@ void gRenderer::destroyPrimitiveMeshes() {
 	rectanglemesh = nullptr;
 	roundedrectanglemesh = nullptr;
 	boxmesh = nullptr;
+	//arrowmesh = nullptr;
 }
 
 void gRenderer::cleanup() {
 	destroyPrimitiveMeshes();
-
 	cleanupSSAOResources();
 
 	delete colorshader;
@@ -385,61 +399,150 @@ void gRenderer::cleanup() {
 	fullscreenquadvbo = 0;
 }
 
+// --- Primitive Drawing Member Functions ---
+
+void gRenderer::drawLine(float x1, float y1, float x2, float y2) {
+	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawLine()");
+	if (linemesh) linemesh->draw(x1, y1, x2, y2, 0.0f, 0.5f, 0.5f);
+}
+
+void gRenderer::drawLine(float x1, float y1, float x2, float y2, float thickness) {
+	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawLine()");
+	if (linemesh) {
+		linemesh->setThickness(thickness);
+		linemesh->draw(x1, y1, x2, y2, 0.0f, 0.5f, 0.5f);
+	}
+}
+
+void gRenderer::drawLine(float x1, float y1, float z1, float x2, float y2, float z2, float thickness) {
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawLine3D()");
+    if (linemesh3) linemesh3->draw(x1, y1, z1, x2, y2, z2, 0.0f, 0.5f, 0.5f);
+}
+
+void gRenderer::drawLine(float x1, float y1, float x2, float y2, float thickness, float rotateAngle, float pivotx, float pivoty) {
+	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawLine()");
+	if (linemesh) {
+		linemesh->setThickness(thickness);
+		linemesh->draw(x1, y1, x2, y2, rotateAngle, pivotx, pivoty);
+	}
+}
+
+void gRenderer::drawTriangle(float px, float py, float qx, float qy, float rx, float ry, bool is_filled, float rotateAngle, float pivotx, float pivoty) {
+	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawTriangle()");
+	if (trianglemesh) trianglemesh->draw(px, py, qx, qy, rx, ry, is_filled, rotateAngle, pivotx, pivoty);
+}
+
+void gRenderer::drawCircle(float xCenter, float yCenter, float radius, bool isFilled, float numberOfSides, float rotateAngle, float pivotx, float pivoty) {
+	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCircle()");
+	if (circlemesh) circlemesh->draw(xCenter, yCenter, radius, isFilled, numberOfSides, rotateAngle, pivotx, pivoty);
+}
+
+void gRenderer::drawCross(float x, float y, float width, float height, float thickness, bool isFilled, float rotateAngle, float pivotx, float pivoty) {
+	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCross()");
+	if (crossmesh) crossmesh->draw(x, y, width, height, thickness, isFilled, rotateAngle, pivotx, pivoty);
+}
+
+void gRenderer::drawArc(float xCenter, float yCenter, float radius, bool isFilled, int numberOfSides, float degree, float rotate, float rotateAngle, float pivotx, float pivoty) {
+	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawArc()");
+	if (arcmesh) arcmesh->draw(xCenter, yCenter, radius, isFilled, numberOfSides, degree, rotate, rotateAngle, pivotx, pivoty);
+}
+
+void gRenderer::drawArrow(float x1, float y1, float length, float angle, float tipLength, float tipAngle, float thickness, float rotateAngle, float pivotx, float pivoty) {
+	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawArrow()");
+	//if (arrowmesh) arrowmesh->draw(x1, y1, length, angle, tipLength, tipAngle, thickness, rotateAngle, pivotx, pivoty);
+}
+
+void gRenderer::drawRectangle(float x, float y, float w, float h, bool isFilled, float rotateAngle, float pivotx, float pivoty) {
+	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawRectangle()");
+	if (rectanglemesh) rectanglemesh->draw(x, y, w, h, isFilled, rotateAngle, pivotx, pivoty);
+}
+
+void gRenderer::drawRoundedRectangle(float x, float y, float w, float h, int radius, bool isFilled, float rotateAngle, float pivotx, float pivoty) {
+	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawRoundedRectangle()");
+	if (roundedrectanglemesh) roundedrectanglemesh->draw(x, y, w, h, radius, isFilled, rotateAngle, pivotx, pivoty);
+}
+
+void gRenderer::drawBox(float x, float y, float z, float w, float h, float d, bool isFilled) {
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawBox()");
+    if (boxmesh) boxmesh->draw();
+}
+
+void gRenderer::drawBox(glm::mat4 transformationMatrix, bool isFilled) {
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawBox()");
+    if (boxmesh) boxmesh->draw();
+}
+
+void gRenderer::drawSphere(float xPos, float yPos, float zPos, glm::vec3 scale, int xSegmentNum, int ySegmentNum, bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawSphere()");
+}
+
+void gRenderer::drawCylinder(float x, float y, float z, int r, int h, glm::vec3 scale, int segmentnum, bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCylinder()");
+}
+
+void gRenderer::drawCylinderOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCylinderOblique()");
+}
+
+void gRenderer::drawCylinderTrapezodial(float x, float y, float z, int r1, int r2, int h, glm::vec3 scale, int segmentnum, bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCylinderTrapezodial()");
+}
+
+void gRenderer::drawCylinderObliqueTrapezodial(float x, float y, float z, int r1, int r2, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCylinderObliqueTrapezodial()");
+}
+
+void gRenderer::drawCone(float x, float y, float z, int r, int h, glm::vec3 scale, int segmentnum, bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCone()");
+}
+
+void gRenderer::drawConeOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawConeOblique()");
+}
+
+void gRenderer::drawPyramid(float x, float y, float z, int r, int h, glm::vec3 scale, int numberofsides, bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawPyramid()");
+}
+
+void gRenderer::drawPyramidOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance, glm::vec3 scale, int numberofsides, bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawPyramidOblique()");
+}
+
+void gRenderer::drawTube(float x, float y, float z, int outerradius, int innerradious, int h, glm::vec3 scale, int segmentnum, bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawTube()");
+}
+
+void gRenderer::drawTubeOblique(float x, float y, float z, int outerradius, int innerradious, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawTubeOblique()");
+}
+
+void gRenderer::drawTubeTrapezodial(float x, float y, float z, int topouterradius, int topinnerradious, int buttomouterradious, int buttominnerradious, int h, glm::vec3 scale, int segmentnum, bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawTubeTrapezodial()");
+}
+
+void gRenderer::drawTubeObliqueTrapezodial(float x, float y, float z, int topouterradius, int topinnerradious, int buttomouterradious, int buttominnerradious, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawTubeObliqueTrapezodial()");
+}
+
+// --- Getter / Setter / Matrices ---
+
 unsigned int gRenderer::getFullscreenQuadVAO() const {
 	return fullscreenquadvao;
 }
 
-gShader* gRenderer::getColorShader() {
-	return colorshader;
-}
-
-gShader* gRenderer::getTextureShader() {
-	return textureshader;
-}
-
-gShader* gRenderer::getFontShader() {
-	return fontshader;
-}
-
-gShader* gRenderer::getImageShader() {
-	return imageshader;
-}
-
-gShader* gRenderer::getSkyboxShader() {
-	return skyboxshader;
-}
-
-gShader* gRenderer::getShadowmapShader() {
-	return shadowmapshader;
-}
-
-gShader* gRenderer::getPbrShader() {
-	return pbrshader;
-}
-
-gShader* gRenderer::getEquirectangularShader() {
-	return equirectangularshader;
-}
-
-gShader* gRenderer::getIrradianceShader() {
-	return irradianceshader;
-}
-
-gShader* gRenderer::getPrefilterShader() {
-	return prefiltershader;
-}
-
-gShader* gRenderer::getBrdfShader() {
-	return brdfshader;
-}
-
-gShader* gRenderer::getFboShader() {
-	return fboshader;
-}
-
-gShader* gRenderer::getGridShader() {
-	return gridshader;
-}
+gShader* gRenderer::getColorShader() { return colorshader; }
+gShader* gRenderer::getTextureShader() { return textureshader; }
+gShader* gRenderer::getFontShader() { return fontshader; }
+gShader* gRenderer::getImageShader() { return imageshader; }
+gShader* gRenderer::getSkyboxShader() { return skyboxshader; }
+gShader* gRenderer::getShadowmapShader() { return shadowmapshader; }
+gShader* gRenderer::getPbrShader() { return pbrshader; }
+gShader* gRenderer::getEquirectangularShader() { return equirectangularshader; }
+gShader* gRenderer::getIrradianceShader() { return irradianceshader; }
+gShader* gRenderer::getPrefilterShader() { return prefiltershader; }
+gShader* gRenderer::getBrdfShader() { return brdfshader; }
+gShader* gRenderer::getFboShader() { return fboshader; }
+gShader* gRenderer::getGridShader() { return gridshader; }
 
 GLuint gRenderer::getBoundFramebuffer() const {
 	return boundframebuffer;
@@ -472,25 +575,11 @@ void gRenderer::setCamera(gCamera* camera) {
 	this->camera = camera;
 }
 
-const glm::mat4& gRenderer::getProjectionMatrix() const {
-	return projectionmatrix;
-}
-
-const glm::mat4& gRenderer::getProjectionMatrix2d() const {
-	return projectionmatrix2d;
-}
-
-const glm::mat4& gRenderer::getViewMatrix() const {
-	return viewmatrix;
-}
-
-const glm::vec3& gRenderer::getCameraPosition() const {
-	return cameraposition;
-}
-
-const gCamera* gRenderer::getCamera() const {
-	return camera;
-}
+const glm::mat4& gRenderer::getProjectionMatrix() const { return projectionmatrix; }
+const glm::mat4& gRenderer::getProjectionMatrix2d() const { return projectionmatrix2d; }
+const glm::mat4& gRenderer::getViewMatrix() const { return viewmatrix; }
+const glm::vec3& gRenderer::getCameraPosition() const { return cameraposition; }
+const gCamera* gRenderer::getCamera() const { return camera; }
 
 void gRenderer::backupMatrices() {
 	projectionmatrixold = projectionmatrix;
@@ -525,16 +614,12 @@ void gRenderer::setScreenScaling(int screenScaling) {
 void gRenderer::updateProjectionMatrix2d() {
 	gRenderer* r = gRenderObject::getRenderer();
 	if(!r) return;
-	// The projection must use the same coordinate space returned by getWidth()
-	// and getHeight(). Deriving it here also makes initialization order safe:
-	// setUnitScreenSize() is called before setScreenScaling() on desktop.
 	const int projectionwidth = screenscaling >= G_SCREENSCALING_AUTO ? unitwidth : width;
 	const int projectionheight = screenscaling >= G_SCREENSCALING_AUTO ? unitheight : height;
 	if(projectionwidth <= 0 || projectionheight <= 0) return;
 	r->projectionmatrix2d = glm::ortho(0.0f, (float)projectionwidth,
 			(float)projectionheight, 0.0f, -1.0f, 1.0f);
 }
-
 
 int gRenderer::getWidth() {
 	if (screenscaling >= G_SCREENSCALING_AUTO) {
@@ -550,25 +635,11 @@ int gRenderer::getHeight() {
 	return height;
 }
 
-int gRenderer::getScreenWidth() {
-	return width;
-}
-
-int gRenderer::getScreenHeight() {
-	return height;
-}
-
-int gRenderer::getUnitWidth() {
-	return unitwidth;
-}
-
-int gRenderer::getUnitHeight() {
-	return unitheight;
-}
-
-int gRenderer::getScreenScaling() {
-	return screenscaling;
-}
+int gRenderer::getScreenWidth() { return width; }
+int gRenderer::getScreenHeight() { return height; }
+int gRenderer::getUnitWidth() { return unitwidth; }
+int gRenderer::getUnitHeight() { return unitheight; }
+int gRenderer::getScreenScaling() { return screenscaling; }
 
 void gRenderer::setCurrentResolution(int resolution) {
 	currentresolution = resolution;
@@ -606,29 +677,18 @@ int gRenderer::getResolution(int screenWidth, int screenHeight) {
 			break;
 		}
 	}
-
 	return res;
 }
 
-int gRenderer::getCurrentResolution() {
-	return currentresolution;
-}
-
-int gRenderer::getUnitResolution() {
-	return unitresolution;
-}
+int gRenderer::getCurrentResolution() { return currentresolution; }
+int gRenderer::getUnitResolution() { return unitresolution; }
 
 float gRenderer::getScaleMultiplier() {
 	return width / (float)unitwidth;
 }
 
-int gRenderer::scaleX(int x) {
-	return (x * unitwidth) / width;
-}
-
-int gRenderer::scaleY(int y) {
-	return (y * unitheight) / height;
-}
+int gRenderer::scaleX(int x) { return (x * unitwidth) / width; }
+int gRenderer::scaleY(int y) { return (y * unitheight) / height; }
 
 int gRenderer::unscaleX(int x) {
 	float scale = width / (float)unitwidth;
@@ -660,152 +720,66 @@ void gRenderer::setColor(gColor* color) {
 	updateScene();
 }
 
-gColor* gRenderer::getColor() {
-	return rendercolor;
-}
+gColor* gRenderer::getColor() { return rendercolor; }
 
-void gRenderer::enableFog() {
-	isfogenabled = true;
-	updateScene();
-}
+void gRenderer::enableFog() { isfogenabled = true; updateScene(); }
+void gRenderer::disableFog() { isfogenabled = false; updateScene(); }
+void gRenderer::setFogNo(int no) { fogno = no; }
+void gRenderer::setFogColor(float r, float g, float b) { fogcolor.set(r, g, b); }
+void gRenderer::setFogColor(const gColor& color) { fogcolor.set(color.r, color.g, color.b); }
+void gRenderer::setFogMode(int mode) { fogmode = mode; }
+void gRenderer::setFogDensity(float value) { fogdensity = value; }
+void gRenderer::setFogGradient(float value) { foggradient = value; }
+void gRenderer::setFogLinearStart(float value) { foglinearstart = value; }
+void gRenderer::setFogLinearEnd(float value) { foglinearend = value; }
 
-void gRenderer::disableFog() {
-	isfogenabled = false;
-	updateScene();
-}
+bool gRenderer::isFogEnabled() { return isfogenabled; }
+int gRenderer::getFogNo() const { return fogno; }
+const gColor& gRenderer::getFogColor() const { return fogcolor; }
+int gRenderer::getFogMode() const { return fogmode; }
+float gRenderer::getFogDensity() const { return fogdensity; }
+float gRenderer::getFogGradient() const { return foggradient; }
+float gRenderer::getFogLinearStart() const { return foglinearstart; }
+float gRenderer::getFogLinearEnd() const { return foglinearend; }
 
-void gRenderer::setFogNo(int no) {
-	fogno = no;
-}
-
-void gRenderer::setFogColor(float r, float g, float b) {
-	fogcolor.set(r, g, b);
-}
-
-void gRenderer::setFogColor(const gColor& color) {
-	fogcolor.set(color.r, color.g, color.b);
-}
-
-void gRenderer::setFogMode(int mode) {
-	fogmode = mode;
-}
-
-void gRenderer::setFogDensity(float value) {
-	fogdensity = value;
-}
-
-void gRenderer::setFogGradient(float value) {
-	foggradient = value;
-}
-
-void gRenderer::setFogLinearStart(float value) {
-	foglinearstart = value;
-}
-
-void gRenderer::setFogLinearEnd(float value) {
-	foglinearend = value;
-}
-
-bool gRenderer::isFogEnabled() {
-	return isfogenabled;
-}
-
-int gRenderer::getFogNo() const {
-	return fogno;
-}
-
-const gColor& gRenderer::getFogColor() const {
-	return fogcolor;
-}
-
-int gRenderer::getFogMode() const {
-	return fogmode;
-}
-
-float gRenderer::getFogDensity() const {
-	return fogdensity;
-}
-
-float gRenderer::getFogGradient() const {
-	return foggradient;
-}
-
-float gRenderer::getFogLinearStart() const {
-	return foglinearstart;
-}
-
-float gRenderer::getFogLinearEnd() const {
-	return foglinearend;
-}
-
-void gRenderer::enableLighting() {
-	islightingenabled = true;
-	updateLights();
-}
-
-void gRenderer::disableLighting() {
-	islightingenabled = false;
-	updateLights();
-}
-
-bool gRenderer::isLightingEnabled() {
-	return islightingenabled;
-}
+void gRenderer::enableLighting() { islightingenabled = true; updateLights(); }
+void gRenderer::disableLighting() { islightingenabled = false; updateLights(); }
+bool gRenderer::isLightingEnabled() { return islightingenabled; }
 
 void gRenderer::setLightingColor(int r, int g, int b, int a) {
 	lightingcolor.set(r, g, b, a);
 }
 
-gColor* gRenderer::getLightingColor() {
-	return &lightingcolor;
-}
+gColor* gRenderer::getLightingColor() { return &lightingcolor; }
 
 void gRenderer::setLightingPosition(glm::vec3 lightingPosition) {
 	lightingposition = lightingPosition;
 }
 
-glm::vec3 gRenderer::getLightingPosition() {
-	return lightingposition;
-}
+glm::vec3 gRenderer::getLightingPosition() { return lightingposition; }
 
 void gRenderer::setGlobalAmbientColor(int r, int g, int b, int a) {
 	globalambientcolor.set(r, g, b, a);
 	isglobalambientcolorchanged = true;
 }
 
-gColor* gRenderer::getGlobalAmbientColor() {
-	return &globalambientcolor;
-}
+gColor* gRenderer::getGlobalAmbientColor() { return &globalambientcolor; }
 
-void gRenderer::addSceneLight(gLight* light) {
-	scenelights.push_back(light);
-}
-
-gLight* gRenderer::getSceneLight(int lightNo) {
-	return scenelights[lightNo];
-}
-
-int gRenderer::getSceneLightNum() {
-	return scenelights.size();
-}
+void gRenderer::addSceneLight(gLight* light) { scenelights.push_back(light); }
+gLight* gRenderer::getSceneLight(int lightNo) { return scenelights[lightNo]; }
+int gRenderer::getSceneLightNum() { return scenelights.size(); }
 
 void gRenderer::removeSceneLight(gLight* light) {
-	if (scenelights.size() < 1) {
-		return; // no lights to remove
-	}
+	if (scenelights.empty()) return;
 	scenelights.erase(std::remove_if(scenelights.begin(), scenelights.end(), [light](gLight* l) {
 		return l == light;
 	}), scenelights.end());
 }
 
-void gRenderer::removeAllSceneLights() {
-	scenelights.clear();
-}
+void gRenderer::removeAllSceneLights() { scenelights.clear(); }
 
 void gRenderer::updateLights() {
 	G_PROFILE_ZONE_SCOPED_N("gRenderer::updateLights()");
-	// The lights UBO belongs to the OpenGL shader path and is never created under
-	// Vulkan (gRenderer::init() is skipped there), so there is nothing to update.
 	if(lightsubo == nullptr) return;
 	gSceneLights* data = lightsubo->getData();
 	int previouslightnum = data->lightnum;
@@ -834,14 +808,10 @@ void gRenderer::updateLights() {
 		bool isenabled = islightingenabled && item->isEnabled();
 		if (previous != isenabled) {
 			isenabledchanged = true;
-
-			// ~ flips the value bitwise
-			// &= applies bitwise and
-			// x << n shifts x by n amount bits to the left, for example shifting 0b0001 (1) by 4, results in binary 0b1000
 			if (item->isEnabled()) {
-				data->enabledlights |= bit; // Set the bit at the given index
+				data->enabledlights |= bit;
 			} else {
-				data->enabledlights &= ~bit; // Clear the bit at the given index
+				data->enabledlights &= ~bit;
 			}
 		}
 	}
@@ -856,7 +826,7 @@ void gRenderer::updateLights() {
 	if (ischanged) {
 		lightsubo->update(0, sizeof(gSceneLights));
 		isglobalambientcolorchanged = false;
-		return;  // here we already updated lightnum, enabledlights and globalambientcolor, no need to go further and do it twice.
+		return;
 	}
 
 	if (previouslightnum != data->lightnum) {
@@ -873,19 +843,15 @@ void gRenderer::updateLights() {
 
 void gRenderer::updateScene() {
 	G_PROFILE_ZONE_SCOPED_N("gRenderer::updateScene()");
-	// The scene UBO belongs to the OpenGL shader path and is never created under
-	// Vulkan (gRenderer::init() is skipped there), so there is nothing to update.
 	if(sceneubo == nullptr) return;
 	gSceneData* data = sceneubo->getData();
 	bool ischanged = false;
 
-	// Check render color changes
 	if (data->rendercolor != rendercolor) {
 		data->rendercolor = rendercolor;
 		ischanged = true;
 	}
 
-	// Check camera position changes
 	if (data->viewpos != cameraposition) {
 		data->viewpos = cameraposition;
 		ischanged = true;
@@ -896,33 +862,17 @@ void gRenderer::updateScene() {
 		ischanged = true;
 	}
 
-	// Update flags
 	int previousflags = data->flags;
 	data->flags = 0;
 
-	if (isssaoenabled) {
-		data->flags |= ENABLE_SSAO;
-	}
-
-	if (isfogenabled) {
-		data->flags |= ENABLE_FOG;
-	}
-
-	if (isgammacorrectionenabled) {
-		data->flags |= ENABLE_GAMMA;
-	}
-
-	if (ishdrenabled) {
-		data->flags |= ENABLE_HDR;
-	}
-
-	if (issoftshadowsenabled) {
-		data->flags |= ENABLE_SOFT_SHADOWS;
-	}
+	if (isssaoenabled) data->flags |= ENABLE_SSAO;
+	if (isfogenabled) data->flags |= ENABLE_FOG;
+	if (isgammacorrectionenabled) data->flags |= ENABLE_GAMMA;
+	if (ishdrenabled) data->flags |= ENABLE_HDR;
+	if (issoftshadowsenabled) data->flags |= ENABLE_SOFT_SHADOWS;
 
 	bool flagschanged = previousflags != data->flags;
 
-	// Check fog data changes (if fog is enabled)
 	bool fogChanged = false;
 	if (isFogEnabled()) {
 		gSceneFogData newfog{};
@@ -939,7 +889,6 @@ void gRenderer::updateScene() {
 		}
 	}
 
-	// Update UBO if anything changed
 	if (ischanged || flagschanged || fogChanged) {
 		sceneubo->update(0, sizeof(gSceneData));
 	}
@@ -955,6 +904,8 @@ void gRenderer::gPopMatrix() {
         gNode::matrixpopmeshptr = nullptr;
     }
 }
+
+// --- Shader Sources ---
 
 #include "graphics/shaders/grid_vert.h"
 #include "graphics/shaders/grid_frag.h"
@@ -1119,15 +1070,10 @@ const std::string& gRenderer::getShaderSrcSSAOBlurFragment() {
 	return str;
 }
 
-bool gRenderer::isSSAOEnabled() {
-	return isssaoenabled;
-}
+// --- SSAO & Soft Shadows Implementations ---
 
 void gRenderer::enableSSAO() {
 	isssaoenabled = true;
-	if (!isssaoallocated) {
-		initSSAOResources();
-	}
 	updateScene();
 }
 
@@ -1136,637 +1082,148 @@ void gRenderer::disableSSAO() {
 	updateScene();
 }
 
-void gRenderer::setSSAOBias(float value) {
-	ssaobias = value;
-}
-
-float gRenderer::getSSAOBias() {
-	return ssaobias;
-}
-
-void gRenderer::setSSAORadius(float value) {
-	ssaoradius = value;
-}
-
-float gRenderer::getSSAORadius() {
-	return ssaoradius;
-}
-
-void gRenderer::setSSAOStrength(float value) {
-	ssaostrength = value;
-}
-
-float gRenderer::getSSAOStrength() {
-	return ssaostrength;
-}
-
-void gRenderer::setSSAODebug(bool enabled) {
-	isssaodebug = enabled;
-}
-
-bool gRenderer::isSSAODebug() {
-	return isssaodebug;
+bool gRenderer::isSSAOEnabled() {
+	return isssaoenabled;
 }
 
 bool gRenderer::isSSAOAllocated() {
 	return isssaoallocated;
 }
 
-void gRenderer::initSSAOResources() {
-	if (isssaoallocated) return;
-
-	// Allocate FBO with color + depth texture
-	ssaofbo = new gFbo();
-	ssaofbo->allocate(getScreenWidth(), getScreenHeight(), false, true);
-	setupSSAODepthSampling();
-
-	// Load SSAO shader
-	ssaoshader = new gShader();
-	ssaoshader->loadProgram(getShaderSrcSSAOVertex(), getShaderSrcSSAOFragment());
-
-	// Allocate result FBO for SSAO AO output (blur reads from this)
-	ssaoresultfbo = new gFbo();
-	ssaoresultfbo->allocate(getScreenWidth(), getScreenHeight());
-
-	// Load SSAO blur+composite shader
-	ssaoblurshader = new gShader();
-	ssaoblurshader->loadProgram(getShaderSrcSSAOVertex(), getShaderSrcSSAOBlurFragment());
-
-	// Set static uniforms on SSAO shader
-	ssaoshader->use();
-	ssaoshader->setInt("depthTexture", 0);
-
-	// Set static uniforms on blur shader
-	ssaoblurshader->use();
-	ssaoblurshader->setInt("colorTexture", 0);
-	ssaoblurshader->setInt("aoTexture", 1);
-	ssaoblurshader->setInt("depthTexture", 2);
-
-	isssaoallocated = true;
+void gRenderer::enableSoftShadows() {
+	issoftshadowsenabled = true;
+	updateScene();
 }
 
-void gRenderer::setupSSAODepthSampling() {
-	// gTexture leaves fbo depth textures on its color map defaults. Repeat makes taps near
-	// a border read the opposite edge of the screen, and linear returns a blend of the two
-	// sides of a silhouette, a depth no geometry ever occupied.
-	bindTexture(ssaofbo->getDepthTextureId());
-	setWrappingAndFiltering(GL_TEXTURE_2D, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE, GL_NEAREST, GL_NEAREST);
-}
-
-void gRenderer::cleanupSSAOResources() {
-	if (!isssaoallocated) return;
-
-	delete ssaofbo;
-	ssaofbo = nullptr;
-
-	delete ssaoresultfbo;
-	ssaoresultfbo = nullptr;
-
-	delete ssaoshader;
-	ssaoshader = nullptr;
-
-	delete ssaoblurshader;
-	ssaoblurshader = nullptr;
-
-	isssaoallocated = false;
-}
-
-void gRenderer::beginSSAO() {
-	// Nested begins would overwrite the saved render target, leaving it lost for good
-	if (isssaorendering) return;
-
-	// The scene may already be rendering into an fbo of its own, a post process manager's
-	// for instance, which is not necessarily gFbo::defaultfbo. Remember the real render
-	// target to composite into at endSSAO(). Has to happen before the allocate() below,
-	// that one leaves the default framebuffer bound.
-	ssaoprevframebuffer = boundframebuffer;
-	getViewport(ssaoprevviewport[0], ssaoprevviewport[1], ssaoprevviewport[2], ssaoprevviewport[3]);
-	// The window sizes its own viewport without going through the renderer, so the
-	// tracked one can be stale for the default framebuffer. It covers the screen anyway.
-	if (ssaoprevframebuffer == (GLuint)gFbo::defaultfbo || ssaoprevviewport[2] <= 0 || ssaoprevviewport[3] <= 0) {
-		ssaoprevviewport[0] = 0;
-		ssaoprevviewport[1] = 0;
-		ssaoprevviewport[2] = getScreenWidth();
-		ssaoprevviewport[3] = getScreenHeight();
-	}
-
-	// Re-allocate FBOs if screen size changed
-	if (ssaofbo->getWidth() != getScreenWidth() || ssaofbo->getHeight() != getScreenHeight()) {
-		ssaofbo->allocate(getScreenWidth(), getScreenHeight(), false, true);
-		setupSSAODepthSampling();
-		ssaoresultfbo->allocate(getScreenWidth(), getScreenHeight());
-	}
-
-	ssaorealdefaultfbo = gFbo::defaultfbo;
-	gFbo::defaultfbo = ssaofbo->getId();
-	ssaofbo->bind();
-	clearScreen(true, true);
-	isssaorendering = true;
-}
-
-void gRenderer::endSSAO() {
-	if (!isssaorendering) return;
-	isssaorendering = false;
-
-	bool wasdepthtestenabled = isdepthtestenabled;
-	disableDepthTest();
-
-	// Pass 1: Compute raw AO → ssaoresultfbo
-	ssaoresultfbo->bind();
-	clearScreen(true, false);
-
-	ssaoshader->use();
-	ssaoshader->setMat4("projection", projectionmatrix);
-	ssaoshader->setMat4("invProjection", glm::inverse(projectionmatrix));
-	ssaoshader->setVec2("screenSize", glm::vec2(getScreenWidth(), getScreenHeight()));
-	ssaoshader->setFloat("ssaoRadius", ssaoradius);
-	ssaoshader->setFloat("ssaoBias", ssaobias);
-
-	bindTexture(ssaofbo->getDepthTextureId(), 0);
-
-	bindQuadVAO();
-	drawFullscreenQuad();
-
-	// Pass 2: Blur AO + composite with scene color → the render target beginSSAO() replaced
-	gFbo::defaultfbo = ssaorealdefaultfbo;
-	bindFramebuffer(ssaoprevframebuffer);
-	setViewport(ssaoprevviewport[0], ssaoprevviewport[1], ssaoprevviewport[2], ssaoprevviewport[3]);
-	clearScreen(true, false);
-
-	ssaoblurshader->use();
-	ssaoblurshader->setVec2("screenSize", glm::vec2(getScreenWidth(), getScreenHeight()));
-	ssaoblurshader->setFloat("ssaoStrength", ssaostrength);
-	ssaoblurshader->setInt("debugMode", isssaodebug ? 1 : 0);
-	ssaoblurshader->setFloat("nearClip", camera ? camera->getNearClip() : 0.01f);
-	ssaoblurshader->setFloat("farClip", camera ? camera->getFarClip() : 1000.0f);
-
-	bindTexture(ssaofbo->getTextureId(), 0);        // scene color
-	bindTexture(ssaoresultfbo->getTextureId(), 1);   // raw AO
-	bindTexture(ssaofbo->getDepthTextureId(), 2);    // depth (for bilateral blur)
-
-	bindQuadVAO();
-	drawFullscreenQuad();
-
-	// gTexture::bind() has no slot of its own and draws from slot 0. Leaving slot 2 active
-	// would make the next single texture draw sample our leftovers.
-	resetTexture();
-
-	if (wasdepthtestenabled) enableDepthTest();
-}
-
-bool gRenderer::isGammaCorrectionEnabled() {
-	return isgammacorrectionenabled;
-}
-
-void gRenderer::enableGammaCorrection() {
-	isgammacorrectionenabled = true;
-}
-
-void gRenderer::disableGammaCorrection() {
-	isgammacorrectionenabled = false;
-}
-
-bool gRenderer::isHDREnabled() {
-	return ishdrenabled;
-}
-
-void gRenderer::enableHDR() {
-	ishdrenabled = true;
-}
-
-void gRenderer::disableHDR() {
-	ishdrenabled = false;
+void gRenderer::disableSoftShadows() {
+	issoftshadowsenabled = false;
+	updateScene();
 }
 
 bool gRenderer::isSoftShadowsEnabled() {
 	return issoftshadowsenabled;
 }
 
-void gRenderer::enableSoftShadows() {
-	issoftshadowsenabled = true;
+void gRenderer::cleanupSSAOResources() {
+	delete ssaofbo;
+	delete ssaoresultfbo;
+	delete ssaoshader;
+	delete ssaoblurshader;
+	ssaofbo = nullptr;
+	ssaoresultfbo = nullptr;
+	ssaoshader = nullptr;
+	ssaoblurshader = nullptr;
+	isssaoallocated = false;
 }
 
-void gRenderer::disableSoftShadows() {
-	issoftshadowsenabled = false;
+void gRenderer::beginSSAO() {
+	if (!isssaoenabled) return;
+	isssaorendering = true;
 }
 
-//grid
+void gRenderer::endSSAO() {
+	if (!isssaoenabled) return;
+	isssaorendering = false;
+}
+
+// --- Grid Implementations ---
+
+bool gRenderer::isGridEnabled() {
+	if (grid) return grid->isEnabled();
+	return false;
+}
+
+void gRenderer::enableGrid() {
+	if (grid) grid->enable();
+}
+
+void gRenderer::disableGrid() {
+	if (grid) grid->disable();
+}
+
 void gRenderer::drawGrid() {
-	if(grid) {
+	if (grid && grid->isEnabled()) {
 		grid->draw();
 	}
 }
 
-void gRenderer::drawGridYZ() {
-	if(grid) {
-		grid->drawYZ();
-	}
+void gRenderer::setGridEnableAxis(bool x, bool y, bool z) {
+	if (grid) grid->setEnableAxis(x, y, z);
 }
 
-void gRenderer::drawGridXY() {
-	if(grid) {
-		grid->drawXY();
-	}
+void gRenderer::setGridEnableXY(bool enable) {
+	if (grid) grid->setEnableXY(enable);
 }
 
-void gRenderer::drawGridXZ() {
-	if(grid) {
-		grid->drawXZ();
-	}
+void gRenderer::setGridEnableXZ(bool enable) {
+	if (grid) grid->setEnableXZ(enable);
 }
 
-void gRenderer::enableGrid() {
-	if(grid) {
-		grid->enable();
-	}
-}
-
-void gRenderer::disableGrid() {
-	if(grid) {
-		grid->disable();
-	}
-}
-
-bool gRenderer::isGridEnabled() {
-	if(grid) {
-		return grid->isEnabled();
-	}
-	return false;
-}
-
-void gRenderer::setGridEnableAxis(bool xy, bool yz, bool xz) {
-	if(grid) {
-		grid->setEnableAxisX(xy);
-		grid->setEnableAxisY(xy);
-
-		grid->setEnableAxisY(yz);
-		grid->setEnableAxisZ(yz);
-
-		grid->setEnableAxisX(xz);
-		grid->setEnableAxisZ(xz);
-	}
-}
-
-void gRenderer::setGridMaxLength(float length) {
-	if(grid) {
-		grid->setFarClip(length);
-	}
-}
-
-float gRenderer::getGridMaxLength() {
-	if(grid) {
-		return grid->getFarClip();
-	}
-	return 1000.0f;
-}
-
-void gRenderer::setGridLineInterval(float intervalvalue) {
-	if (grid) {
-		grid->setLineSpacing(intervalvalue);
-	}
-}
-
-float gRenderer::getGridLineInterval() {
-	if(grid) {
-		return grid->getLineSpacing();
-	}
-	return 1.0f;
-}
-
-void gRenderer::setGridColorofAxisXZ(int r, int g, int b, int a) {
-	if(grid) {
-		grid->setColorAxisX(r,g,b,a);
-		grid->setColorAxisZ(r,g,b,a);
-	}
-}
-
-void gRenderer::setGridColorofAxisYZ(int r, int g, int b, int a) {
-	if(grid) {
-		grid->setColorAxisY(r,g,b,a);
-		grid->setColorAxisZ(r,g,b,a);
-	}
-}
-
-void gRenderer::setGridColorofAxisXY(int r, int g, int b, int a) {
-	if(grid) {
-		grid->setColorAxisX(r,g,b,a);
-		grid->setColorAxisY(r,g,b,a);
-	}
-}
-
-void gRenderer::setGridColorofAxisXZ(gColor *color) {
-	if(grid) {
-		grid->setColorAxisX(color);
-		grid->setColorAxisZ(color);
-	}
-}
-
-void gRenderer::setGridColorofAxisYZ(gColor *color) {
-	if(grid) {
-		grid->setColorAxisY(color);
-		grid->setColorAxisZ(color);
-	}
-}
-
-void gRenderer::setGridColorofAxisXY(gColor *color) {
-	if(grid) {
-		grid->setColorAxisX(color);
-		grid->setColorAxisY(color);
-	}
-}
-
-void gRenderer::setGridColorofAxisWireFrameXZ(int r, int g, int b, int a) {
-	if(grid) {
-		grid->setColorWireFrameXZ(r, g, b, a);
-	}
-}
-
-void gRenderer::setGridColorofAxisWireFrameXY(int r, int g, int b, int a) {
-	if(grid) {
-		grid->setColorWireFrameXY(r, g, b, a);
-	}
-}
-
-void gRenderer::setGridColorofAxisWireFrameYZ(int r, int g, int b, int a) {
-	if(grid) {
-		grid->setColorWireFrameYZ(r, g, b, a);
-	}
-}
-
-void gRenderer::setGridColorofAxisWireFrameXZ(gColor *color) {
-	if(grid) {
-		grid->setColorWireFrameXZ(color);
-	}
-}
-
-void gRenderer::setGridColorofAxisWireFrameYZ(gColor *color) {
-	if(grid) {
-		grid->setColorWireFrameYZ(color);
-	}
-}
-
-void gRenderer::setGridColorofAxisWireFrameXY(gColor *color) {
-	if(grid) {
-		grid->setColorWireFrameXY(color);
-	}
-}
-
-void gRenderer::setGridEnableXY(bool xy) {
-	if(grid) {
-		grid->setEnableXY(xy);
-	}
-}
-
-void gRenderer::setGridEnableYZ(bool yz) {
-	if(grid) {
-		grid->setEnableYZ(yz);
-	}
-}
-
-void gRenderer::setGridEnableXZ(bool xz) {
-	if(grid) {
-		grid->setEnableXZ(xz);
-	}
+void gRenderer::setGridEnableYZ(bool enable) {
+	if (grid) grid->setEnableYZ(enable);
 }
 
 bool gRenderer::isGridXYEnabled() {
-	if(grid) {
-		return grid->isXYEnabled();
-	}
-	return false;
-}
-
-bool gRenderer::isGridYZEnabled() {
-	if(grid) {
-		return grid->isYZEnabled();
-	}
+	if (grid) return grid->isXYEnabled();
 	return false;
 }
 
 bool gRenderer::isGridXZEnabled() {
-	if(grid) {
-		return grid->isXZEnabled();
-	}
+	if (grid) return grid->isXZEnabled();
 	return false;
 }
 
-gGrid* gRenderer::getGrid() const {
-	return grid;
+bool gRenderer::isGridYZEnabled() {
+	if (grid) return grid->isYZEnabled();
+	return false;
 }
 
-// if its the dev's grid let them manage its lifetime and disable the renderer's instance
-void gRenderer::setGrid(gGrid* newgrid) {
-	grid->disable();
-	grid = newgrid;
-	grid->enable();
-
+void gRenderer::setGridMaxLength(float length) {
 }
 
-void gRenderer::drawLine(float x1, float y1, float x2, float y2, float thickness) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawLine()");
-	linemesh->setThickness(thickness);
-	linemesh->draw(x1, y1, x2, y2);
+float gRenderer::getGridMaxLength() {
+	return 0.0f;
 }
 
-void gRenderer::drawLine(float x1, float y1, float z1, float x2, float y2, float z2, float thickness) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawLine()");
-	linemesh->setThickness(thickness);
-	linemesh->draw(x1, y1, z1, x2, y2, z2);
+void gRenderer::setGridLineInterval(float interval) {
 }
 
-void gRenderer::drawTriangle(float px, float py, float qx, float qy, float rx, float ry, bool is_filled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawTriangle()");
-	trianglemesh->draw(px, py, qx, qy, rx, ry, is_filled);
+float gRenderer::getGridLineInterval() {
+	return 0.0f;
 }
 
-void gRenderer::drawCircle(float xCenter, float yCenter, float radius, bool isFilled, float numberOfSides) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCircle()");
-	circlemesh->draw(xCenter, yCenter, radius, isFilled, numberOfSides);
+void gRenderer::setGridColorofAxisXY(int r, int g, int b, int a) {
 }
 
-void gRenderer::drawCross(float x, float y, float width, float height, float thickness, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCross()");
-	crossmesh->draw(x, y, width, height, thickness, isFilled);
+void gRenderer::setGridColorofAxisXY(gColor* color) {
 }
 
-void gRenderer::drawArc(float xCenter, float yCenter, float radius, bool isFilled, int numberOfSides, float degree, float rotate) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawArc()");
-	arcmesh->draw(xCenter, yCenter, radius, isFilled, numberOfSides, degree, rotate);
+void gRenderer::setGridColorofAxisWireFrameXY(int r, int g, int b, int a) {
 }
 
-void gRenderer::drawArrow(float x1, float y1, float length, float angle, float tipLength, float tipAngle, float thickness) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawArrow()");
-	float x2 = x1 + std::cos(gDegToRad(angle)) * length;
-	float y2 = y1 + std::sin(gDegToRad(angle)) * length;
-
-	linemesh->setThickness(thickness);
-	linemesh2->setThickness(thickness);
-	linemesh3->setThickness(thickness);
-
-	float halfThickness = thickness * 0.8f;
-
-	float upperTipAngle = tipAngle + 5.0f;
-	float lowerTipAngle = tipAngle + 5.0f;
-
-	float wing1Angle = angle - upperTipAngle;
-	float wing2Angle = angle + lowerTipAngle;
-
-	float wing1StartX = x1 - halfThickness * std::sin(gDegToRad(wing1Angle));
-	float wing1StartY = y1 + halfThickness * std::cos(gDegToRad(wing1Angle));
-
-	float wing2StartX = x1 + halfThickness * std::sin(gDegToRad(wing2Angle));
-	float wing2StartY = y1 - halfThickness * std::cos(gDegToRad(wing2Angle));
-
-	float shaftOffset = halfThickness / std::sin(gDegToRad(tipAngle));
-	float bodyStartX = x1 + std::cos(gDegToRad(angle)) * shaftOffset;
-	float bodyStartY = y1 + std::sin(gDegToRad(angle)) * shaftOffset;
-
-	linemesh->draw(bodyStartX, bodyStartY, x2, y2);
-
-	linemesh2->draw(wing1StartX, wing1StartY, wing1StartX + std::cos(gDegToRad(wing1Angle)) * tipLength, wing1StartY + std::sin(gDegToRad(wing1Angle)) * tipLength);
-	linemesh3->draw(wing2StartX, wing2StartY, wing2StartX + std::cos(gDegToRad(wing2Angle)) * tipLength, wing2StartY + std::sin(gDegToRad(wing2Angle)) * tipLength);
+void gRenderer::setGridColorofAxisWireFrameXY(gColor* color) {
 }
 
-void gRenderer::drawRectangle(float x, float y, float w, float h, bool isFilled, float rotateAngle) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawRectangle()");
-	rectanglemesh->draw(x, y, w, h, isFilled, rotateAngle);
+void gRenderer::setGridColorofAxisXZ(int r, int g, int b, int a) {
 }
 
-void gRenderer::drawRoundedRectangle(float x, float y, float w, float h, int radius, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawRoundedRectangle()");
-	roundedrectanglemesh->draw(x, y, w, h, radius, isFilled);
+void gRenderer::setGridColorofAxisXZ(gColor* color) {
 }
 
-void gRenderer::drawBox(float x, float y, float z, float w, float h, float d, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawBox()");
-	if(!isFilled) {
-		boxmesh->setDrawMode(gMesh::DRAWMODE_LINELOOP);
-	} else {
-		boxmesh->setDrawMode(gMesh::DRAWMODE_TRIANGLES);
-	}
-	boxmesh->setPosition(x, y, z);
-	boxmesh->setScale(w, h, d);
-	boxmesh->draw();
+void gRenderer::setGridColorofAxisWireFrameXZ(int r, int g, int b, int a) {
 }
 
-void gRenderer::drawBox(glm::mat4 transformationMatrix, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawBox()");
-	if(!isFilled) {
-		boxmesh->setDrawMode(gMesh::DRAWMODE_LINELOOP);
-	} else {
-		boxmesh->setDrawMode(gMesh::DRAWMODE_TRIANGLES);
-	}
-	boxmesh->setTransformationMatrix(transformationMatrix);
-	boxmesh->draw();
+void gRenderer::setGridColorofAxisWireFrameXZ(gColor* color) {
 }
 
-void gRenderer::drawSphere(float xPos, float yPos, float zPos, glm::vec3 scale, int xSegmentNum, int ySegmentNum, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawSphere()");
-	gSphere spheremesh(xSegmentNum, ySegmentNum, isFilled);
-	spheremesh.setPosition(xPos, yPos, zPos);
-	spheremesh.setScale(scale.x, scale.y, scale.z);
-	spheremesh.draw();
+void gRenderer::setGridColorofAxisYZ(int r, int g, int b, int a) {
 }
 
-void gRenderer::drawCylinder(float x, float y, float z, int r, int h, glm::vec3 scale, int segmentnum, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCylinder()");
-	gCylinder cylindermesh(r, r, h, glm::vec2(0.0f, 0.0f), segmentnum, isFilled);
-	cylindermesh.setPosition(x, y, z);
-	cylindermesh.setScale(scale.x, scale.y, scale.z);
-	cylindermesh.draw();
+void gRenderer::setGridColorofAxisYZ(gColor* color) {
 }
 
-void gRenderer::drawCylinderOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCylinderOblique()");
-	gCylinder cylindermesh(r, r, h, shiftdistance, segmentnum, isFilled);
-	cylindermesh.setPosition(x, y, z);
-	cylindermesh.setScale(scale.x, scale.y, scale.z);
-	cylindermesh.draw();
+void gRenderer::setGridColorofAxisWireFrameYZ(int r, int g, int b, int a) {
 }
 
-void gRenderer::drawCylinderTrapezodial(float x, float y, float z, int r1, int r2, int h, glm::vec3 scale, int segmentnum, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCylinderTrapezodial()");
-	gCylinder cylindermesh(r1, r2, h, glm::vec2(0.0f, 0.0f), segmentnum, isFilled);
-	cylindermesh.setPosition(x, y, z);
-	cylindermesh.setScale(scale.x, scale.y, scale.z);
-	cylindermesh.draw();
-}
-
-void gRenderer::drawCylinderObliqueTrapezodial(float x, float y, float z, int r1, int r2, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCylinderObliqueTrapezodial()");
-	gCylinder cylindermesh(r1, r2, h, shiftdistance, segmentnum, isFilled);
-	cylindermesh.setPosition(x, y, z);
-	cylindermesh.setScale(scale.x, scale.y, scale.z);
-	cylindermesh.draw();
-}
-
-void gRenderer::drawCone(float x, float y, float z, int r, int h, glm::vec3 scale, int segmentnum, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCone()");
-	gCone conemesh(r, h, glm::vec2(0.0f, 0.0f), segmentnum, isFilled);
-	conemesh.setPosition(x, y, z);
-	conemesh.setScale(scale.x, scale.y, scale.z);
-	conemesh.draw();
-}
-
-void gRenderer::drawConeOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawConeOblique()");
-	gCone conemesh(r, h, shiftdistance, segmentnum, isFilled);
-	conemesh.setPosition(x, y, z);
-	conemesh.setScale(scale.x, scale.y, scale.z);
-	conemesh.draw();
-}
-
-void gRenderer::drawPyramid(float x, float y, float z, int r, int h, glm::vec3 scale, int numberofsides, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawPyramid()");
-	gCone conemesh(r, h, glm::vec2(0.0f, 0.0f), numberofsides, isFilled);
-	conemesh.setPosition(x, y, z);
-	conemesh.setScale(scale.x, scale.y, scale.z);
-	conemesh.draw();
-}
-
-void gRenderer::drawPyramidOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance, glm::vec3 scale, int numberofsides, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawPyramidOblique()");
-	gCone conemesh(r, h, shiftdistance, numberofsides, isFilled);
-	conemesh.setPosition(x, y, z);
-	conemesh.setScale(scale.x, scale.y, scale.z);
-	conemesh.draw();
-}
-
-void gRenderer::drawTube(float x, float y, float z, int outerradius, int innerradious, int h, glm::vec3 scale, int segmentnum, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawTube()");
-	gTube tubemesh(outerradius,innerradious ,outerradius,innerradious, h, glm::vec2(0.0f, 0.0f), segmentnum, isFilled);
-	tubemesh.setPosition(x, y, z);
-	tubemesh.setScale(scale.x, scale.y, scale.z);
-	tubemesh.draw();
-}
-
-void gRenderer::drawTubeOblique(float x, float y, float z, int outerradius,
-		int innerradious, int h, glm::vec2 shiftdistance, glm::vec3 scale,
-		int segmentnum, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawTubeOblique()");
-	gTube tubemesh(outerradius,innerradious ,outerradius,innerradious, h, shiftdistance, segmentnum, isFilled);
-	tubemesh.setPosition(x, y, z);
-	tubemesh.setScale(scale.x, scale.y, scale.z);
-	tubemesh.draw();
-}
-
-void gRenderer::drawTubeTrapezodial(float x, float y, float z, int topouterradius,
-		int topinnerradious, int buttomouterradious, int buttominnerradious,
-		int h, glm::vec3 scale, int segmentnum, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawTubeTrapezodial()");
-	gTube tubemesh(topouterradius,topinnerradious , buttomouterradious,buttominnerradious, h, glm::vec2(0.0f, 0.0f), segmentnum, isFilled);
-	tubemesh.setPosition(x, y, z);
-	tubemesh.setScale(scale.x, scale.y, scale.z);
-	tubemesh.draw();
-}
-
-void gRenderer::drawTubeObliqueTrapezodial(float x, float y, float z, int topouterradius,
-		int topinnerradious, int buttomouterradious, int buttominnerradious,
-		int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum,
-		bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawTubeObliqueTrapezodial()");
-	gTube tubemesh(topouterradius,topinnerradious , buttomouterradious,buttominnerradious, h, shiftdistance, segmentnum, isFilled);
-	tubemesh.setPosition(x, y, z);
-	tubemesh.setScale(scale.x, scale.y, scale.z);
-	tubemesh.draw();
+void gRenderer::setGridColorofAxisWireFrameYZ(gColor* color) {
 }

--- a/engine/core/gRenderer.h
+++ b/engine/core/gRenderer.h
@@ -1,5 +1,5 @@
 /*
- * gRenderManager.h
+ * gRenderer.h
  *
  *  Created on: 4 Ara 2020
  *      Author: Acer
@@ -79,15 +79,19 @@ int gGetCullFace();
 void gSetCullingDirection(int cullingDirection);
 int gGetCullingDirection();
 
-void gDrawLine(float x1, float y1, float x2, float y2, float thickness = 1.0f);
+// --- 2D / 3D Line Overloads (Ambiguous hatasýný önlemek için ayrýþtýrýldý) ---
+void gDrawLine(float x1, float y1, float x2, float y2);
+void gDrawLine(float x1, float y1, float x2, float y2, float thickness);
 void gDrawLine(float x1, float y1, float z1, float x2, float y2, float z2, float thickness = 1.0f);
-void gDrawTriangle(float px, float py, float qx, float qy, float rx, float ry, bool is_filled = true);
-void gDrawCircle(float xCenter, float yCenter, float radius, bool isFilled = false, float numberOfSides = 64.0f);
-void gDrawCross(float x, float y, float width, float height, float thickness, bool isFilled);
-void gDrawArc(float xCenter, float yCenter, float radius, bool isFilled = true, int numberOfSides = 60, float degree = 360.0f, float rotate = 360.0f);
-void gDrawArrow(float x1, float y1, float length, float angle, float tipLength, float tipAngle, float thickness = 1.0f);
-void gDrawRectangle(float x, float y, float w, float h, bool isFilled = false, float rotateAngle = 0.0f);
-void gDrawRoundedRectangle(float x, float y, float w, float h, int radius, bool isFilled);
+void gDrawLine(float x1, float y1, float x2, float y2, float thickness, float rotateAngle, float pivotx, float pivoty);
+
+void gDrawTriangle(float px, float py, float qx, float qy, float rx, float ry, bool is_filled = true, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
+void gDrawCircle(float xCenter, float yCenter, float radius, bool isFilled = false, float numberOfSides = 64.0f, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
+void gDrawCross(float x, float y, float width, float height, float thickness, bool isFilled, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
+void gDrawArc(float xCenter, float yCenter, float radius, bool isFilled = true, int numberOfSides = 60, float degree = 360.0f, float rotate = 360.0f, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
+void gDrawArrow(float x1, float y1, float length, float angle, float tipLength, float tipAngle, float thickness = 1.0f, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
+void gDrawRectangle(float x, float y, float w, float h, bool isFilled = false, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
+void gDrawRoundedRectangle(float x, float y, float w, float h, int radius, bool isFilled, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
 void gDrawBox(float x, float y, float z, float w = 1.0f, float h = 1.0f, float d = 1.0f, bool isFilled = true);
 void gDrawBox(glm::mat4 transformationMatrix, bool isFilled = true);
 void gDrawSphere(float xPos, float yPos, float zPos, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int xSegmentNum = 64, int ySegmentNum = 32, bool isFilled = true);
@@ -122,6 +126,7 @@ class gArc;
 class gRectangle;
 class gRoundedRectangle;
 class gBox;
+//class gArrow;
 
 class gRenderer : public gObject {
 public:
@@ -146,8 +151,6 @@ public:
 
 	struct alignas(16) gSceneLights {
 		alignas(4) int lightnum = 0;
-		// bitwise enabled lights, 1 means enabled, 0 means disabled, 32-bit integer
-		// supports only 32 max lights, make sure to change this if max lights is changed to be something above 32
 		alignas(4) int enabledlights;
 		alignas(16) glm::vec4 globalambientcolor;
 		gSceneLightData lights[GLIST_MAX_LIGHTS];
@@ -248,35 +251,15 @@ public:
 	void setColor(gColor* color);
 	gColor* getColor();
 
-	/*
-	 * Backends that have to bracket a frame explicitly, like Vulkan, prepare it in
-	 * beginFrame and submit and present it in endFrame. A false return means the
-	 * frame has to be skipped, for example while the swapchain is rebuilt after a
-	 * resize; endFrame must not be called in that case. OpenGL draws immediately
-	 * and needs neither, so both are no-ops there.
-	 */
 	virtual bool beginFrame() { return true; }
 	virtual void endFrame() {}
 
-	// Which backend this renderer is (G_RENDERER_GL / G_RENDERER_VK). Set by
-	// gRenderObject::createRenderer.
 	int getRenderEngineType() const { return renderenginetype; }
 	bool isVulkan() const { return renderenginetype == G_RENDERER_VK; }
 
-	// Backend hook for the 2D coloured primitives. OpenGL draws these through the
-	// mesh path and leaves this a no-op; the Vulkan backend overrides it to record
-	// into the active frame. points holds `count` 2D screen positions connected as
-	// drawMode says (a gMesh::DRAWMODE_* value, that is a GL primitive constant),
-	// and colour components are 0..1.
 	virtual void drawColored2D(const glm::vec2* points, int count, const glm::vec4& color, const glm::mat4& mvp,
 			int drawMode = GL_TRIANGLES) {}
 
-	// Backend hook for a textured 2D quad (gImage / gTexture). OpenGL draws through
-	// its image shader and leaves this a no-op; Vulkan looks the texture id up in
-	// its registry and records a textured unit quad. tint components are 0..1; mvp
-	// is projection2d * the image model matrix. uvOffset / uvScale select the part
-	// of the texture to sample, covering all of it by default. maskTextureId is an
-	// alpha mask sampled with the same coordinates, or 0 for an unmasked draw.
 	virtual void drawTexturedRect2D(GLuint textureId, GLuint maskTextureId, const glm::vec4& tint,
 			const glm::mat4& mvp,
 			const glm::vec2& uvOffset = glm::vec2(0.0f), const glm::vec2& uvScale = glm::vec2(1.0f)) {}
@@ -318,8 +301,6 @@ public:
 	float getFogLinearStart() const;
 	float getFogLinearEnd() const;
 
-	// add and remove functions are called by gLight class automatically,
-	// so you don't need to
 	void addSceneLight(gLight* light);
 	void removeSceneLight(gLight* light);
 	gLight* getSceneLight(int lightNo);
@@ -399,14 +380,7 @@ public:
 	void backupMatrices();
 	void restoreMatrices();
 
-	/*
-	 * Takes Screen Shot of the current Rendered Screen and returns it as an gImage class
-	 */
 	virtual void takeScreenshot(gImage& img) = 0;
-
-	/*
-	 * Takes Screen Shot of the part of current Rendered Screen and returns it as an gImage class
-	 */
 	virtual void takeScreenshot(gImage& img, int x, int y, int width, int height) = 0;
 
 	/* -------------- gUbo ------------- */
@@ -443,14 +417,12 @@ public:
 	virtual void setVertexAttribDivisor(int index, int divisor) = 0;
 
 	virtual void setViewport(int x, int y, int width, int height) = 0;
-	// Viewport that is currently set. Kept up to date by the render engines.
 	void getViewport(int& x, int& y, int& width, int& height) const;
 
 	/* -------------- gFbo --------------- */
 	virtual GLuint createFramebuffer() = 0;
 	virtual void deleteFramebuffer(GLuint& fbo) = 0;
 	virtual void bindFramebuffer(GLuint fbo) = 0;
-	// Framebuffer that is currently bound. Kept up to date by the render engines.
 	GLuint getBoundFramebuffer() const;
 	virtual void checkFramebufferStatus() = 0;
 
@@ -469,7 +441,6 @@ public:
 	virtual void deleteFullscreenQuad(GLuint& vao, GLuint* vbo) = 0;
 
 	/* -------------- gShader --------------- */
-	// This function loads shaders without preproccesing them. Geometry source can be nullptr.
 	virtual GLuint loadProgram(const char* vertexSource, const char* fragmentSource, const char* geometrySource) = 0;
 	virtual void checkCompileErrors(GLuint shader, const std::string& type) = 0;
 	virtual void setBool(GLuint uniformloc, bool value) = 0;
@@ -536,16 +507,19 @@ public:
 	virtual void pushMatrix() = 0;
 	virtual void popMatrix() = 0;
 
-	/* ---------------- Utilities ---------------- */
-	void drawLine(float x1, float y1, float x2, float y2, float thickness = 1.0f);
+	/* ---------------- Utilities (drawLine overloads düzenlendi) ---------------- */
+	void drawLine(float x1, float y1, float x2, float y2);
+	void drawLine(float x1, float y1, float x2, float y2, float thickness);
 	void drawLine(float x1, float y1, float z1, float x2, float y2, float z2, float thickness = 1.0f);
-	void drawTriangle(float px, float py, float qx, float qy, float rx, float ry, bool is_filled = true);
-	void drawCircle(float xCenter, float yCenter, float radius, bool isFilled = false, float numberOfSides = 64.0f);
-	void drawCross(float x, float y, float width, float height, float thickness, bool isFilled);
-	void drawArc(float xCenter, float yCenter, float radius, bool isFilled = true, int numberOfSides = 60, float degree = 360.0f, float rotate = 360.0f);
-	void drawArrow(float x1, float y1, float length, float angle, float tipLength, float tipAngle, float thickness = 1.0f);
-	void drawRectangle(float x, float y, float w, float h, bool isFilled = false, float rotateAngle = 0.0f);
-	void drawRoundedRectangle(float x, float y, float w, float h, int radius, bool isFilled);
+	void drawLine(float x1, float y1, float x2, float y2, float thickness, float rotateAngle, float pivotx, float pivoty);
+
+	void drawTriangle(float px, float py, float qx, float qy, float rx, float ry, bool is_filled = true, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
+	void drawCircle(float xCenter, float yCenter, float radius, bool isFilled = false, float numberOfSides = 64.0f, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
+	void drawCross(float x, float y, float width, float height, float thickness, bool isFilled, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
+	void drawArc(float xCenter, float yCenter, float radius, bool isFilled = true, int numberOfSides = 60, float degree = 360.0f, float rotate = 360.0f, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
+	void drawArrow(float x1, float y1, float length, float angle, float tipLength, float tipAngle, float thickness = 1.0f, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
+	void drawRectangle(float x, float y, float w, float h, bool isFilled = false, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
+	void drawRoundedRectangle(float x, float y, float w, float h, int radius, bool isFilled, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
 	void drawBox(float x, float y, float z, float w = 1.0f, float h = 1.0f, float d = 1.0f, bool isFilled = true);
 	void drawBox(glm::mat4 transformationMatrix, bool isFilled = true);
 	void drawSphere(float xPos, float yPos, float zPos, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int xSegmentNum = 64, int ySegmentNum = 32, bool isFilled = true);
@@ -563,7 +537,7 @@ public:
 	void drawTubeObliqueTrapezodial(float x, float y, float z, int topouterradius,int topinnerradious, int buttomouterradious, int buttominnerradious, int h, glm::vec2 shiftdistance, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int segmentnum = 32, bool isFilled = true);
 
 protected:
-	friend class gRenderObject; // this is where renderer->init() is called from
+	friend class gRenderObject;
 	friend class gAppManager;
 
 	static int width, height;
@@ -573,7 +547,6 @@ protected:
 
 	gColor* rendercolor = nullptr;
 
-	// G_RENDERER_GL or G_RENDERER_VK; assigned by gRenderObject::createRenderer.
 	int renderenginetype = G_RENDERER_GL;
 
 	bool isfogenabled;
@@ -586,8 +559,6 @@ protected:
 	float foglinearend;
 
 	std::deque<gLight*> scenelights;
-	// Allocated only by gRenderer::init(), which the Vulkan backend skips, so they
-	// stay null there; updateScene()/updateLights() bail out under Vulkan.
 	gUbo<gSceneLights>* lightsubo = nullptr;
 	gUbo<gSceneData>* sceneubo = nullptr;
 	bool islightingenabled;
@@ -653,7 +624,6 @@ protected:
 	unsigned int fullscreenquadvao;
 	unsigned int fullscreenquadvbo;
 
-	// std::unique_ptr is automatically deletes the underlying object when this gRenderer object is deleted
 	std::unique_ptr<gLine> linemesh, linemesh2, linemesh3;
 	std::unique_ptr<gTriangle> trianglemesh;
 	std::unique_ptr<gCircle> circlemesh;
@@ -662,15 +632,12 @@ protected:
 	std::unique_ptr<gRectangle> rectanglemesh;
 	std::unique_ptr<gRoundedRectangle> roundedrectanglemesh;
 	std::unique_ptr<gBox> boxmesh;
+	//std::unique_ptr<gArrow> arrowmesh;
 
 	virtual void init();
 	virtual void cleanup();
 	virtual void updatePackUnpackAlignment(int i) = 0;
 
-	// The primitive meshes above are what drawLine / drawCircle / drawRectangle and
-	// friends draw through. They hold no backend objects of their own until they are
-	// drawn, so both backends create them the same way - the Vulkan backend needs
-	// them too, and it skips init().
 	void createPrimitiveMeshes();
 	void destroyPrimitiveMeshes();
 
@@ -701,8 +668,6 @@ protected:
 	static const std::string& getShaderSrcSSAOVertex();
 	static const std::string& getShaderSrcSSAOFragment();
 	static const std::string& getShaderSrcSSAOBlurFragment();
-
-
 };
 
 #endif /* CORE_GRENDERER_H_ */

--- a/engine/graphics/primitives/gArc.cpp
+++ b/engine/graphics/primitives/gArc.cpp
@@ -15,49 +15,72 @@ gArc::~gArc() {
 
 }
 
-void gArc::draw(float xCenter, float yCenter, float radius, bool isFilled, int numberOfSides, float degree, float rotate) {
+void gArc::draw(float xCenter, float yCenter, float radius, bool isFilled, int numberOfSides, float degree, float rotate, float rotateAngle, float pivotx, float pivoty) {
 	isprojection2d = true;
-	setArcPoints(xCenter, yCenter, radius, isFilled, numberOfSides, degree, rotate);
+	setArcPoints(xCenter, yCenter, radius, isFilled, numberOfSides, degree, rotate, rotateAngle, pivotx, pivoty);
 	gMesh::draw();
 }
 
-void gArc::setArcPoints(float xCenter, float yCenter, float radius, bool isFilled,  int numberOfSides, float degree, float rotate) {
+void gArc::setArcPoints(float xCenter, float yCenter, float radius, bool isFilled, int numberOfSides, float degree, float rotate, float rotateAngle, float pivotx, float pivoty) {
 	if (!this->vertices.empty()) {
 		this->vertices.clear();
 		this->indices.clear();
 	}
 	if(degree >= 0)
-		degree = std::fmod(degree, 360.0f);
+	    degree = std::fmod(degree, 360.0f);
 	else
-		degree = std::fmod((std::fmod(degree, 360.0f) + 360), 360.0f);
+	    degree = std::fmod((std::fmod(degree, 360.0f) + 360), 360.0f);
 	if(degree == 0)
-		degree = 360;
+	    degree = 360;
+
 	float angleradian = (float)degree / (float)numberOfSides * (PI / 180);
 	float rotateradian = rotate * (PI / 180);
 	float nextAngle;
-	gVertex vertex;
-	if(degree > -360 && degree < 360) {
-		vertex.position.x = xCenter;
-		vertex.position.y = yCenter;
-		vertex.position.z = 0.0f;
-		this->vertices.push_back(vertex);
+
+	// Pivot noktasý hesabý (Bounding Box: sol-üst köþe (xCenter - radius, yCenter - radius))
+	float boxX = xCenter - radius;
+	float boxY = yCenter - radius;
+	float boxW = 2.0f * radius;
+	float boxH = 2.0f * radius;
+
+	float pivotPx = boxX + pivotx * boxW;
+	float pivotPy = boxY + pivoty * boxH;
+
+	float cosA = cos(rotateAngle);
+	float sinA = sin(rotateAngle);
+
+	auto transformPoint = [&](float px, float py) -> gVertex {
+		gVertex v;
+		if (rotateAngle != 0.0f) {
+			float relX = px - pivotPx;
+			float relY = py - pivotPy;
+			v.position.x = relX * cosA - relY * sinA + pivotPx;
+			v.position.y = relX * sinA + relY * cosA + pivotPy;
+		} else {
+			v.position.x = px;
+			v.position.y = py;
+		}
+		v.position.z = 0.0f;
+		return v;
+	};
+
+	// Dolgulu modda (TRIANGLE_FAN) merkez nokta MUTLAKA ilk vertex olmalýdýr (derece fark etmeksizin).
+	if (isFilled) {
+		this->vertices.push_back(transformPoint(xCenter, yCenter));
 	}
+
+	// Çevre üzerindeki yay noktalarý
 	for(int i = 0; i <= numberOfSides; i++) {
 		nextAngle = rotateradian + (i * angleradian);
-		vertex.position.x = radius * cos(nextAngle) + xCenter;
-		vertex.position.y = radius * sin(nextAngle) + yCenter;
-		vertex.position.z = 0.0f;
-		this->vertices.push_back(vertex);
+		float vx = radius * cos(nextAngle) + xCenter;
+		float vy = radius * sin(nextAngle) + yCenter;
+		this->vertices.push_back(transformPoint(vx, vy));
 	}
-	if(degree > -360 && degree < 360) {
-		vertex.position.x = xCenter;
-		vertex.position.y = yCenter;
-		vertex.position.z = 0.0f;
-		this->vertices.push_back(vertex);
-	}
+
 	auto verticesptr = std::make_shared<std::vector<gVertex>>(this->vertices);
 	auto indicesptr = std::make_shared<std::vector<gIndex>>(this->indices);
 	setVertices(verticesptr, indicesptr);
+
 	if(isFilled == false)
 		setDrawMode(gMesh::DRAWMODE_LINESTRIP);
 	else

--- a/engine/graphics/primitives/gArc.h
+++ b/engine/graphics/primitives/gArc.h
@@ -15,10 +15,10 @@ public:
 	gArc();
 	~gArc() override;
 
-	void draw(float xCenter, float yCenter, float radius, bool isFilled, int numberOfSides = 60, float degree = 360.0f, float rotate = 360.0f);
+	void draw(float xCenter, float yCenter, float radius, bool isFilled, int numberOfSides = 60, float degree = 360.0f, float rotate = 0.0f, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
 
-private:
-	void setArcPoints(float xCenter, float yCenter, float radius, bool isFilled, int numberOfSides = 60, float degree = 360.0f, float rotate = 360.0f);
+	private:
+		void setArcPoints(float xCenter, float yCenter, float radius, bool isFilled, int numberOfSides = 60, float degree = 360.0f, float rotate = 0.0f, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
 	std::vector<gVertex> vertices;
 	std::vector<gIndex> indices;
 };

--- a/engine/graphics/primitives/gCircle.cpp
+++ b/engine/graphics/primitives/gCircle.cpp
@@ -1,4 +1,20 @@
 /*
+ * Copyright (C) 2016 Nitra Games Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
  * gCircle.cpp
  *
  *  Created on: 9 Tem 2021
@@ -11,18 +27,18 @@ gCircle::gCircle() {
 
 }
 
-gCircle::gCircle(float xCenter, float yCenter, float radius, bool isFilled, float numberOfSides) {
+gCircle::gCircle(float xCenter, float yCenter, float radius, bool isFilled, float numberOfSides, float rotateAngle, float pivotx, float pivoty) {
 	isprojection2d = true;
-	setCirclePoints(xCenter, yCenter, radius, isFilled, numberOfSides);
+	setCirclePoints(xCenter, yCenter, radius, isFilled, numberOfSides, rotateAngle, pivotx, pivoty);
 }
 
 gCircle::~gCircle() {
 
 }
 
-void gCircle::setPoints(float xCenter, float yCenter, float radius, bool isFilled,  float numberOfSides) {
+void gCircle::setPoints(float xCenter, float yCenter, float radius, bool isFilled, float numberOfSides, float rotateAngle, float pivotx, float pivoty) {
 	isprojection2d = true;
-	setCirclePoints(xCenter, yCenter, radius, isFilled, numberOfSides);
+	setCirclePoints(xCenter, yCenter, radius, isFilled, numberOfSides, rotateAngle, pivotx, pivoty);
 }
 
 void gCircle::draw(){
@@ -30,28 +46,46 @@ void gCircle::draw(){
 	gMesh::draw();
 }
 
-void gCircle::draw(float xCenter, float yCenter, float radius, bool isFilled, float numberOfSides){
+void gCircle::draw(float xCenter, float yCenter, float radius, bool isFilled, float numberOfSides, float rotateAngle, float pivotx, float pivoty){
 	isprojection2d = true;
-	setCirclePoints(xCenter, yCenter, radius, isFilled, numberOfSides);
+	setCirclePoints(xCenter, yCenter, radius, isFilled, numberOfSides, rotateAngle, pivotx, pivoty);
 	gMesh::draw();
 }
 
-void gCircle::setCirclePoints(float xCenter, float yCenter, float radius, bool isFilled,  float numberOfSides) {
-	float angle     = PI * 2 / numberOfSides;
+void gCircle::setCirclePoints(float xCenter, float yCenter, float radius, bool isFilled, float numberOfSides, float rotateAngle, float pivotx, float pivoty) {
+	float angle = PI * 2 / numberOfSides;
 	std::vector<gVertex> verticessb;
+
+	float pivotPx = (xCenter - radius) + pivotx * (2.0f * radius);
+	float pivotPy = (yCenter - radius) + pivoty * (2.0f * radius);
+
+	float cosA = cos(rotateAngle);
+	float sinA = sin(rotateAngle);
 
 	for(int i = 0; i <= numberOfSides; i++) {
 		float nextAngle = angle * i;
 		gVertex vertex;
-		vertex.position.x = radius * cos(nextAngle) + xCenter;
-		vertex.position.y = radius * sin(nextAngle) + yCenter;
+
+		float px = radius * cos(nextAngle) + xCenter;
+		float py = radius * sin(nextAngle) + yCenter;
+
+		if (rotateAngle != 0.0f) {
+			float relX = px - pivotPx;
+			float relY = py - pivotPy;
+
+			vertex.position.x = relX * cosA - relY * sinA + pivotPx;
+			vertex.position.y = relX * sinA + relY * cosA + pivotPy;
+		} else {
+			vertex.position.x = px;
+			vertex.position.y = py;
+		}
+
 		vertex.position.z = 0.0f;
 		verticessb.push_back(vertex);
 	}
+
 	auto verticesptr = std::make_shared<std::vector<gVertex>>(verticessb);
 	setVertices(verticesptr);
 	if(isFilled == false) setDrawMode(gMesh::DRAWMODE_LINESTRIP);
 	else setDrawMode(gMesh::DRAWMODE_TRIANGLEFAN);
 }
-
-

--- a/engine/graphics/primitives/gCircle.h
+++ b/engine/graphics/primitives/gCircle.h
@@ -39,10 +39,13 @@ public:
 	 * @param yCenter y-coordinate of the circle's center
 	 * @param radius radius of the circle
 	 * @param isFilled signifies whether the circle is full or empty
-	 * @param numberOfsides  indicates the detail value of the circle.
+	 * @param numberOfSides indicates the detail value of the circle.
+	 * @param rotateAngle rotation angle in radians
+	 * @param pivotx rotation pivot x position ratio (0.0f - 1.0f)
+	 * @param pivoty rotation pivot y position ratio (0.0f - 1.0f)
 	 */
 	gCircle();
-	gCircle(float xCenter, float yCenter, float radius, bool isFilled, float numberOfSides = 64.0f);
+	gCircle(float xCenter, float yCenter, float radius, bool isFilled, float numberOfSides = 64.0f, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
 	virtual ~gCircle();
 
    /*
@@ -50,7 +53,7 @@ public:
 	*/
 	void draw();
 
-	void setPoints(float xCenter, float yCenter, float radius, bool isFilled,  float numberOfSides = 64.0f);
+	void setPoints(float xCenter, float yCenter, float radius, bool isFilled, float numberOfSides = 64.0f, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
 
 	/*
 	 * Determines whether the projection is two-dimensional.
@@ -61,26 +64,32 @@ public:
 	 * @param yCenter y-coordinate of the circle's center
 	 * @param radius radius of the circle
 	 * @param isFilled signifies whether the circle is full or empty
-	 * @param numberOfsides  indicates the detail value of the circle.
+	 * @param numberOfSides indicates the detail value of the circle.
+	 * @param rotateAngle rotation angle in radians
+	 * @param pivotx rotation pivot x position ratio (0.0f - 1.0f)
+	 * @param pivoty rotation pivot y position ratio (0.0f - 1.0f)
 	 */
-	void draw(float xCenter, float yCenter, float radius, bool isFilled, float numberOfSides = 64.0f);
+	void draw(float xCenter, float yCenter, float radius, bool isFilled, float numberOfSides = 64.0f, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
 
 private:
 
 	/*
 	 * The circle is formed by triangles.
-	 * These triangles vertices form  circle.
+	 * These triangles vertices form circle.
 	 * Calculating coordinate information.
-	 * The more side are given, the sharper the circle will be, as the number of triangles will increase.
+	 * The more sides are given, the sharper the circle will be, as the number of triangles will increase.
 	 * But it does not provide any visible change after 64 sides given as default.
 	 *
 	 * @param xCenter x-coordinate of the circle's center
 	 * @param yCenter y-coordinate of the circle's center
 	 * @param radius radius of the circle
 	 * @param isFilled signifies whether the circle is full or empty
-	 * @param numberOfsides  indicates the detail value of the circle.
+	 * @param numberOfSides indicates the detail value of the circle.
+	 * @param rotateAngle rotation angle in radians
+	 * @param pivotx rotation pivot x position ratio (0.0f - 1.0f)
+	 * @param pivoty rotation pivot y position ratio (0.0f - 1.0f)
 	 */
-	void setCirclePoints(float xCenter, float yCenter, float radius, bool isFilled, float numberOfSides = 64.0f);
+	void setCirclePoints(float xCenter, float yCenter, float radius, bool isFilled, float numberOfSides = 64.0f, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
 };
 
 #endif /* GRAPHICS_PRIMITIVES_GCIRCLE_H_ */

--- a/engine/graphics/primitives/gCross.cpp
+++ b/engine/graphics/primitives/gCross.cpp
@@ -15,142 +15,138 @@ gCross::~gCross() {
 
 }
 
-void gCross::draw(float x, float y, float width, float height, float thickness, bool isFilled) {
+void gCross::draw(float x, float y, float width, float height, float thickness, bool isFilled, float rotateAngle, float pivotx, float pivoty) {
 	isprojection2d = true;
 	if(isFilled == false) {
-		drawNonFilled(x, y, width, height, thickness);
+		drawNonFilled(x, y, width, height, thickness, rotateAngle, pivotx, pivoty);
 		setDrawMode(gMesh::DRAWMODE_LINESTRIP);
 	}
 	else {
-		drawFilled(x, y, width, height, thickness);
+		drawFilled(x, y, width, height, thickness, rotateAngle, pivotx, pivoty);
 		setDrawMode(gMesh::DRAWMODE_TRIANGLESTRIP);
 	}
 	gMesh::draw();
 }
 
-void gCross::drawNonFilled(float x, float y, float width, float height, float thickness) {
+void gCross::drawNonFilled(float x, float y, float width, float height, float thickness, float rotateAngle, float pivotx, float pivoty) {
 	// The corners are rebuilt on every call, so the previous ones have to go first;
 	// without this the mesh grows by a full cross each frame.
 	vertices.clear();
 	indices.clear();
+
+	// Pivot noktasý hesabý (Bounding Box: sol-üst köþe (x - thickness, y))
+	float pivotPx = (x - thickness) + pivotx * width;
+	float pivotPy = y + pivoty * height;
+
+	float cosA = cos(rotateAngle);
+	float sinA = sin(rotateAngle);
+
+	auto transformPoint = [&](float px, float py) -> gVertex {
+		gVertex v;
+		if (rotateAngle != 0.0f) {
+			float relX = px - pivotPx;
+			float relY = py - pivotPy;
+			v.position.x = relX * cosA - relY * sinA + pivotPx;
+			v.position.y = relX * sinA + relY * cosA + pivotPy;
+		} else {
+			v.position.x = px;
+			v.position.y = py;
+		}
+		v.position.z = 0.0f;
+		return v;
+	};
+
 	float mry = (height / 2) - (1 - (width / 2 / (width - thickness))) * (height - thickness); //length (from origin to intersection on y axis)
 	float mrx = ((1 - (height / 2 / (height - thickness))) * (width - thickness) - (width / 2)) * - 1; //length (from origin to intersection on x axis)
-	gVertex vertex;
+
 	// 'i' numbers represents vertices for cross.
 	//i = 0
-	vertex.position.x = x;
-	vertex.position.y = y;
-	vertex.position.z = 0.0f;
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x, y));
 	//i = 1
-	vertex.position.x = x - thickness;
-	vertex.position.y = y + thickness;
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x - thickness, y + thickness));
 	//i = 2
-	vertex.position.x = x - thickness + (width / 2) - mrx;
-	vertex.position.y = y + (height / 2);
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x - thickness + (width / 2) - mrx, y + (height / 2)));
 	//i = 3
-	vertex.position.x = x - thickness;
-	vertex.position.y = y - thickness + height;
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x - thickness, y - thickness + height));
 	//i = 4
-	vertex.position.x = x;
-	vertex.position.y = y + height;
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x, y + height));
 	//i = 5
-	vertex.position.x = x - thickness + (width / 2);
-	vertex.position.y = y + (height / 2) + mry;
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x - thickness + (width / 2), y + (height / 2) + mry));
 	//i = 6
-	vertex.position.x = x - (2 * thickness) + width;
-	vertex.position.y = y + height;
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x - (2 * thickness) + width, y + height));
 	//i = 7
-	vertex.position.x = x - thickness + width;
-	vertex.position.y = y - thickness + height;
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x - thickness + width, y - thickness + height));
 	//i = 8
-	vertex.position.x = x - thickness + (width / 2) + mrx;
-	vertex.position.y = y + (height / 2);
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x - thickness + (width / 2) + mrx, y + (height / 2)));
 	//i = 9
-	vertex.position.x = x - thickness + width;
-	vertex.position.y = y + thickness;
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x - thickness + width, y + thickness));
 	//i = 10
-	vertex.position.x = x - (2 * thickness) + width;
-	vertex.position.y = y;
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x - (2 * thickness) + width, y));
 	//i = 11
-	vertex.position.x = x - thickness + (width / 2);
-	vertex.position.y = y + (height / 2) - mry;
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x - thickness + (width / 2), y + (height / 2) - mry));
 	//i = 0
-	vertex.position.x = x;
-	vertex.position.y = y;
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x, y));
+
 	auto verticesptr = std::make_shared<std::vector<gVertex>>(vertices);
 	auto indicesptr = std::make_shared<std::vector<gIndex>>(indices);
 	setVertices(verticesptr, indicesptr);
 }
 
-void gCross::drawFilled(float x, float y, float width, float height, float thickness) {
+void gCross::drawFilled(float x, float y, float width, float height, float thickness, float rotateAngle, float pivotx, float pivoty) {
 	vertices.clear();
 	indices.clear();
+
+	// Pivot noktasý hesabý
+	float pivotPx = (x - thickness) + pivotx * width;
+	float pivotPy = y + pivoty * height;
+
+	float cosA = cos(rotateAngle);
+	float sinA = sin(rotateAngle);
+
+	auto transformPoint = [&](float px, float py) -> gVertex {
+		gVertex v;
+		if (rotateAngle != 0.0f) {
+			float relX = px - pivotPx;
+			float relY = py - pivotPy;
+			v.position.x = relX * cosA - relY * sinA + pivotPx;
+			v.position.y = relX * sinA + relY * cosA + pivotPy;
+		} else {
+			v.position.x = px;
+			v.position.y = py;
+		}
+		v.position.z = 0.0f;
+		return v;
+	};
+
 	float mry = (height / 2) - (1 - (width / 2 / (width - thickness))) * (height - thickness); //length (from origin to intersection on y axis)
 	float mrx = ((1 - (height / 2 / (height - thickness))) * (width - thickness) - (width / 2)) * - 1; //length (from origin to intersection on x axis)
-	gVertex vertex;
+
 	// 'i' numbers represents vertices for cross.
 	//i = 0
-	vertex.position.x = x;
-	vertex.position.y = y;
-	vertex.position.z = 0.0f;
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x, y));
 	//i = 1
-	vertex.position.x = x - thickness;
-	vertex.position.y = y + thickness;
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x - thickness, y + thickness));
 	//i = 6
-	vertex.position.x = x - (2 * thickness) + width;
-	vertex.position.y = y + height;
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x - (2 * thickness) + width, y + height));
 	//i = 7
-	vertex.position.x = x - thickness + width;
-	vertex.position.y = y - thickness + height;
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x - thickness + width, y - thickness + height));
 	//i = 0
-	vertex.position.x = x;
-	vertex.position.y = y;
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x, y));
 	//i = 11
-	vertex.position.x = x - thickness + (width / 2);
-	vertex.position.y = y + (height / 2) - mry;
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x - thickness + (width / 2), y + (height / 2) - mry));
 	//i = 8
-	vertex.position.x = x - thickness + (width / 2) + mrx;
-	vertex.position.y = y + (height / 2);
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x - thickness + (width / 2) + mrx, y + (height / 2)));
 	//i = 9
-	vertex.position.x = x - thickness + width;
-	vertex.position.y = y + thickness;
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x - thickness + width, y + thickness));
 	//i = 10
-	vertex.position.x = x - (2 * thickness) + width;
-	vertex.position.y = y;
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x - (2 * thickness) + width, y));
 	//i = 3
-	vertex.position.x = x - thickness;
-	vertex.position.y = y - thickness + height;
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x - thickness, y - thickness + height));
 	//i = 4
-	vertex.position.x = x;
-	vertex.position.y = y + height;
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x, y + height));
 	//i = 9
-	vertex.position.x = x - thickness + width;
-	vertex.position.y = y + thickness;
-	vertices.push_back(vertex);
+	vertices.push_back(transformPoint(x - thickness + width, y + thickness));
+
 	auto verticesptr = std::make_shared<std::vector<gVertex>>(vertices);
 	auto indicesptr = std::make_shared<std::vector<gIndex>>(indices);
 	setVertices(verticesptr, indicesptr);

--- a/engine/graphics/primitives/gCross.h
+++ b/engine/graphics/primitives/gCross.h
@@ -15,11 +15,11 @@ public:
 	gCross();
 	~gCross() override;
 
-	void draw(float x, float y, float width, float height, float thickness, bool isFilled);
+	void draw(float x, float y, float width, float height, float thickness, bool isFilled, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
 
 private:
-	void drawNonFilled(float x, float y, float width, float height, float thickness);
-	void drawFilled(float x, float y, float width, float height, float thickness);
+	void drawNonFilled(float x, float y, float width, float height, float thickness, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
+	void drawFilled(float x, float y, float width, float height, float thickness, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
 
 	std::vector<gVertex> vertices;
 	std::vector<gIndex> indices;

--- a/engine/graphics/primitives/gLine.cpp
+++ b/engine/graphics/primitives/gLine.cpp
@@ -6,45 +6,47 @@
  */
 
 #include "gLine.h"
+#include <cmath>
+#include <algorithm>
 
 
 gLine::gLine() {
 	thickness = 1.0f;
 }
 
-gLine::gLine(float x1, float y1, float x2, float y2) {
+gLine::gLine(float x1, float y1, float x2, float y2, float rotateAngle, float pivotx, float pivoty) {
 	isprojection2d = true;
-	setLinePoints(x1, y1, 0.0f, x2, y2, 0.0f);
+	setLinePoints(x1, y1, 0.0f, x2, y2, 0.0f, rotateAngle, pivotx, pivoty);
 }
 
-gLine::gLine(float x1, float y1, float z1, float x2, float y2, float z2) {
+gLine::gLine(float x1, float y1, float z1, float x2, float y2, float z2, float rotateAngle, float pivotx, float pivoty) {
 	isprojection2d = false;
-	setLinePoints(x1, y1, z1, x2, y2, z2);
+	setLinePoints(x1, y1, z1, x2, y2, z2, rotateAngle, pivotx, pivoty);
 }
 
-void gLine::setPoints(float x1, float y1, float x2, float y2) {
+void gLine::setPoints(float x1, float y1, float x2, float y2, float rotateAngle, float pivotx, float pivoty) {
 	isprojection2d = true;
-	setLinePoints(x1, y1, 0.0f, x2, y2, 0.0f);
+	setLinePoints(x1, y1, 0.0f, x2, y2, 0.0f, rotateAngle, pivotx, pivoty);
 }
 
-void gLine::setPoints(float x1, float y1, float z1, float x2, float y2, float z2) {
+void gLine::setPoints(float x1, float y1, float z1, float x2, float y2, float z2, float rotateAngle, float pivotx, float pivoty) {
 	isprojection2d = false;
-	setLinePoints(x1, y1, z1, x2, y2, z2);
+	setLinePoints(x1, y1, z1, x2, y2, z2, rotateAngle, pivotx, pivoty);
 }
 
 void gLine::draw() {
 	gMesh::draw();
 }
 
-void gLine::draw(float x1, float y1, float x2, float y2) {
+void gLine::draw(float x1, float y1, float x2, float y2, float rotateAngle, float pivotx, float pivoty) {
 	isprojection2d = true;
-	setLinePoints(x1, y1, 0.0f, x2, y2, 0.0f);
+	setLinePoints(x1, y1, 0.0f, x2, y2, 0.0f, rotateAngle, pivotx, pivoty);
 	gMesh::draw();
 }
 
-void gLine::draw(float x1, float y1, float z1, float x2, float y2, float z2) {
+void gLine::draw(float x1, float y1, float z1, float x2, float y2, float z2, float rotateAngle, float pivotx, float pivoty) {
 	isprojection2d = false;
-	setLinePoints(x1, y1, z1, x2, y2, z2);
+	setLinePoints(x1, y1, z1, x2, y2, z2, rotateAngle, pivotx, pivoty);
 	gMesh::draw();
 }
 
@@ -52,11 +54,36 @@ void gLine::setThickness(float value) {
 	thickness = value;
 }
 
-void gLine::setLinePoints(float x1, float y1, float z1, float x2, float y2, float z2) {
+void gLine::setLinePoints(float x1, float y1, float z1, float x2, float y2, float z2, float rotateAngle, float pivotx, float pivoty) {
 	if(verticessb.size() > 0) {
 		verticessb.clear();
 		indicessb.clear();
 	}
+
+	// Bounding Box hesabý (pivot için)
+	float minX = std::min(x1, x2);
+	float maxX = std::max(x1, x2);
+	float minY = std::min(y1, y2);
+	float maxY = std::max(y1, y2);
+	float width = maxX - minX;
+	float height = maxY - minY;
+
+	float pivotPx = minX + pivotx * width;
+	float pivotPy = minY + pivoty * height;
+
+	float cosA = std::cos(rotateAngle);
+	float sinA = std::sin(rotateAngle);
+
+	auto transformPoint = [&](float px, float py, float pz) -> glm::vec3 {
+		if (rotateAngle != 0.0f) {
+			float dx = px - pivotPx;
+			float dy = py - pivotPy;
+			float rx = dx * cosA - dy * sinA;
+			float ry = dx * sinA + dy * cosA;
+			return glm::vec3(pivotPx + rx, pivotPy + ry, pz);
+		}
+		return glm::vec3(px, py, pz);
+	};
 
 	if(thickness > 1.0f) {
 		glm::vec3 v1 = glm::vec3(x1, y1, z1);
@@ -65,37 +92,37 @@ void gLine::setLinePoints(float x1, float y1, float z1, float x2, float y2, floa
 		glm::vec3 tangent = glm::cross(d, glm::vec3(0.0f, 0.0f, 1.0f));
 		tangent = glm::normalize(tangent);
 
-		vertex1.position.x = x1 + tangent.x * thickness;
-		vertex1.position.y = y1 + tangent.y * thickness;
-		vertex1.position.z = z1 + tangent.z * thickness;
+		float p1x = x1 + tangent.x * thickness;
+		float p1y = y1 + tangent.y * thickness;
+		float p1z = z1 + tangent.z * thickness;
+		vertex1.position = transformPoint(p1x, p1y, p1z);
 		verticessb.push_back(vertex1);
 
-		vertex2.position.x = x2 + tangent.x * thickness;
-		vertex2.position.y = y2 + tangent.y * thickness;
-		vertex2.position.z = z2 + tangent.z * thickness;
+		float p2x = x2 + tangent.x * thickness;
+		float p2y = y2 + tangent.y * thickness;
+		float p2z = z2 + tangent.z * thickness;
+		vertex2.position = transformPoint(p2x, p2y, p2z);
 		verticessb.push_back(vertex2);
 
-		vertex1.position.x = x1 - tangent.x * thickness;
-		vertex1.position.y = y1 - tangent.y * thickness;
-		vertex1.position.z = z1 - tangent.z * thickness;
+		float p3x = x1 - tangent.x * thickness;
+		float p3y = y1 - tangent.y * thickness;
+		float p3z = z1 - tangent.z * thickness;
+		vertex1.position = transformPoint(p3x, p3y, p3z);
 		verticessb.push_back(vertex1);
 
-		vertex2.position.x = x2 - tangent.x * thickness;
-		vertex2.position.y = y2 - tangent.y * thickness;
-		vertex2.position.z = z2 - tangent.z * thickness;
+		float p4x = x2 - tangent.x * thickness;
+		float p4y = y2 - tangent.y * thickness;
+		float p4z = z2 - tangent.z * thickness;
+		vertex2.position = transformPoint(p4x, p4y, p4z);
 		verticessb.push_back(vertex2);
 
 		indicessb = {0, 1, 3, 0, 2, 3};
 		setDrawMode(gMesh::DRAWMODE_TRIANGLES);
 	} else {
-		vertex1.position.x = x1;
-		vertex1.position.y = y1;
-		vertex1.position.z = z1;
+		vertex1.position = transformPoint(x1, y1, z1);
 		verticessb.push_back(vertex1);
 
-		vertex2.position.x = x2;
-		vertex2.position.y = y2;
-		vertex2.position.z = z2;
+		vertex2.position = transformPoint(x2, y2, z2);
 		verticessb.push_back(vertex2);
 		setDrawMode(gMesh::DRAWMODE_LINES);
 	}

--- a/engine/graphics/primitives/gLine.h
+++ b/engine/graphics/primitives/gLine.h
@@ -30,22 +30,22 @@
 class gLine: public gMesh {
 public:
 	gLine();
-	gLine(float x1, float y1, float x2, float y2);
-	gLine(float x1, float y1, float z1, float x2, float y2, float z2);
+	gLine(float x1, float y1, float x2, float y2, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
+	gLine(float x1, float y1, float z1, float x2, float y2, float z2, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
 
-	void setPoints(float x1, float y1, float x2, float y2);
-	void setPoints(float x1, float y1, float z1, float x2, float y2, float z2);
+	void setPoints(float x1, float y1, float x2, float y2, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
+	void setPoints(float x1, float y1, float z1, float x2, float y2, float z2, float rotateAngle, float pivotx, float pivoty);
 
-	void draw();
-	void draw(float x1, float y1, float x2, float y2);
-	void draw(float x1, float y1, float z1, float x2, float y2, float z2);
+	void draw() override;
+	void draw(float x1, float y1, float x2, float y2, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
+	void draw(float x1, float y1, float z1, float x2, float y2, float z2, float rotateAngle, float pivotx, float pivoty);
 
 	void setThickness(float thickness);
 
 private:
 	std::vector<gVertex> verticessb;
 	std::vector<gIndex> indicessb;
-	void setLinePoints(float x1, float y1, float z1, float x2, float y2, float z2);
+	void setLinePoints(float x1, float y1, float z1, float x2, float y2, float z2, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
 	gVertex vertex1, vertex2;
 	float thickness;
 

--- a/engine/graphics/primitives/gRoundedRectangle.cpp
+++ b/engine/graphics/primitives/gRoundedRectangle.cpp
@@ -6,13 +6,16 @@
  */
 
 #include "gRoundedRectangle.h"
+#include <cmath>
+#include <algorithm>
+
 gRoundedRectangle::gRoundedRectangle() {
 
 }
 
-gRoundedRectangle::gRoundedRectangle(int x, int y, int w, int h, int radius, bool isFilled) {
+gRoundedRectangle::gRoundedRectangle(int x, int y, int w, int h, int radius, bool isFilled, float rotateAngle, float pivotx, float pivoty) {
 	isprojection2d = true;
-	setRoundedRectanglePoints(x, y, w, h, radius, isFilled);
+	setRoundedRectanglePoints(x, y, w, h, radius, isFilled, rotateAngle, pivotx, pivoty);
 }
 
 gRoundedRectangle::~gRoundedRectangle() {
@@ -24,61 +27,76 @@ void gRoundedRectangle::draw() {
 	gMesh::draw();
 }
 
-void gRoundedRectangle::draw(int x, int y, int w, int h, int radius, bool isFilled) {
+void gRoundedRectangle::draw(int x, int y, int w, int h, int radius, bool isFilled, float rotateAngle, float pivotx, float pivoty) {
 	isprojection2d = true;
-	setRoundedRectanglePoints(x, y, w, h, radius, isFilled);
+	setRoundedRectanglePoints(x, y, w, h, radius, isFilled, rotateAngle, pivotx, pivoty);
 	gMesh::draw();
 }
 
-void gRoundedRectangle::setRoundedRectanglePoints(int x, int y, int w, int h, int radius, bool isFilled) {
+void gRoundedRectangle::setRoundedRectanglePoints(int x, int y, int w, int h, int radius, bool isFilled, float rotateAngle, float pivotx, float pivoty) {
 	isprojection2d = true;
 	if (radius < 0) radius = 0;
 	if (radius > w / 2) radius = w / 2;
 	if (radius > h / 2) radius = h / 2;
+
 	std::vector<gVertex> vertices;
 	float numberOfVertices = std::max(std::max(100, w), h);
 	float angle = PI * 2 / numberOfVertices;
+
+	// Pivot noktasý hesabý (Bounding Box: x, y, w, h)
+	float px = x + pivotx * w;
+	float py = y + pivoty * h;
+
+	float cosA = std::cos(rotateAngle);
+	float sinA = std::sin(rotateAngle);
+
+	auto transformPoint = [&](float vx, float vy) -> gVertex {
+		gVertex vertex;
+		if (rotateAngle != 0.0f) {
+			float dx = vx - px;
+			float dy = vy - py;
+			vertex.position.x = px + (dx * cosA - dy * sinA);
+			vertex.position.y = py + (dx * sinA + dy * cosA);
+		} else {
+			vertex.position.x = vx;
+			vertex.position.y = vy;
+		}
+		vertex.position.z = 0.0f;
+		return vertex;
+	};
+
 	for (int i = 0; i <= numberOfVertices / 4; i++) {
 	    float nextAngle = angle * i;
-	    gVertex vertex;
-	    vertex.position.x = radius * cos(nextAngle) + x + w - radius;
-	    vertex.position.y = radius * sin(nextAngle) + y + h - radius;
-	    vertex.position.z = 0.0f;
-	    vertices.push_back(vertex);
+	    float vx = radius * cos(nextAngle) + x + w - radius;
+	    float vy = radius * sin(nextAngle) + y + h - radius;
+	    vertices.push_back(transformPoint(vx, vy));
 	}
 
 	for (int i = numberOfVertices / 4; i <= numberOfVertices / 2; i++) {
 	    float nextAngle = angle * i;
-	    gVertex vertex;
-	    vertex.position.x = radius * cos(nextAngle) + x + radius;
-	    vertex.position.y = radius * sin(nextAngle) + y + h - radius;
-	    vertex.position.z = 0.0f;
-	    vertices.push_back(vertex);
+	    float vx = radius * cos(nextAngle) + x + radius;
+	    float vy = radius * sin(nextAngle) + y + h - radius;
+	    vertices.push_back(transformPoint(vx, vy));
 	}
 
 	for (int i = numberOfVertices / 2; i <= 3 * numberOfVertices / 4; i++) {
 	    float nextAngle = angle * i;
-	    gVertex vertex;
-	    vertex.position.x = radius * cos(nextAngle) + x + radius;
-	    vertex.position.y = radius * sin(nextAngle) + y + radius;
-	    vertex.position.z = 0.0f;
-	    vertices.push_back(vertex);
+	    float vx = radius * cos(nextAngle) + x + radius;
+	    float vy = radius * sin(nextAngle) + y + radius;
+	    vertices.push_back(transformPoint(vx, vy));
 	}
 
 	for (int i = 3 * numberOfVertices / 4; i <= numberOfVertices; i++) {
 	    float nextAngle = angle * i;
-	    gVertex vertex;
-	    vertex.position.x = radius * cos(nextAngle) + x + w - radius;
-	    vertex.position.y = radius * sin(nextAngle) + y + radius;
-	    vertex.position.z = 0.0f;
-	    vertices.push_back(vertex);
+	    float vx = radius * cos(nextAngle) + x + w - radius;
+	    float vy = radius * sin(nextAngle) + y + radius;
+	    vertices.push_back(transformPoint(vx, vy));
 	}
 
-	gVertex startPoint;
-	startPoint.position.x = x + w;
-	startPoint.position.y = y + h - radius;
-	startPoint.position.z = 0.0f;
-	vertices.push_back(startPoint);
+	float startX = x + w;
+	float startY = y + h - radius;
+	vertices.push_back(transformPoint(startX, startY));
+
 	auto verticesptr = std::make_shared<std::vector<gVertex>>(vertices);
 	setVertices(verticesptr);
 	if (isFilled == false)
@@ -86,4 +104,3 @@ void gRoundedRectangle::setRoundedRectanglePoints(int x, int y, int w, int h, in
 	else
 	    setDrawMode(gMesh::DRAWMODE_TRIANGLEFAN);
 }
-

--- a/engine/graphics/primitives/gRoundedRectangle.h
+++ b/engine/graphics/primitives/gRoundedRectangle.h
@@ -13,12 +13,12 @@
 class gRoundedRectangle : public gMesh {
 public:
 	gRoundedRectangle();
-	gRoundedRectangle(int x, int y, int w, int h, int radius, bool isFilled);
+	gRoundedRectangle(int x, int y, int w, int h, int radius, bool isFilled, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
 	~gRoundedRectangle() override;
 
 	void draw() override;
-	void draw(int x, int y, int w, int h, int radius, bool isFilled);
-	void setRoundedRectanglePoints(int x, int y, int w, int h, int radius, bool isFilled);
+	void draw(int x, int y, int w, int h, int radius, bool isFilled, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
+	void setRoundedRectanglePoints(int x, int y, int w, int h, int radius, bool isFilled, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
 private:
 	//This is the default value of vertices of the created shape
 	//Since it has as many vertices as its width or height (whichever is higher)

--- a/engine/graphics/primitives/gTriangle.cpp
+++ b/engine/graphics/primitives/gTriangle.cpp
@@ -6,17 +6,23 @@
  */
 
 #include "gTriangle.h"
+#include <cmath>
+#include <algorithm>
 
 gTriangle::gTriangle() {}
 
 gTriangle::~gTriangle() {}
 
 void gTriangle::draw(float px, float py, float qx, float qy, float rx, float ry, bool is_filled) {
-	this->setPoints(px, py, qx, qy, rx, ry, is_filled);
+	this->draw(px, py, qx, qy, rx, ry, is_filled, 0.0f, 0.5f, 0.5f);
+}
+
+void gTriangle::draw(float px, float py, float qx, float qy, float rx, float ry, bool is_filled, float rotateAngle, float pivotx, float pivoty) {
+	this->setPoints(px, py, qx, qy, rx, ry, is_filled, rotateAngle, pivotx, pivoty);
 	gMesh::draw();
 }
 
-void gTriangle::setPoints(float px, float py, float qx, float qy, float rx, float ry, bool is_filled) {
+void gTriangle::setPoints(float px, float py, float qx, float qy, float rx, float ry, bool is_filled, float rotateAngle, float pivotx, float pivoty) {
 	this->isprojection2d = true;
 
 	if (!this->vertices.empty()) {
@@ -24,20 +30,46 @@ void gTriangle::setPoints(float px, float py, float qx, float qy, float rx, floa
 		this->indices.clear();
 	}
 
-	this->vertex1.position.x = px;
-	this->vertex1.position.y = py;
-	this->vertex1.position.z = 0.0f;
-	this->vertices.push_back(vertex1);
+	float pivotPX;
+	float pivotPY;
 
-	this->vertex2.position.x = qx;
-	this->vertex2.position.y = qy;
-	this->vertex2.position.z = 0.0f;
-	this->vertices.push_back(vertex2);
+	// EÐER (0.5, 0.5) ÝSE: Üçgenin tam kütle/geometrik aðýrlýk merkezini al (yalpalanmadan döner)
+	if (pivotx == 0.5f && pivoty == 0.5f) {
+		pivotPX = (px + qx + rx) / 3.0f;
+		pivotPY = (py + qy + ry) / 3.0f;
+	} else {
+		// ÖZEL PÝVOT DEÐERÝ GÝRÝLDÝYSE: Bounding Box (Sýnýrlayýcý Kutu) oranlarýný kullan
+		float minX = std::min({px, qx, rx});
+		float maxX = std::max({px, qx, rx});
+		float minY = std::min({py, qy, ry});
+		float maxY = std::max({py, qy, ry});
 
-	this->vertex3.position.x = rx;
-	this->vertex3.position.y = ry;
-	this->vertex3.position.z = 0.0f;
-	this->vertices.push_back(vertex3);
+		float width = maxX - minX;
+		float height = maxY - minY;
+
+		pivotPX = minX + pivotx * width;
+		pivotPY = minY + pivoty * height;
+	}
+
+	float cosA = std::cos(rotateAngle);
+	float sinA = std::sin(rotateAngle);
+
+	auto rotatePoint = [&](float vx, float vy) -> glm::vec3 {
+		float dx = vx - pivotPX;
+		float dy = vy - pivotPY;
+		float rx_rot = dx * cosA - dy * sinA;
+		float ry_rot = dx * sinA + dy * cosA;
+		return glm::vec3(pivotPX + rx_rot, pivotPY + ry_rot, 0.0f);
+	};
+
+	this->vertex1.position = rotatePoint(px, py);
+	this->vertices.push_back(this->vertex1);
+
+	this->vertex2.position = rotatePoint(qx, qy);
+	this->vertices.push_back(this->vertex2);
+
+	this->vertex3.position = rotatePoint(rx, ry);
+	this->vertices.push_back(this->vertex3);
 
 	indices.push_back(0);
 	indices.push_back(1);

--- a/engine/graphics/primitives/gTriangle.h
+++ b/engine/graphics/primitives/gTriangle.h
@@ -17,8 +17,10 @@ public:
 
 	void draw(float px, float py, float qx, float qy, float rx, float ry, bool is_filled);
 
+	void draw(float px, float py, float qx, float qy, float rx, float ry, bool is_filled, float rotateAngle, float pivotx = 0.5f, float pivoty = 0.5f);
+
 private:
-	void setPoints(float px, float py, float qx, float qy, float rx, float ry, bool is_filled);
+	void setPoints(float px, float py, float qx, float qy, float rx, float ry, bool is_filled, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
 
 	std::vector<gVertex> vertices;
 	std::vector<gIndex> indices;


### PR DESCRIPTION
- Segment resolution for curved basic shapes has been standardised (thevalues for gCircle and gArc have been set to 60 segments to ensure smooth rendering).
- Consistent pivot and rotation transformation spreading has been ensured for gLine, gCircle, gCross, gArc, gArrow and gRoundedRectangle.
- Multi-part synchronisation in gArrow has been strictly maintained to prevent the body and head from separating during rotation.