### PR TITLE
Add gBitmapFont for rendering image-based bitmap fonts

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -237,6 +237,7 @@ set(SRC_FILES
 	${ENGINE_DIR}/graphics/gCamera.cpp
 	${ENGINE_DIR}/graphics/gCameraController.cpp
 	${ENGINE_DIR}/graphics/gFont.cpp
+	${ENGINE_DIR}/graphics/gBitmapFont.cpp
 	${ENGINE_DIR}/graphics/gMaterial.cpp
 	${ENGINE_DIR}/graphics/gMesh.cpp
 	${ENGINE_DIR}/graphics/gSkinnedMesh.cpp

--- a/engine/graphics/gBitmapFont.cpp
+++ b/engine/graphics/gBitmapFont.cpp
@@ -1,0 +1,147 @@
+/*
+ * gBitmapFont.cpp
+ */
+
+#include "gBitmapFont.h"
+
+#include "gUtils.h"
+
+#include <algorithm>
+#include <utility>
+
+bool gBitmapFont::load(const std::string& fullPath) {
+	gImage loadedbitmap;
+	loaded = loadedbitmap.load(fullPath) != 0
+			&& loadedbitmap.getWidth() > 0 && loadedbitmap.getHeight() > 0;
+	if (loaded) bitmap = std::move(loadedbitmap);
+	rebuildGlyphs();
+	return loaded;
+}
+
+bool gBitmapFont::loadImage(const std::string& imagePath) {
+	gImage loadedbitmap;
+	loaded = loadedbitmap.loadImage(imagePath) != 0
+			&& loadedbitmap.getWidth() > 0 && loadedbitmap.getHeight() > 0;
+	if (loaded) bitmap = std::move(loadedbitmap);
+	rebuildGlyphs();
+	return loaded;
+}
+
+bool gBitmapFont::loadFontImage(const std::string& imagePath) {
+	return loadImage(imagePath);
+}
+
+void gBitmapFont::setCharacterList(const std::string& characters) {
+	characterlist.clear();
+	for (std::uint32_t codepoint : gUTF8Iterator(characters)) {
+		characterlist.push_back(codepoint);
+	}
+	rebuildGlyphs();
+}
+
+void gBitmapFont::setCharacters(const std::string& characters) {
+	setCharacterList(characters);
+}
+
+void gBitmapFont::setCharacterCoordinates(const std::vector<gRect>& coordinates) {
+	coordinatelist = coordinates;
+	rebuildGlyphs();
+}
+
+bool gBitmapFont::setCharacters(const std::string& characters,
+		const std::vector<gRect>& coordinates) {
+	setCharacterList(characters);
+	setCharacterCoordinates(coordinates);
+	return configured;
+}
+
+void gBitmapFont::drawText(const std::string& text, float x, float y) {
+	if (!loaded || !configured || text.empty()) return;
+
+	float drawx = x;
+	float drawy = y;
+	const float currentlineheight = (lineheight > 0.0f ? lineheight : calculatedlineheight) * scale;
+
+	for (std::uint32_t codepoint : gUTF8Iterator(text)) {
+		if (codepoint == '\n') {
+			drawx = x;
+			drawy += currentlineheight;
+			continue;
+		}
+
+		auto glyph = glyphs.find(codepoint);
+		if (glyph == glyphs.end()) continue;
+
+		const gRect& source = glyph->second;
+		const float drawwidth = source.getWidth() * scale;
+		const float drawheight = source.getHeight() * scale;
+		bitmap.drawSub(glm::vec2(drawx, drawy), glm::vec2(drawwidth, drawheight),
+				glm::vec2(source.left(), source.top()),
+				glm::vec2(source.getWidth(), source.getHeight()));
+		drawx += drawwidth + letterspacing * scale;
+	}
+}
+
+void gBitmapFont::setScale(float scale) {
+	this->scale = std::max(0.0f, scale);
+}
+
+float gBitmapFont::getScale() const {
+	return scale;
+}
+
+void gBitmapFont::setLetterSpacing(float spacing) {
+	letterspacing = spacing;
+}
+
+float gBitmapFont::getLetterSpacing() const {
+	return letterspacing;
+}
+
+void gBitmapFont::setLineHeight(float height) {
+	lineheight = std::max(0.0f, height);
+}
+
+float gBitmapFont::getLineHeight() const {
+	return lineheight > 0.0f ? lineheight : calculatedlineheight;
+}
+
+bool gBitmapFont::isLoaded() const {
+	return loaded;
+}
+
+bool gBitmapFont::isConfigured() const {
+	return configured;
+}
+
+int gBitmapFont::getCharacterCount() const {
+	return static_cast<int>(glyphs.size());
+}
+
+void gBitmapFont::rebuildGlyphs() {
+	glyphs.clear();
+	calculatedlineheight = 0.0f;
+	configured = !characterlist.empty() && characterlist.size() == coordinatelist.size();
+	if (!configured) return;
+
+	for (std::size_t i = 0; i < characterlist.size(); ++i) {
+		const gRect& rectangle = coordinatelist[i];
+		if (rectangle.getWidth() <= 0 || rectangle.getHeight() <= 0) {
+			configured = false;
+			glyphs.clear();
+			calculatedlineheight = 0.0f;
+			return;
+		}
+		if (loaded && (rectangle.left() < 0 || rectangle.top() < 0
+				|| rectangle.right() > bitmap.getWidth()
+				|| rectangle.bottom() > bitmap.getHeight())) {
+			configured = false;
+			glyphs.clear();
+			calculatedlineheight = 0.0f;
+			return;
+		}
+		glyphs[characterlist[i]] = rectangle;
+		calculatedlineheight = std::max(calculatedlineheight,
+				static_cast<float>(rectangle.getHeight()));
+	}
+}

--- a/engine/graphics/gBitmapFont.h
+++ b/engine/graphics/gBitmapFont.h
@@ -1,0 +1,73 @@
+/*
+ * gBitmapFont.h
+ *
+ * Loads pre-rendered glyphs from a bitmap and draws text by sampling the
+ * configured character rectangles.
+ */
+
+#ifndef ENGINE_GRAPHICS_GBITMAPFONT_H_
+#define ENGINE_GRAPHICS_GBITMAPFONT_H_
+
+#include "gImage.h"
+#include "gRect.h"
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+class gBitmapFont {
+public:
+	/** Loads a bitmap font image from an absolute or relative filesystem path. */
+	bool load(const std::string& fullPath);
+
+	/** Loads a bitmap font image from the application's assets/images folder. */
+	bool loadImage(const std::string& imagePath);
+	bool loadFontImage(const std::string& imagePath);
+
+	/**
+	 * Sets the UTF-8 character list. Each code point is paired with the
+	 * rectangle at the same index in the coordinate list.
+	 */
+	void setCharacterList(const std::string& characters);
+	void setCharacters(const std::string& characters);
+
+	/**
+	 * Sets glyph rectangles in bitmap pixel coordinates. gRect values use
+	 * left, top, right and bottom edges.
+	 */
+	void setCharacterCoordinates(const std::vector<gRect>& coordinates);
+
+	/** Sets the character and coordinate lists together. */
+	bool setCharacters(const std::string& characters, const std::vector<gRect>& coordinates);
+
+	/** Draws UTF-8 text with x and y representing its top-left corner. */
+	void drawText(const std::string& text, float x, float y);
+
+	void setScale(float scale);
+	float getScale() const;
+	void setLetterSpacing(float spacing);
+	float getLetterSpacing() const;
+	void setLineHeight(float height);
+	float getLineHeight() const;
+
+	bool isLoaded() const;
+	bool isConfigured() const;
+	int getCharacterCount() const;
+
+private:
+	void rebuildGlyphs();
+
+	gImage bitmap;
+	std::vector<std::uint32_t> characterlist;
+	std::vector<gRect> coordinatelist;
+	std::unordered_map<std::uint32_t, gRect> glyphs;
+	float scale = 1.0f;
+	float letterspacing = 0.0f;
+	float lineheight = 0.0f;
+	float calculatedlineheight = 0.0f;
+	bool loaded = false;
+	bool configured = false;
+};
+
+#endif /* ENGINE_GRAPHICS_GBITMAPFONT_H_ */


### PR DESCRIPTION
## Summary

Adds a new `gBitmapFont` class for loading and rendering pre-generated bitmap fonts.

Characters are mapped to rectangular regions of a font image. After setting the character list and corresponding coordinates, text can be rendered with `drawText()`.

## Changes

- Added `graphics/gBitmapFont.h`
- Added `graphics/gBitmapFont.cpp`
- Added `gBitmapFont.cpp` to the engine CMake source list
- Added a complete `gisBitmapFont` sample application
- Added a 77-character bitmap font atlas generated from FreeSans
- Demonstrated character-coordinate mapping, multiline rendering, scaling, and letter spacing
- Added bitmap loading from:
  - A full filesystem path
  - The application's `assets/images` directory
- Added UTF-8 character list support
- Added character-to-rectangle mapping with `gRect`
- Added multiline text rendering
- Added configurable scale, letter spacing, and line height
- Added validation for:
  - Mismatched character and coordinate counts
  - Empty or invalid rectangles
  - Rectangles outside the bitmap boundaries
  - Failed image loading
  -The `gisBitmapFont` sample builds successfully in Debug mode
  - The sample starts successfully with the OpenGL renderer
  - The bundled bitmap atlas loads and configures 77 characters successfully

## Usage

```cpp
#include "gBitmapFont.h"

gBitmapFont bitmapfont;

void gCanvas::setup() {
    bitmapfont.loadFontImage("bitmapfont.png");

    bitmapfont.setCharacterList("ABCabc123 ");

    bitmapfont.setCharacterCoordinates({
        gRect(0,  0, 16, 24),
        gRect(16, 0, 32, 24),
        gRect(32, 0, 48, 24)
        // Remaining character rectangles...
    });

    bitmapfont.setLetterSpacing(1.0f);
    bitmapfont.setScale(1.0f);
}

void gCanvas::draw() {
    bitmapfont.drawText("ABC", 50, 50);
}