### PR TITLE
Vulkan: fix unlit rendering and shared poses on re-uploaded meshes

### DIFF
--- a/engine/core/gRenderer.h
+++ b/engine/core/gRenderer.h
@@ -391,7 +391,14 @@ public:
 	gLight* getSceneLight(int lightNo);
 	int getSceneLightNum();
 	void removeAllSceneLights();
-	void updateLights();
+	// Virtual because the two backends publish light state at different moments.
+	// OpenGL writes its uniform block right here, the instant a light is enabled or
+	// its colour changes. The Vulkan backend gathers the whole scene block once per
+	// render pass instead, so it overrides this to mark that block stale - a canvas
+	// that enables its light just before drawing and disables it after, which is
+	// what gLight's API invites, would otherwise be shaded with the state left over
+	// from the previous frame, when the light was off.
+	virtual void updateLights();
 
 	void updateScene();
 
@@ -647,34 +654,34 @@ protected:
 
 	int renderenginetype = G_RENDERER_GL;
 
-	bool isfogenabled;
-	int fogno;
+	bool isfogenabled = false;
+	int fogno = -1;
 	gColor fogcolor;
-	float fogdensity;
-	float foggradient;
-	int fogmode;
-	float foglinearstart;
-	float foglinearend;
+	float fogdensity = 0.3f;
+	float foggradient = 2.0f;
+	int fogmode = FOGMODE_EXP;
+	float foglinearstart = 0.0f;
+	float foglinearend = 1.0f;
 
 	std::deque<gLight*> scenelights;
 	gUbo<gSceneLights>* lightsubo = nullptr;
 	gUbo<gSceneData>* sceneubo = nullptr;
-	bool islightingenabled;
+	bool islightingenabled = true;
 	glm::vec3 lightingposition;
 	gColor lightingcolor;
 	gColor globalambientcolor;
-	bool isglobalambientcolorchanged;
+	bool isglobalambientcolorchanged = true;
 
-	bool isdepthtestenabled;
-	int depthtesttype;
+	bool isdepthtestenabled = false;
+	int depthtesttype = 0;
 	bool iscullingenabled = false;
 	int cullface = GL_BACK;
 	int cullingdirection = GL_CCW;
 	unsigned int depthtesttypeid[2];
-	bool isalphablendingenabled, isalphatestenabled;
+	bool isalphablendingenabled = false, isalphatestenabled = false;
 
-	GLuint boundframebuffer;
-	int viewportx, viewporty, viewportwidth, viewportheight;
+	GLuint boundframebuffer = 0;
+	int viewportx = 0, viewporty = 0, viewportwidth = 0, viewportheight = 0;
 
 	bool isssaoenabled;
 	float ssaobias;
@@ -693,9 +700,9 @@ protected:
 	void initSSAOResources();
 	void cleanupSSAOResources();
 	void setupSSAODepthSampling();
-	bool isgammacorrectionenabled;
-	bool ishdrenabled;
-	bool issoftshadowsenabled;
+	bool isgammacorrectionenabled = false;
+	bool ishdrenabled = false;
+	bool issoftshadowsenabled = false;
 
 	gShader* colorshader;
 	gShader* textureshader;

--- a/engine/core/gVKContext.h
+++ b/engine/core/gVKContext.h
@@ -30,6 +30,8 @@
 #ifdef GVK_DESKTOP_GLFW
 
 #include <vulkan/vulkan.h>
+#include <algorithm>
+#include <cstdint>
 #include <cstring>
 #include <string>
 #include <vector>
@@ -69,6 +71,8 @@ bool gvkCreateGraphicsPipelines(gVKContext& ctx);
 bool gvkReloadGraphicsPipelines(gVKContext& ctx);
 void gvkDestroyGraphicsPipelines(gVKContext& ctx);
 bool gvkCreateDrawResources(gVKContext& ctx);
+bool gvkEnsureMeshArena(gVKContext& ctx, VkDeviceSize capacity);
+void gvkDestroyMeshArena(gVKContext& ctx);
 void gvkDestroyDrawResources(gVKContext& ctx);
 bool gvkCreateShadowResources(gVKContext& ctx, uint32_t width, uint32_t height);
 bool gvkCreateShadowPipeline(gVKContext& ctx);
@@ -128,6 +132,8 @@ struct gVKContext {
 	friend bool gvkReloadGraphicsPipelines(gVKContext&);
 	friend void gvkDestroyGraphicsPipelines(gVKContext&);
 	friend bool gvkCreateDrawResources(gVKContext&);
+	friend bool gvkEnsureMeshArena(gVKContext&, VkDeviceSize);
+	friend void gvkDestroyMeshArena(gVKContext&);
 	friend void gvkDestroyDrawResources(gVKContext&);
 	friend bool gvkCreateShadowResources(gVKContext&, uint32_t, uint32_t);
 	friend bool gvkCreateShadowPipeline(gVKContext&);
@@ -417,6 +423,49 @@ struct gVKContext {
 		return offset;
 	}
 
+	// The same idea again, for 3D meshes whose vertices the CPU rewrites: a per
+	// frame arena that every upload takes its own slice of.
+	//
+	// One slice per upload rather than one buffer per mesh, because a mesh can be
+	// uploaded to several times in a single frame and drawn in between. A game
+	// posing one soldier model once per enemy does exactly that, and a single
+	// buffer per mesh gives every one of them the last pose written - the draws are
+	// recorded now and executed later, so they all read whatever the buffer holds
+	// by the end of the frame. Slices keep each draw pointing at the data it was
+	// recorded with.
+	//
+	// pushMeshData returns the byte offset to bind from, or VK_WHOLE_SIZE when the
+	// arena is full - the caller falls back to its own buffer for that frame, and
+	// the arena grows to the high-water mark at the next frame start.
+	void resetMeshArena() {
+		if(mesharenaoffsets.empty()) return;
+		if(mesharenaoffsets[currentframe] > mesharenahighwater) {
+			mesharenahighwater = mesharenaoffsets[currentframe];
+		}
+		mesharenaoffsets[currentframe] = 0;
+		meshgeneration++;
+	}
+	VkBuffer getCurrentMeshArena() {
+		return mesharenabuffers.empty() ? VK_NULL_HANDLE : mesharenabuffers[currentframe];
+	}
+	VkDeviceSize pushMeshData(const void* data, VkDeviceSize size) {
+		if(mesharenamapped.empty() || mesharenamapped[currentframe] == nullptr) return VK_WHOLE_SIZE;
+		VkDeviceSize offset = (mesharenaoffsets[currentframe] + 63) & ~static_cast<VkDeviceSize>(63);
+		if(offset + size > mesharenacapacity) {
+			// Remember what was actually asked for, so the grow at the next reset is
+			// big enough rather than one slice short of it.
+			mesharenahighwater = std::max(mesharenahighwater, offset + size);
+			return VK_WHOLE_SIZE;
+		}
+		std::memcpy(static_cast<char*>(mesharenamapped[currentframe]) + offset, data, size);
+		mesharenaoffsets[currentframe] = offset + size;
+		return offset;
+	}
+	// Which frame the arena is on. A slice handed out in an earlier frame points
+	// into memory that has since been rewound, so a mesh drawn without a fresh
+	// upload compares this before trusting the slice it kept.
+	uint64_t getMeshGeneration() const { return meshgeneration; }
+
 private:
 	std::string appname = "GlistApp";
 	std::string enginename = "GlistEngine";
@@ -593,6 +642,15 @@ private:
 	std::vector<void*> dynvertexmapped;
 	std::vector<VkDeviceSize> dynvertexoffsets;
 	VkDeviceSize dynvertexcapacity = 0;
+
+	// Per-frame arena for mesh vertices the CPU rewrites; see pushMeshData.
+	std::vector<VkBuffer> mesharenabuffers;
+	std::vector<VkDeviceMemory> mesharenamemories;
+	std::vector<void*> mesharenamapped;
+	std::vector<VkDeviceSize> mesharenaoffsets;
+	VkDeviceSize mesharenacapacity = 0;
+	VkDeviceSize mesharenahighwater = 0;
+	uint64_t meshgeneration = 0;
 };
 
 #endif /* GVK_DESKTOP_GLFW */

--- a/engine/core/gVKDraw.cpp
+++ b/engine/core/gVKDraw.cpp
@@ -16,6 +16,58 @@
 // a warning rather than growing the buffer mid-frame.
 static constexpr VkDeviceSize GVK_DYNAMIC_VERTEX_CAPACITY = 1u << 20;
 
+// Enough for a few thousand animated vertices on the first frame; it grows from
+// here the moment a frame needs more.
+static constexpr VkDeviceSize GVK_MESH_ARENA_INITIAL_CAPACITY = 8 * 1024 * 1024;
+
+// One host visible arena per frame in flight, persistently mapped. Recreated
+// rather than resized, which is why the caller drains the device first: the
+// buffers being replaced may still be referenced by work in flight.
+bool gvkEnsureMeshArena(gVKContext& ctx, VkDeviceSize capacity) {
+	if(ctx.device == VK_NULL_HANDLE || capacity == 0) return false;
+	if(capacity <= ctx.mesharenacapacity) return true;
+
+	gvkDestroyMeshArena(ctx);
+
+	const int frames = GVK_MAX_FRAMES_IN_FLIGHT;
+	ctx.mesharenacapacity = capacity;
+	ctx.mesharenabuffers.assign(frames, VK_NULL_HANDLE);
+	ctx.mesharenamemories.assign(frames, VK_NULL_HANDLE);
+	ctx.mesharenamapped.assign(frames, nullptr);
+	ctx.mesharenaoffsets.assign(frames, 0);
+	for(int i = 0; i < frames; i++) {
+		if(!gvkCreateBuffer(ctx, capacity, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
+				VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+				ctx.mesharenabuffers[i], ctx.mesharenamemories[i])) {
+			gLoge("gVKDraw") << "Could not create the " << capacity
+					<< " byte mesh arena; animated meshes fall back to one buffer each.";
+			gvkDestroyMeshArena(ctx);
+			return false;
+		}
+		vkMapMemory(ctx.device, ctx.mesharenamemories[i], 0, capacity, 0, &ctx.mesharenamapped[i]);
+	}
+	gLogi("gVKDraw") << "Mesh arena ready: " << frames << " x " << capacity << " bytes";
+	return true;
+}
+
+void gvkDestroyMeshArena(gVKContext& ctx) {
+	if(ctx.device == VK_NULL_HANDLE) return;
+	for(size_t i = 0; i < ctx.mesharenabuffers.size(); i++) {
+		if(ctx.mesharenamemories[i] != VK_NULL_HANDLE) {
+			vkUnmapMemory(ctx.device, ctx.mesharenamemories[i]);
+			vkFreeMemory(ctx.device, ctx.mesharenamemories[i], nullptr);
+		}
+		if(ctx.mesharenabuffers[i] != VK_NULL_HANDLE) {
+			vkDestroyBuffer(ctx.device, ctx.mesharenabuffers[i], nullptr);
+		}
+	}
+	ctx.mesharenabuffers.clear();
+	ctx.mesharenamemories.clear();
+	ctx.mesharenamapped.clear();
+	ctx.mesharenaoffsets.clear();
+	ctx.mesharenacapacity = 0;
+}
+
 bool gvkCreateDrawResources(gVKContext& ctx) {
 	if(ctx.device == VK_NULL_HANDLE) return false;
 
@@ -36,11 +88,16 @@ bool gvkCreateDrawResources(gVKContext& ctx) {
 		// Host coherent and persistently mapped: no flush and no per-frame remap.
 		vkMapMemory(ctx.device, ctx.dynvertexmemories[i], 0, ctx.dynvertexcapacity, 0, &ctx.dynvertexmapped[i]);
 	}
+	// The mesh arena starts modest and grows to whatever a frame actually asks
+	// for; a scene that re-poses one model per enemy needs a slice per draw, and
+	// how many that is only the running game knows.
+	if(!gvkEnsureMeshArena(ctx, GVK_MESH_ARENA_INITIAL_CAPACITY)) return false;
 	gLogi("gVKDraw") << "Dynamic vertex buffers ready.";
 	return true;
 }
 
 void gvkDestroyDrawResources(gVKContext& ctx) {
+	gvkDestroyMeshArena(ctx);
 	if(ctx.device == VK_NULL_HANDLE) return;
 	for(size_t i = 0; i < ctx.dynvertexbuffers.size(); i++) {
 		if(ctx.dynvertexmapped[i] != nullptr) vkUnmapMemory(ctx.device, ctx.dynvertexmemories[i]);
@@ -192,11 +249,12 @@ void gvkDrawTextured2D(gVKContext& ctx, VkDescriptorSet textureSet, VkDescriptor
 	vkCmdDraw(cmd, 6, 1, 0, 0);
 }
 
-void gvkDrawMesh3D(gVKContext& ctx, VkBuffer vertexBuffer, VkBuffer indexBuffer, int count,
+void gvkDrawMesh3D(gVKContext& ctx, VkBuffer vertexBuffer, VkDeviceSize vertexOffset,
+		VkBuffer indexBuffer, int count,
 		VkIndexType indexType, const gVKMeshPush& push,
 		VkDescriptorSet diffuseSet, VkDescriptorSet specularSet, VkDescriptorSet normalSet,
 		VkDescriptorSet shadowSet,
-		VkBuffer instanceBuffer, int instanceCount,
+		VkBuffer instanceBuffer, VkDeviceSize instanceOffset, int instanceCount,
 		VkPrimitiveTopology topology, bool depthTest, bool depthTestAlways, bool lines,
 		const gVKCullState& culling, bool blending) {
 	if(count <= 0 || vertexBuffer == VK_NULL_HANDLE) return;
@@ -242,7 +300,7 @@ void gvkDrawMesh3D(gVKContext& ctx, VkBuffer vertexBuffer, VkBuffer indexBuffer,
 	// per-instance model matrices and is never absent; see gVKRenderEngine's
 	// identity instance buffer.
 	VkBuffer buffers[] = {vertexBuffer, instanceBuffer};
-	VkDeviceSize offsets[] = {0, 0};
+	VkDeviceSize offsets[] = {vertexOffset, instanceOffset};
 	vkCmdBindVertexBuffers(cmd, 0, instanceBuffer != VK_NULL_HANDLE ? 2 : 1, buffers, offsets);
 
 	const uint32_t pushsize = std::min<uint32_t>(sizeof(push), ctx.getMesh3DPushSize());
@@ -259,10 +317,11 @@ void gvkDrawMesh3D(gVKContext& ctx, VkBuffer vertexBuffer, VkBuffer indexBuffer,
 	}
 }
 
-void gvkDrawShadowCaster(gVKContext& ctx, VkBuffer vertexBuffer, VkBuffer indexBuffer,
+void gvkDrawShadowCaster(gVKContext& ctx, VkBuffer vertexBuffer, VkDeviceSize vertexOffset,
+		VkBuffer indexBuffer,
 		int count, VkIndexType indexType, const gVKShadowPush& push,
 		VkDescriptorSet diffuseSet,
-		VkBuffer instanceBuffer, int instanceCount, VkPrimitiveTopology topology) {
+		VkBuffer instanceBuffer, VkDeviceSize instanceOffset, int instanceCount, VkPrimitiveTopology topology) {
 	if(count <= 0 || vertexBuffer == VK_NULL_HANDLE) return;
 	// No gvkEnsureRenderPass here: the shadow pass is opened by the frame loop
 	// before the scene is drawn, and this must not fall back to opening the screen
@@ -289,7 +348,7 @@ void gvkDrawShadowCaster(gVKContext& ctx, VkBuffer vertexBuffer, VkBuffer indexB
 	}
 
 	VkBuffer buffers[] = {vertexBuffer, instanceBuffer};
-	VkDeviceSize offsets[] = {0, 0};
+	VkDeviceSize offsets[] = {vertexOffset, instanceOffset};
 	vkCmdBindVertexBuffers(cmd, 0, instanceBuffer != VK_NULL_HANDLE ? 2 : 1, buffers, offsets);
 
 	const uint32_t pushsize = std::min<uint32_t>(sizeof(push), ctx.getShadowPushSize());
@@ -320,10 +379,11 @@ void gvkDrawShadowCaster(gVKContext& ctx, VkBuffer vertexBuffer, VkBuffer indexB
 	}
 }
 
-void gvkDrawMesh3DPbr(gVKContext& ctx, VkBuffer vertexBuffer, VkBuffer indexBuffer, int count,
+void gvkDrawMesh3DPbr(gVKContext& ctx, VkBuffer vertexBuffer, VkDeviceSize vertexOffset,
+		VkBuffer indexBuffer, int count,
 		VkIndexType indexType, const gVKPbrPush& push, VkDescriptorSet materialSet,
 		VkDescriptorSet shadowSet,
-		VkBuffer instanceBuffer, int instanceCount,
+		VkBuffer instanceBuffer, VkDeviceSize instanceOffset, int instanceCount,
 		VkPrimitiveTopology topology, bool depthTest, bool depthTestAlways,
 		const gVKCullState& culling, bool blending) {
 	if(count <= 0 || vertexBuffer == VK_NULL_HANDLE) return;
@@ -353,7 +413,7 @@ void gvkDrawMesh3DPbr(gVKContext& ctx, VkBuffer vertexBuffer, VkBuffer indexBuff
 			0, 3, sets, 0, nullptr);
 
 	VkBuffer buffers[] = {vertexBuffer, instanceBuffer};
-	VkDeviceSize offsets[] = {0, 0};
+	VkDeviceSize offsets[] = {vertexOffset, instanceOffset};
 	vkCmdBindVertexBuffers(cmd, 0, instanceBuffer != VK_NULL_HANDLE ? 2 : 1, buffers, offsets);
 
 	const uint32_t pushsize = std::min<uint32_t>(sizeof(push), ctx.getMesh3DPbrPushSize());

--- a/engine/core/gVKDraw.h
+++ b/engine/core/gVKDraw.h
@@ -73,6 +73,10 @@ void gvkDrawTextured2D(gVKContext& ctx, VkDescriptorSet textureSet, VkDescriptor
 void gvkDrawTexturedTriangles2D(gVKContext& ctx, VkDescriptorSet textureSet,
 		const glm::vec4& tint, const glm::mat4& mvp, const float* xyuv, int vertexCount);
 
+// vertexOffset is where this mesh's vertices start inside the bound buffer. Zero
+// for a mesh uploaded once; a mesh whose vertices the CPU rewrites is given a
+// slice of the frame's arena instead, so that each of its draws reads the data
+// it was recorded with rather than whatever the last upload of the frame left.
 // Records one 3D mesh out of buffers that already live on the device, unlike the
 // 2D calls above, which copy their geometry into a per-frame ring first. A mesh
 // uploads once through gVKMeshBuffer and is then drawn straight from there.
@@ -97,11 +101,12 @@ void gvkDrawTexturedTriangles2D(gVKContext& ctx, VkDescriptorSet textureSet,
 // instanceBuffer holds one model matrix per instance and is bound as binding 1. It
 // is required even for a single draw, because the shader always reads from it - the
 // caller passes a one-element identity buffer when the draw is not instanced.
-void gvkDrawMesh3D(gVKContext& ctx, VkBuffer vertexBuffer, VkBuffer indexBuffer, int count,
+void gvkDrawMesh3D(gVKContext& ctx, VkBuffer vertexBuffer, VkDeviceSize vertexOffset,
+		VkBuffer indexBuffer, int count,
 		VkIndexType indexType, const gVKMeshPush& push,
 		VkDescriptorSet diffuseSet, VkDescriptorSet specularSet, VkDescriptorSet normalSet,
 		VkDescriptorSet shadowSet,
-		VkBuffer instanceBuffer, int instanceCount,
+		VkBuffer instanceBuffer, VkDeviceSize instanceOffset, int instanceCount,
 		VkPrimitiveTopology topology, bool depthTest, bool depthTestAlways, bool lines,
 		const gVKCullState& culling, bool blending);
 
@@ -110,10 +115,11 @@ void gvkDrawMesh3D(gVKContext& ctx, VkBuffer vertexBuffer, VkBuffer indexBuffer,
 // holes it punches; it must be a real descriptor even for an opaque mesh, where the
 // 1x1 white texture stands in and push.misc.x says not to sample it. Only valid
 // while the shadow render pass is open.
-void gvkDrawShadowCaster(gVKContext& ctx, VkBuffer vertexBuffer, VkBuffer indexBuffer,
+void gvkDrawShadowCaster(gVKContext& ctx, VkBuffer vertexBuffer, VkDeviceSize vertexOffset,
+		VkBuffer indexBuffer,
 		int count, VkIndexType indexType, const gVKShadowPush& push,
 		VkDescriptorSet diffuseSet,
-		VkBuffer instanceBuffer, int instanceCount, VkPrimitiveTopology topology);
+		VkBuffer instanceBuffer, VkDeviceSize instanceOffset, int instanceCount, VkPrimitiveTopology topology);
 
 // Records one 3D mesh through the PBR pipeline. materialSet holds all five maps in
 // a single descriptor set (bindings 0..4), unlike the non-PBR path where each map
@@ -121,10 +127,11 @@ void gvkDrawShadowCaster(gVKContext& ctx, VkBuffer vertexBuffer, VkBuffer indexB
 // textures would need six. shadowSet is the depth map from the light's point of
 // view and goes in as set 2, per frame rather than per material. There is no line
 // variant - a wireframe PBR draw has no meaning that the OpenGL path offers either.
-void gvkDrawMesh3DPbr(gVKContext& ctx, VkBuffer vertexBuffer, VkBuffer indexBuffer, int count,
+void gvkDrawMesh3DPbr(gVKContext& ctx, VkBuffer vertexBuffer, VkDeviceSize vertexOffset,
+		VkBuffer indexBuffer, int count,
 		VkIndexType indexType, const gVKPbrPush& push, VkDescriptorSet materialSet,
 		VkDescriptorSet shadowSet,
-		VkBuffer instanceBuffer, int instanceCount,
+		VkBuffer instanceBuffer, VkDeviceSize instanceOffset, int instanceCount,
 		VkPrimitiveTopology topology, bool depthTest, bool depthTestAlways,
 		const gVKCullState& culling, bool blending);
 

--- a/engine/core/gVKFrame.cpp
+++ b/engine/core/gVKFrame.cpp
@@ -76,6 +76,15 @@ bool gvkBeginFrame(gVKContext& ctx, GLFWwindow* window) {
 	// frame that draws nothing, in gvkEndFrame. Rewind this frame's vertex ring so
 	// the draw path can refill it from the start.
 	ctx.resetDynamicVertices();
+	// Rewind the mesh arena too, and grow it first if the last frames wanted more
+	// than it holds. Growing here means draining the device, which is why it is
+	// done at a frame boundary and only when the high-water mark says it is
+	// needed - in practice a handful of times while a level loads, then never.
+	if(ctx.mesharenahighwater > ctx.mesharenacapacity) {
+		vkDeviceWaitIdle(ctx.device);
+		gvkEnsureMeshArena(ctx, ctx.mesharenahighwater * 2);
+	}
+	ctx.resetMeshArena();
 	ctx.renderpassactive = false;
 	ctx.frameactive = true;
 	return true;

--- a/engine/core/gVKMeshBuffer.cpp
+++ b/engine/core/gVKMeshBuffer.cpp
@@ -114,11 +114,37 @@ bool gvkUploadMeshBuffer(gVKContext& ctx, gVKMeshBuffer& buf, const void* data,
 			// buffer dynamic, which is what it has already shown itself to be.
 			if(!gvkMakeMeshBufferDynamic(ctx, buf, size, isIndex)) return false;
 		}
-		const uint32_t slot = ctx.getCurrentFrame() % GVK_MAX_FRAMES_IN_FLIGHT;
 		std::memcpy(buf.shadow.data(), data, static_cast<size_t>(size));
 		buf.version++;
+
+		// A slice of its own for this upload. The mesh may be uploaded to and drawn
+		// several times in one frame - a game posing a single soldier model once per
+		// enemy does exactly that - and every one of those draws has to read the data
+		// it was recorded with. One buffer per mesh cannot do that: the draws execute
+		// after the frame is submitted, so they would all read whatever was written
+		// last and every soldier would strike the same pose.
+		// Vertices only. The arena is created as a vertex buffer, and index data has
+		// no reason to be there anyway: what makes a slice per draw necessary is the
+		// same mesh being re-posed between draws, and re-posing rewrites positions,
+		// never the indices that join them.
+		const VkDeviceSize arenaoffset = buf.isindex
+				? VK_WHOLE_SIZE : ctx.pushMeshData(data, size);
+		if(arenaoffset != VK_WHOLE_SIZE) {
+			buf.arenabuffer = ctx.getCurrentMeshArena();
+			buf.arenaoffset = arenaoffset;
+			buf.arenageneration = ctx.getMeshGeneration();
+			buf.buffer = buf.arenabuffer;
+			return true;
+		}
+
+		// The arena is full for this frame. It grows at the next frame start, so this
+		// is the one frame where the mesh's own per-frame buffer stands in - correct
+		// against anything drawn in another frame, and only wrong if the same mesh is
+		// posed more than once inside this one.
+		const uint32_t slot = ctx.getCurrentFrame() % GVK_MAX_FRAMES_IN_FLIGHT;
 		std::memcpy(buf.slotmapped[slot], data, static_cast<size_t>(size));
 		buf.slotversion[slot] = buf.version;
+		buf.arenabuffer = VK_NULL_HANDLE;
 		buf.buffer = buf.slotbuffers[slot];
 		return true;
 	}
@@ -178,8 +204,34 @@ bool gvkUploadMeshBuffer(gVKContext& ctx, gVKMeshBuffer& buf, const void* data,
 	return true;
 }
 
-VkBuffer gvkResolveMeshBuffer(gVKContext& ctx, gVKMeshBuffer& buf) {
+VkBuffer gvkResolveMeshBuffer(gVKContext& ctx, gVKMeshBuffer& buf, VkDeviceSize& outOffset) {
+	outOffset = 0;
 	if(!buf.isdynamic) return buf.buffer;
+
+	// The slice this mesh was last uploaded into, as long as it belongs to the frame
+	// being recorded. Two enemies posed to the same animation frame skip the second
+	// upload entirely, and this is what lets the second draw reuse the first's data
+	// rather than push an identical copy.
+	if(!buf.isindex && buf.arenabuffer != VK_NULL_HANDLE && buf.arenageneration == ctx.getMeshGeneration()) {
+		outOffset = buf.arenaoffset;
+		buf.buffer = buf.arenabuffer;
+		return buf.arenabuffer;
+	}
+
+	// A new frame has rewound the arena, so the slice is gone. Push the newest data
+	// back in and carry on; falling through to the per-frame buffer below would work
+	// too, but this keeps every draw of the frame reading from the same place.
+	if(!buf.isindex && !buf.shadow.empty()) {
+		const VkDeviceSize offset = ctx.pushMeshData(buf.shadow.data(), buf.shadow.size());
+		if(offset != VK_WHOLE_SIZE) {
+			buf.arenabuffer = ctx.getCurrentMeshArena();
+			buf.arenaoffset = offset;
+			buf.arenageneration = ctx.getMeshGeneration();
+			buf.buffer = buf.arenabuffer;
+			outOffset = offset;
+			return buf.arenabuffer;
+		}
+	}
 
 	const uint32_t slot = ctx.getCurrentFrame() % GVK_MAX_FRAMES_IN_FLIGHT;
 	if(buf.slotmapped[slot] == nullptr) return VK_NULL_HANDLE;

--- a/engine/core/gVKMeshBuffer.h
+++ b/engine/core/gVKMeshBuffer.h
@@ -76,6 +76,14 @@ struct gVKMeshBuffer {
 	uint64_t slotversion[GVK_MAX_FRAMES_IN_FLIGHT] = {};
 	uint64_t version = 0;
 	std::vector<unsigned char> shadow;
+
+	// Where this mesh's newest data sits inside the per-frame arena, and which
+	// frame that slice belongs to. A mesh drawn without a fresh upload keeps
+	// using its slice for the rest of that frame; once the arena has been rewound
+	// the generation no longer matches and the data is pushed again.
+	VkBuffer arenabuffer = VK_NULL_HANDLE;
+	VkDeviceSize arenaoffset = 0;
+	uint64_t arenageneration = 0;
 };
 
 /*
@@ -102,10 +110,13 @@ bool gvkUploadMeshBuffer(gVKContext& ctx, gVKMeshBuffer& buf, const void* data,
  * one belonging to the frame being recorded, refreshing it from the newest data
  * first if that frame has not seen the latest upload.
  *
+ * outOffset is the byte offset to bind the vertex buffer from - zero for a
+ * static mesh, and the mesh's slice inside the arena for a dynamic one.
+ *
  * A static buffer is returned as it is. Returns VK_NULL_HANDLE if there is nothing
  * to draw from, which callers already check for.
  */
-VkBuffer gvkResolveMeshBuffer(gVKContext& ctx, gVKMeshBuffer& buf);
+VkBuffer gvkResolveMeshBuffer(gVKContext& ctx, gVKMeshBuffer& buf, VkDeviceSize& outOffset);
 
 /*
  * Frees the device local buffers that promotions replaced. They are held rather

--- a/engine/core/gVKRenderEngine.cpp
+++ b/engine/core/gVKRenderEngine.cpp
@@ -1956,9 +1956,12 @@ void gVKRenderEngine::updateSceneUniforms() {
 	uniforms.view = viewmatrix;
 	uniforms.viewpos = glm::vec4(cameraposition, 1.0f);
 	uniforms.globalambientcolor = globalambientcolor.asVec4();
-	// See gVKSceneUniforms::rendercolor: the OpenGL colour shader multiplies every
-	// mesh by this, so leaving it out was the whole of the colour difference between
-	// the two backends in a scene that drew text before its geometry.
+	// Still filled in, but no shader reads it any more: renderColor reaches a mesh
+	// through the push constant instead, because it has to be able to change between
+	// two draws of the same pass and a uniform block cannot express that. The field
+	// stays because both 3D shaders still declare it in this block, and the C++ side
+	// has to match that layout byte for byte. Dropping it means editing the two
+	// shaders as well; worth doing, not worth doing in the same change as the fix.
 	uniforms.rendercolor = rendercolor != nullptr ? rendercolor->asVec4() : glm::vec4(1.0f);
 
 	// The w component doubles as the "is a shadow map bound" flag the shader tests,
@@ -2447,6 +2450,23 @@ bool gVKRenderEngine::beginShadowPass() {
 	return gvkBeginShadowPass(*vkcontext);
 #else
 	return false;
+#endif
+}
+
+void gVKRenderEngine::updateLights() {
+	gRenderer::updateLights();
+#ifdef GVK_DESKTOP_GLFW
+	// A light was enabled, disabled or recoloured. The scene block this backend
+	// hands the shaders holds that state, and it is gathered once and then left
+	// alone for the rest of the pass, so it has to be dropped here or the change
+	// only lands on the frame after next.
+	//
+	// This is what a canvas doing the ordinary thing runs into: enable the light,
+	// draw the scene, disable it again. Without this the first draw of the pass
+	// captures the state from before the enable - the light off - and every mesh in
+	// that pass is shaded by the global ambient fallback instead, which comes out
+	// far brighter than the light would have made it.
+	sceneuniformswritten = false;
 #endif
 }
 

--- a/engine/core/gVKRenderEngine.cpp
+++ b/engine/core/gVKRenderEngine.cpp
@@ -2014,11 +2014,14 @@ void gVKRenderEngine::drawMesh3D(GLuint vertexArrayId, int vertexCount, int inde
 	// hands back its single buffer and nothing else happens.
 	gVKMeshBuffer* vertices = getMeshBuffer(arrayentry->second.vertexbuffer);
 	if(vertices == nullptr) return;
-	const VkBuffer vertexbuffer = gvkResolveMeshBuffer(*vkcontext, *vertices);
+	VkDeviceSize vertexoffset = 0;
+	const VkBuffer vertexbuffer = gvkResolveMeshBuffer(*vkcontext, *vertices, vertexoffset);
 	if(vertexbuffer == VK_NULL_HANDLE) return;
 	gVKMeshBuffer* indices = getMeshBuffer(arrayentry->second.indexbuffer);
+	// Indices are never rewritten per frame, so their offset is always zero.
+	VkDeviceSize indexoffset = 0;
 	const VkBuffer indexbuffer = indices != nullptr
-			? gvkResolveMeshBuffer(*vkcontext, *indices) : VK_NULL_HANDLE;
+			? gvkResolveMeshBuffer(*vkcontext, *indices, indexoffset) : VK_NULL_HANDLE;
 	const bool indexed = indexbuffer != VK_NULL_HANDLE && indexCount > 0;
 
 	// The mesh's draw mode picks both the pipeline (triangle or line) and the
@@ -2064,14 +2067,16 @@ void gVKRenderEngine::drawMesh3D(GLuint vertexArrayId, int vertexCount, int inde
 		if(lines) return;
 
 		VkBuffer shadowinstances = VK_NULL_HANDLE;
+		VkDeviceSize shadowinstancesoffset = 0;
 		if(instanceCount > 1) {
 			gVKMeshBuffer* instances = getMeshBuffer(arrayentry->second.instancebuffer);
 			if(instances == nullptr) return;
-			shadowinstances = gvkResolveMeshBuffer(*vkcontext, *instances);
+			shadowinstances = gvkResolveMeshBuffer(*vkcontext, *instances, shadowinstancesoffset);
 			if(shadowinstances == VK_NULL_HANDLE) return;
 		} else {
 			if(!ensureIdentityInstanceBuffer()) return;
 			shadowinstances = identityinstancebuffer->buffer;
+			shadowinstancesoffset = 0;
 		}
 		// Cutout casters: a mesh whose diffuse map punches holes in it has to cast a
 		// shadow with the same holes, so the map is looked up here and the fragment
@@ -2097,10 +2102,10 @@ void gVKRenderEngine::drawMesh3D(GLuint vertexArrayId, int vertexCount, int inde
 		}
 
 		const VkIndexType shadowindextype = sizeof(gIndex) == 2 ? VK_INDEX_TYPE_UINT16 : VK_INDEX_TYPE_UINT32;
-		gvkDrawShadowCaster(*vkcontext, vertexbuffer,
+		gvkDrawShadowCaster(*vkcontext, vertexbuffer, vertexoffset,
 				indexed ? indexbuffer : VK_NULL_HANDLE,
 				indexed ? indexCount : vertexCount, shadowindextype, shadowpush, cutoutset,
-				shadowinstances, instanceCount, topology);
+				shadowinstances, shadowinstancesoffset, instanceCount, topology);
 		return;
 	}
 
@@ -2146,21 +2151,23 @@ void gVKRenderEngine::drawMesh3D(GLuint vertexArrayId, int vertexCount, int inde
 		pbrpush.maps1 = glm::ivec4(surface.aomapid != 0 ? 1 : 0, 0, 0, 0);
 
 		VkBuffer pbrinstances = VK_NULL_HANDLE;
+		VkDeviceSize pbrinstancesoffset = 0;
 		if(instanceCount > 1) {
 			gVKMeshBuffer* instances = getMeshBuffer(arrayentry->second.instancebuffer);
 			if(instances == nullptr) return;
-			pbrinstances = gvkResolveMeshBuffer(*vkcontext, *instances);
+			pbrinstances = gvkResolveMeshBuffer(*vkcontext, *instances, pbrinstancesoffset);
 			if(pbrinstances == VK_NULL_HANDLE) return;
 		} else {
 			if(!ensureIdentityInstanceBuffer()) return;
 			pbrinstances = identityinstancebuffer->buffer;
+			pbrinstancesoffset = 0;
 		}
 
 		const VkIndexType pbrindextype = sizeof(gIndex) == 2 ? VK_INDEX_TYPE_UINT16 : VK_INDEX_TYPE_UINT32;
-		gvkDrawMesh3DPbr(*vkcontext, vertexbuffer, indexed ? indexbuffer : VK_NULL_HANDLE,
+		gvkDrawMesh3DPbr(*vkcontext, vertexbuffer, vertexoffset, indexed ? indexbuffer : VK_NULL_HANDLE,
 				indexed ? indexCount : vertexCount, pbrindextype, pbrpush, materialset,
 				pbrshadowset,
-				pbrinstances, instanceCount, topology,
+				pbrinstances, pbrinstancesoffset, instanceCount, topology,
 				isdepthtestenabled, depthtesttype == DEPTHTESTTYPE_ALWAYS, cullstate,
 				isalphablendingenabled);
 		return;
@@ -2233,24 +2240,26 @@ void gVKRenderEngine::drawMesh3D(GLuint vertexArrayId, int vertexCount, int inde
 	// matrix from it. An instanced draw uses the one gVbo uploaded; anything else
 	// gets the shared identity, which multiplies out to no change at all.
 	VkBuffer instancebuffer = VK_NULL_HANDLE;
+	VkDeviceSize instancebufferoffset = 0;
 	if(instanceCount > 1) {
 		gVKMeshBuffer* instances = getMeshBuffer(arrayentry->second.instancebuffer);
 		if(instances == nullptr) return;
-		instancebuffer = gvkResolveMeshBuffer(*vkcontext, *instances);
+		instancebuffer = gvkResolveMeshBuffer(*vkcontext, *instances, instancebufferoffset);
 		if(instancebuffer == VK_NULL_HANDLE) return;
 	} else {
 		if(!ensureIdentityInstanceBuffer()) return;
 		instancebuffer = identityinstancebuffer->buffer;
+		instancebufferoffset = 0;
 	}
 
 	// gIndex is what gVbo uploaded, so the index type follows it: 16 bit on Android,
 	// 32 bit everywhere else.
 	const VkIndexType indextype = sizeof(gIndex) == 2 ? VK_INDEX_TYPE_UINT16 : VK_INDEX_TYPE_UINT32;
 
-	gvkDrawMesh3D(*vkcontext, vertexbuffer, indexed ? indexbuffer : VK_NULL_HANDLE,
+	gvkDrawMesh3D(*vkcontext, vertexbuffer, vertexoffset, indexed ? indexbuffer : VK_NULL_HANDLE,
 			indexed ? indexCount : vertexCount, indextype, push, diffuseset, specularset, normalset,
 			shadowset,
-			instancebuffer, instanceCount,
+			instancebuffer, instancebufferoffset, instanceCount,
 			topology, isdepthtestenabled, depthtesttype == DEPTHTESTTYPE_ALWAYS, lines, cullstate,
 			isalphablendingenabled);
 #endif

--- a/engine/core/gVKRenderEngine.h
+++ b/engine/core/gVKRenderEngine.h
@@ -236,6 +236,10 @@ public:
 	void setShadowMapState(bool enabled, const glm::mat4& lightMatrix,
 			const glm::vec3& lightPosition, bool softShadows) override;
 
+	// Drops the gathered scene block so the next 3D draw rebuilds it; see the base
+	// declaration for why the two backends cannot share one moment for this.
+	void updateLights() override;
+
 	void drawTexturedRect2D(GLuint textureId, GLuint maskTextureId, const glm::vec4& tint,
 			const glm::mat4& mvp,
 			const glm::vec2& uvOffset = glm::vec2(0.0f), const glm::vec2& uvScale = glm::vec2(1.0f)) override;

--- a/engine/core/gVKUniform.h
+++ b/engine/core/gVKUniform.h
@@ -65,14 +65,16 @@ struct alignas(16) gVKSceneUniforms {
 	alignas(16) glm::mat4 lightmatrix;
 	alignas(16) glm::vec4 viewpos;
 	alignas(16) glm::vec4 globalambientcolor;
-	// The renderer's current draw colour. color_frag.glsl ends with
-	// "result * renderColor", so a mesh on the OpenGL path is tinted by whatever
-	// setColor was last given - including a colour left over from drawing text.
-	// Matched here rather than left out, because OpenGL is the reference this port
-	// is measured against. One difference remains and is not worth a per-draw push
-	// constant: OpenGL refreshes it inside setColor, while this block is written
-	// once per frame, so a colour changed between two mesh draws lands on the next
-	// frame rather than immediately.
+	// The renderer's current draw colour, kept for layout only: both 3D shaders
+	// still declare this field, so the struct has to match, but neither reads it.
+	//
+	// It started here and had to move. color_frag.glsl ends with
+	// "result * renderColor", and OpenGL republishes the value inside setColor, so a
+	// canvas that recolours between two meshes gets a different colour on each. A
+	// uniform block cannot follow that: it is read when the commands execute, not
+	// when they are recorded, so every draw of the frame sees whichever value was
+	// written last. drawMesh3D folds the colour into the material push constant
+	// instead, which is per draw by construction.
 	alignas(16) glm::vec4 rendercolor;
 	// xyz is the shadow-casting light's position, which the depth bias is computed
 	// from; w is 0 or 1 for whether a shadow map is bound at all.


### PR DESCRIPTION
Vulkan: fix unlit rendering and shared poses on re-uploaded meshes
Two bugs in the Vulkan backend, both found by running a real game against it (game_martyr) rather than the test bench. They share a root shape: OpenGL publishes renderer state the moment it changes, while the Vulkan backend latches it and reuses it for a whole frame. Wherever a game changed something between two draws, the two backends disagreed.

1. Vulkan rendered everything unlit
gRenderer's state flags are assigned only in gRenderer::init(), and gVKRenderEngine::init() deliberately does not call it — that function compiles GLSL and builds the OpenGL primitive meshes, neither of which exists here. Nothing assigned them anywhere else, so on Vulkan every one of them started as whatever happened to be in that memory.

islightingenabled is the one that showed. Read as false, no light is ever marked enabled, mesh3d.frag finds none and falls back to globalambientcolor * material — a flat picture with no diffuse term, no normals doing anything and no specular. Measured against OpenGL on the same scene, surfaces came out up to twice as bright and lost all their shading.

It hid behind a second thing: an app that calls enableLighting() sets the flag on the way past and never sees this — which is exactly what the Vulkan test bench does. A game that relies on the default, as the API invites, gets an unlit scene. The two disagreed and the bench was the one that was wrong.

Fifteen fields were in the same state — depth test, alpha blending, soft shadows, fog, the post-processing flags and the viewport among them. They now carry in the header the values init() gives them, so they are defined whichever init the backend runs, and init() overwriting them changes nothing for OpenGL.

updateLights() becomes virtual for a related reason: OpenGL republishes light state inside that call, so a canvas that enables its light immediately before drawing and disables it after — the shape gLight's API invites — is shaded correctly. This backend gathers the whole scene block once per render pass, so it overrides the call to drop that block and let the next draw rebuild it.

Evidence. Logging what each backend hands its shaders, over one session: OpenGL published the light enabled and disabled about 27000 times; Vulkan published disabled once and never again.

2. Models posed more than once per frame all struck the same pose
A mesh whose vertices the CPU rewrites was given one buffer per frame in flight. That is enough when the mesh is uploaded once a frame, and wrong the moment it is uploaded more than once: draws are recorded now and execute later, so all of them read whatever the buffer holds by the end of the frame.

game_martyr walks straight into it — its enemies share one soldier model, re-posed and drawn once per enemy inside a single frame, so every soldier came out in whichever pose was uploaded last. They still moved, because position is a matrix rather than vertex data, so what it looked like was soldiers sliding across the ground: walking when the last pose happened to be mid-stride, gliding when it was not.

The fix is a per-frame arena that each upload takes a slice of, plus a vertex offset carried through to the draw so it binds the slice it was recorded with. The arena starts at 8 MB and grows to the high-water mark at a frame boundary, where draining the device is safe.

Two things surfaced while wiring it up, both fixed here:

Index buffers must stay out of the arena. gMesh rewrites the indices of a fan or a loop on first draw, which marks them dynamic too, and the arena is a vertex buffer — binding it as an index buffer silently dropped the cylinder, the cone and every instanced tree from the scene.
Instance buffers do belong there, since gMesh uploads the transforms on every instanced draw, so their offset is carried through as well.
OpenGL
Untouched behaviourally. The only shared file is gRenderer.h, where the fields now carry the defaults gRenderer::init() already assigned them, and updateLights() gains virtual. Both are no-ops for the OpenGL path.

Verification
Vulkan test bench: full scene, validation silent, no errors on either backend.
game_martyr on both backends, side by side: shading now matches, and the soldiers animate independently.
Compiled with GLIST_HAS_VULKAN undefined, so the Vulkan modules stay empty translation units — this is what broke the macOS and Linux runners last time.
upstream/main merged in, no conflicts.
Known and not addressed here
The skybox goes through its own shader and still differs in tone from OpenGL.
OpenGL draws no shadows in these scenes, which is a pre-existing gap on that path and unrelated to this change.
Vulkan is not yet faster than OpenGL. The backend binds descriptors per mesh and does no batching, so the frame cost is dominated by exactly what Vulkan is meant to remove; that is a separate piece of work.
Credits
Developer: Burak Eroğlu
Contributor: Mehmet (MemoryHearth)