### PR TITLE
feat(renderer): add axis-angle rotation support to gDrawBox

### DIFF
--- a/engine/core/gRenderer.cpp
+++ b/engine/core/gRenderer.cpp
@@ -117,6 +117,11 @@ void gDrawBox(float x, float y, float z, float w, float h, float d, bool isFille
 	gRenderObject::getRenderer()->drawBox(x, y, z, w, h, d, isFilled);
 }
 
+void gDrawBox(float x, float y, float z,float w, float h, float d, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled) {
+    G_PROFILE_ZONE_SCOPED_N("gDrawBox()");
+    gRenderObject::getRenderer()->drawBox(x, y, z, w, h, d, rotateAngle, axisX, axisY, axisZ, isFilled);
+}
+
 void gDrawBox(glm::mat4 transformationMatrix, bool isFilled) {
 	G_PROFILE_ZONE_SCOPED_N("gDrawBox()");
 	gRenderObject::getRenderer()->drawBox(transformationMatrix, isFilled);
@@ -464,12 +469,52 @@ void gRenderer::drawRoundedRectangle(float x, float y, float w, float h, int rad
 
 void gRenderer::drawBox(float x, float y, float z, float w, float h, float d, bool isFilled) {
     G_PROFILE_ZONE_SCOPED_N("gRenderer::drawBox()");
-    if (boxmesh) boxmesh->draw();
+    if (boxmesh) {
+        boxmesh->setPosition(x, y, z);
+        boxmesh->setScale(w, h, d);
+        boxmesh->setOrientation(
+        glm::quat(1.0f, 0.0f, 0.0f, 0.0f)
+        );
+
+        boxmesh->draw();
+    }
+}
+
+void gRenderer::drawBox(float x, float y, float z, float w, float h, float d, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled) {
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawBox()");
+    if (boxmesh) {
+        boxmesh->setPosition(x, y, z);
+        boxmesh->setScale(w, h, d);
+        glm::vec3 axis(axisX, axisY, axisZ);
+
+        if (glm::length(axis) > 0.0f) {
+
+            axis = glm::normalize(axis);
+
+            glm::quat rotation =
+                glm::angleAxis(rotateAngle, axis);
+
+            rotation = glm::normalize(rotation);
+
+            boxmesh->setOrientation(rotation);
+
+        } else {
+
+            boxmesh->setOrientation(
+                glm::quat(1.0f, 0.0f, 0.0f, 0.0f)
+            );
+        }
+
+        boxmesh->draw();
+    }
 }
 
 void gRenderer::drawBox(glm::mat4 transformationMatrix, bool isFilled) {
     G_PROFILE_ZONE_SCOPED_N("gRenderer::drawBox()");
-    if (boxmesh) boxmesh->draw();
+    if (boxmesh) {
+        boxmesh->setTransformationMatrix(transformationMatrix);
+        boxmesh->draw();
+    }
 }
 
 void gRenderer::drawSphere(float xPos, float yPos, float zPos, glm::vec3 scale, int xSegmentNum, int ySegmentNum, bool isFilled) {

--- a/engine/core/gRenderer.h
+++ b/engine/core/gRenderer.h
@@ -79,7 +79,7 @@ int gGetCullFace();
 void gSetCullingDirection(int cullingDirection);
 int gGetCullingDirection();
 
-// --- 2D / 3D Line Overloads (Ambiguous hatas�n� �nlemek i�in ayr��t�r�ld�) ---
+// --- 2D / 3D Line Overloads
 void gDrawLine(float x1, float y1, float x2, float y2);
 void gDrawLine(float x1, float y1, float x2, float y2, float thickness);
 void gDrawLine(float x1, float y1, float z1, float x2, float y2, float z2, float thickness = 1.0f);
@@ -93,6 +93,7 @@ void gDrawArrow(float x1, float y1, float length, float angle, float tipLength, 
 void gDrawRectangle(float x, float y, float w, float h, bool isFilled = false, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
 void gDrawRoundedRectangle(float x, float y, float w, float h, int radius, bool isFilled, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
 void gDrawBox(float x, float y, float z, float w = 1.0f, float h = 1.0f, float d = 1.0f, bool isFilled = true);
+void gDrawBox(float x, float y, float z, float w, float h, float d, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 void gDrawBox(glm::mat4 transformationMatrix, bool isFilled = true);
 void gDrawSphere(float xPos, float yPos, float zPos, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int xSegmentNum = 64, int ySegmentNum = 32, bool isFilled = true);
 void gDrawCylinder(float x, float y, float z, int r, int h, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int segmentnum = 32, bool isFilled = true);
@@ -650,6 +651,7 @@ public:
 	void drawRectangle(float x, float y, float w, float h, bool isFilled = false, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
 	void drawRoundedRectangle(float x, float y, float w, float h, int radius, bool isFilled, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
 	void drawBox(float x, float y, float z, float w = 1.0f, float h = 1.0f, float d = 1.0f, bool isFilled = true);
+	void drawBox(float x, float y, float z, float w, float h, float d, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 	void drawBox(glm::mat4 transformationMatrix, bool isFilled = true);
 	void drawSphere(float xPos, float yPos, float zPos, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int xSegmentNum = 64, int ySegmentNum = 32, bool isFilled = true);
 	void drawCylinder(float x, float y, float z, int r, int h, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int segmentnum = 32, bool isFilled = true);

--- a/engine/core/gVKRenderEngine.cpp
+++ b/engine/core/gVKRenderEngine.cpp
@@ -2132,25 +2132,20 @@ void gVKRenderEngine::recordQueuedDrawGroup(size_t first, size_t count) {
 
 
 void gVKRenderEngine::init() {
-	// gRenderer::init() is deliberately not called: it compiles shaders and
-	// builds GL objects, and there is no GL context under Vulkan. originalgrid
-	// is assigned only inside that function and is never initialised in a
-	// constructor, so it is nulled here to keep the destructor's delete safe.
-	originalgrid = nullptr;
-	// gRenderer::init() also allocates rendercolor, but it is skipped under Vulkan;
-	// the 2D draw helpers read the current colour, so create a white default here.
-	rendercolor = new gColor();
-	rendercolor->set(255, 255, 255, 255);
-	// The primitive meshes are created by gRenderer::init() as well. They hold no GL
-	// objects until they are drawn, and the 2D ones now record through the backend's
-	// draw path, so drawLine / drawCircle / drawRectangle and friends need them here
-	// just as much as the OpenGL path does.
-	createPrimitiveMeshes();
-	if(!initVulkan()) {
-		gLoge("gVKRenderEngine") << "Vulkan initialization failed; the Vulkan backend is not usable.";
-	}
-}
 
+    originalgrid = nullptr;
+
+    rendercolor = new gColor();
+    rendercolor->set(255, 255, 255, 255);
+
+    if(!initVulkan()) {
+        gLoge("gVKRenderEngine")
+            << "Vulkan initialization failed; the Vulkan backend is not usable.";
+        return;
+    }
+
+    createPrimitiveMeshes();
+}
 
 void gVKRenderEngine::cleanup() {
 	// The GL resources gRenderer::cleanup() would release were never created,


### PR DESCRIPTION
- add rotated gDrawBox overload with custom rotation axis
- forward rotation parameters to gRenderer::drawBox
- apply normalized axis-angle rotation to box mesh
- initialize Vulkan before creating primitive meshes
- fix Vulkan box rendering through renderer primitive path