### PR TITLE
Bound gFont atlas memory usage with configurable page limits

### DIFF
--- a/engine/core/gVKRenderEngine.cpp
+++ b/engine/core/gVKRenderEngine.cpp
@@ -1070,7 +1070,9 @@ void gVKRenderEngine::texImage2D(GLenum target, GLint internalFormat, int width,
 		// Runtime glyph-atlas growth can replace a texture that an in-flight frame
 		// still samples. Drain the device before destroying that image and its
 		// descriptor resources. Atlas uploads are cache misses, not per-frame work.
-		if(*vkcontext->getDevice() != VK_NULL_HANDLE) vkDeviceWaitIdle(*vkcontext->getDevice());
+		if(it->second->sampled && *vkcontext->getDevice() != VK_NULL_HANDLE) {
+			vkDeviceWaitIdle(*vkcontext->getDevice());
+		}
 		gvkDestroyTexture(*vkcontext, it->second);
 		vktextures.erase(it);
 	}
@@ -2230,10 +2232,14 @@ void gVKRenderEngine::drawTexturedRect2D(GLuint textureId, GLuint maskTextureId,
 	if(vkcontext == nullptr) return;
 	auto it = vktextures.find(textureId);
 	if(it == vktextures.end() || it->second == nullptr) return;
+	it->second->sampled = true;
 	VkDescriptorSet maskset = VK_NULL_HANDLE;
 	if(maskTextureId != 0) {
 		auto maskit = vktextures.find(maskTextureId);
-		if(maskit != vktextures.end() && maskit->second != nullptr) maskset = maskit->second->descriptorset;
+		if(maskit != vktextures.end() && maskit->second != nullptr) {
+			maskit->second->sampled = true;
+			maskset = maskit->second->descriptorset;
+		}
 	}
 	gvkDrawTextured2D(*vkcontext, it->second->descriptorset, maskset, tint, mvp, uvOffset, uvScale);
 #endif
@@ -2245,6 +2251,7 @@ void gVKRenderEngine::drawTexturedTriangles2D(GLuint textureId, const glm::vec4&
 	if(vkcontext == nullptr) return;
 	auto it = vktextures.find(textureId);
 	if(it == vktextures.end() || it->second == nullptr) return;
+	it->second->sampled = true;
 	gvkDrawTexturedTriangles2D(*vkcontext, it->second->descriptorset, tint, mvp, xyuv, vertexCount);
 #endif
 }

--- a/engine/core/gVKTexture.h
+++ b/engine/core/gVKTexture.h
@@ -37,6 +37,10 @@ struct gVKTexture {
 	// True for a texture created as an FBO attachment rather than uploaded from
 	// pixels. Those carry no mip chain and are cleared by the render pass.
 	bool isattachment = false;
+	// Set after the descriptor has been recorded by a draw. Replacing a texture
+	// that has never been sampled needs no device-wide wait (for example the
+	// duplicate upload performed while gTexture initially sets itself up).
+	bool sampled = false;
 	// What the current sampler was built with, so a filtering or wrapping change
 	// can be detected and only then rebuild it. The defaults match what gTexture
 	// starts from.

--- a/engine/graphics/gFont.cpp
+++ b/engine/graphics/gFont.cpp
@@ -99,6 +99,39 @@ gFont::TextRenderMode gFont::getTextRenderMode() const {
 	return textrendermode;
 }
 
+void gFont::setAtlasPageLimit(int maxPageCount) {
+	const int previouslimit = atlasmaxpages;
+	atlasmaxpages = std::max(1, maxPageCount);
+	if (atlasmaxpages > previouslimit) {
+		for (auto& entry : charproperties) {
+			if (!entry.second.inatlas) entry.second.atlasattempted = false;
+		}
+	}
+	if (atlaspages.size() <= static_cast<size_t>(atlasmaxpages)) return;
+
+	for (size_t i = static_cast<size_t>(atlasmaxpages); i < atlaspages.size(); ++i) {
+		delete atlaspages[i].texture;
+	}
+	atlaspages.resize(static_cast<size_t>(atlasmaxpages));
+	for (auto& entry : charproperties) {
+		CharProperties& properties = entry.second;
+		if (properties.atlaspage >= atlasmaxpages) {
+			properties.atlaspage = -1;
+			properties.atlasattempted = false;
+			properties.inatlas = false;
+		}
+	}
+	batchvertices.clear();
+}
+
+int gFont::getAtlasPageLimit() const {
+	return atlasmaxpages;
+}
+
+int gFont::getAtlasPageCount() const {
+	return static_cast<int>(atlaspages.size());
+}
+
 void gFont::getVisualBoundsX(const std::string& text, float& xmin, float& xmax) {
 	float posx = 0.0f;
 
@@ -197,14 +230,14 @@ bool gFont::buildAtlas() {
 void gFont::drawText(const std::string& text, float x, float y) {
 	G_PROFILE_ZONE_SCOPED_N("gFont::drawText()");
 	std::wstring wtext = s2ws(text);
-	bool canbatch = textrendermode == TextRenderMode::ATLAS && !wtext.empty();
-	if (canbatch) {
+	const bool useatlas = textrendermode == TextRenderMode::ATLAS && !wtext.empty();
+	if (useatlas) {
 		atlasbuilding = true;
 		for (wchar_t wc : wtext) {
 			const int c = static_cast<int>(wc);
 			if (c == '\n') continue;
 			auto it = charproperties.find(c);
-			if (it == charproperties.end() || !it->second.inatlas) loadChar(c);
+			if (it == charproperties.end() || (!it->second.inatlas && !it->second.atlasattempted)) loadChar(c);
 		}
 		atlasbuilding = false;
 
@@ -219,22 +252,15 @@ void gFont::drawText(const std::string& text, float x, float y) {
 			page.texture->setData(page.pixels.data(), atlaswidth, atlasheight, 4, false, false);
 			page.dirty = false;
 		}
-
-		for (wchar_t wc : wtext) {
-			const int c = static_cast<int>(wc);
-			if (c == '\n') continue;
-			auto it = charproperties.find(c);
-			if (it == charproperties.end() || !it->second.inatlas
-					|| it->second.atlaspage < 0
-					|| it->second.atlaspage >= static_cast<int>(atlaspages.size())
-					|| atlaspages[it->second.atlaspage].texture == nullptr) {
-				canbatch = false;
-				break;
-			}
-		}
 	}
 
-	if (canbatch) {
+	if (useatlas) {
+		struct LegacyGlyphDraw {
+			gTexture* texture;
+			glm::vec2 position;
+			glm::vec2 size;
+		};
+		std::vector<LegacyGlyphDraw> legacyglyphs;
 		batchvertices.clear();
 		batchvertices.resize(atlaspages.size());
 		float posx = x;
@@ -250,26 +276,45 @@ void gFont::drawText(const std::string& text, float x, float y) {
 				continue;
 			}
 
-			const CharProperties& p = charproperties[c];
+			auto properties = charproperties.find(c);
+			bool glyphinatlas = properties != charproperties.end()
+					&& properties->second.inatlas
+					&& properties->second.atlaspage >= 0
+					&& properties->second.atlaspage < static_cast<int>(atlaspages.size())
+					&& atlaspages[properties->second.atlaspage].texture != nullptr;
+			if (!glyphinatlas && chartextures.find(c) == chartextures.end()) loadChar(c);
+			properties = charproperties.find(c);
+			if (properties == charproperties.end()) continue;
+
+			const CharProperties& p = properties->second;
 			posx += getKerning(c, previous);
 			const float x0 = roundIfRequired(posx + p.leftmargin);
 			const float y0 = roundIfRequired(posy + p.dytop);
 			const float x1 = x0 + p.texturewidth;
 			const float y1 = y0 + p.textureheight;
-			std::vector<float>& vertices = batchvertices[p.atlaspage];
-			auto appendvertex = [&vertices](float px, float py, float u, float v) {
-				vertices.push_back(px);
-				vertices.push_back(py);
-				vertices.push_back(u);
-				vertices.push_back(v);
-			};
 
-			appendvertex(x0, y0, p.atlasu0, p.atlasv0);
-			appendvertex(x1, y0, p.atlasu1, p.atlasv0);
-			appendvertex(x1, y1, p.atlasu1, p.atlasv1);
-			appendvertex(x0, y0, p.atlasu0, p.atlasv0);
-			appendvertex(x1, y1, p.atlasu1, p.atlasv1);
-			appendvertex(x0, y1, p.atlasu0, p.atlasv1);
+			if (glyphinatlas) {
+				std::vector<float>& vertices = batchvertices[p.atlaspage];
+				auto appendvertex = [&vertices](float px, float py, float u, float v) {
+					vertices.push_back(px);
+					vertices.push_back(py);
+					vertices.push_back(u);
+					vertices.push_back(v);
+				};
+
+				appendvertex(x0, y0, p.atlasu0, p.atlasv0);
+				appendvertex(x1, y0, p.atlasu1, p.atlasv0);
+				appendvertex(x1, y1, p.atlasu1, p.atlasv1);
+				appendvertex(x0, y0, p.atlasu0, p.atlasv0);
+				appendvertex(x1, y1, p.atlasu1, p.atlasv1);
+				appendvertex(x0, y1, p.atlasu0, p.atlasv1);
+			} else {
+				auto texture = chartextures.find(c);
+				if (texture != chartextures.end() && texture->second != nullptr) {
+					legacyglyphs.push_back({texture->second, glm::vec2(x0, y0),
+							glm::vec2(p.texturewidth, p.textureheight)});
+				}
+			}
 
 			posx += p.advance * letterspacing * (c == ' ' ? spacesize : 1.0f);
 			previous = c;
@@ -284,6 +329,9 @@ void gFont::drawText(const std::string& text, float x, float y) {
 			if (vertices.empty()) continue;
 			renderer->drawTexturedTriangles2D(atlaspages[pageindex].texture->getId(), tint,
 					renderer->getProjectionMatrix2d(), vertices.data(), static_cast<int>(vertices.size() / 4));
+		}
+		for (const LegacyGlyphDraw& glyph : legacyglyphs) {
+			glyph.texture->draw(glyph.position, glyph.size);
 		}
 	} else {
 		float posx = x;
@@ -554,6 +602,7 @@ void gFont::loadChar(int charCode) {
 	// Prepare properties
 	CharProperties& props = charproperties[charCode];
 	if (atlasbuilding) {
+		props.atlasattempted = true;
 		auto existing = chartextures.find(charCode);
 		if (existing != chartextures.end()) {
 			delete existing->second;
@@ -580,7 +629,7 @@ void gFont::loadChar(int charCode) {
 				}
 			}
 
-			if (pageindex == -1) {
+			if (pageindex == -1 && static_cast<int>(atlaspages.size()) < atlasmaxpages) {
 				AtlasPage page;
 				page.pixels.resize(static_cast<size_t>(atlaswidth) * atlasheight * 4);
 				for (size_t i = 0; i < page.pixels.size(); i += 4) {

--- a/engine/graphics/gFont.h
+++ b/engine/graphics/gFont.h
@@ -108,6 +108,14 @@ public:
 	void setTextRenderMode(TextRenderMode renderMode);
 	TextRenderMode getTextRenderMode() const;
 
+	/**
+	 * Limits the number of 1024x1024 atlas pages owned by this font.
+	 * Glyphs that do not fit within the budget use the legacy glyph path.
+	 */
+	void setAtlasPageLimit(int maxPageCount);
+	int getAtlasPageLimit() const;
+	int getAtlasPageCount() const;
+
 
 	/**
 	 * @brief Draws the given text vertically flipped at the specified position.
@@ -235,6 +243,7 @@ private:
 		float dxleft = 0.0f, dxright = 0.0f, dytop = 0.0f, dybottom = 0.0f;
 		float atlasu0 = 0.0f, atlasv0 = 0.0f, atlasu1 = 0.0f, atlasv1 = 0.0f;
 		int atlaspage = -1;
+		bool atlasattempted = false;
 		bool inatlas = false;
 	};
 
@@ -252,6 +261,7 @@ private:
 	std::vector<AtlasPage> atlaspages;
 	static constexpr int atlaswidth = 1024;
 	static constexpr int atlasheight = 1024;
+	int atlasmaxpages = 2;
 	bool atlasbuilding = false;
 	std::vector<std::vector<float>> batchvertices;
 	TextRenderMode textrendermode = TextRenderMode::GLYPH;


### PR DESCRIPTION
## Summary

- Adds a configurable atlas page limit to `gFont`.
- Uses two 1024x1024 atlas pages per font by default.
- Preserves atlas batching for cached glyphs when the page budget is reached.
- Falls back to the legacy per-glyph rendering path only for glyphs that do not fit.
- Supports the same behavior in OpenGL and Vulkan through `gFont::drawText()`.

## Changes

- Added `setAtlasPageLimit()`, `getAtlasPageLimit()`, and `getAtlasPageCount()`.
- Limited atlas growth to a configurable number of pages.
- Prevented failed glyph insertions from being retried every frame.
- Allows previously rejected glyphs to be retried when the page limit is increased.
- Releases pages above the new limit when the limit is reduced.
- Keeps atlas-resident glyphs batched while rendering overflow glyphs through the legacy path.
- Avoids unnecessary Vulkan device-wide waits when replacing textures that have not yet been sampled.

## Memory Behavior

Each 1024x1024 RGBA atlas page consumes approximately:

- 4 MiB of CPU memory
- 4 MiB of GPU memory

With the default two-page limit, one font can use up to approximately:

- 8 MiB of CPU atlas memory
- 8 MiB of GPU atlas memory

Pages are still created lazily. A font only consumes atlas memory when atlas rendering is selected and glyphs are drawn.

Applications can select a different budget:

```cpp
font.setAtlasPageLimit(1);