### PR TITLE
refactor(renderer): restore engine comments and fix header comment

### DIFF
--- a/engine/core/gRenderer.h
+++ b/engine/core/gRenderer.h
@@ -637,7 +637,7 @@ public:
 	virtual void pushMatrix() = 0;
 	virtual void popMatrix() = 0;
 
-	/* ---------------- Utilities (drawLine overloads d�zenlendi) ---------------- */
+	/* ---------------- Utilities ---------------- */
 	void drawLine(float x1, float y1, float x2, float y2);
 	void drawLine(float x1, float y1, float x2, float y2, float thickness);
 	void drawLine(float x1, float y1, float z1, float x2, float y2, float z2, float thickness = 1.0f);

--- a/engine/core/gVKRenderEngine.cpp
+++ b/engine/core/gVKRenderEngine.cpp
@@ -2132,12 +2132,19 @@ void gVKRenderEngine::recordQueuedDrawGroup(size_t first, size_t count) {
 
 
 void gVKRenderEngine::init() {
-
+	// gRenderer::init() is deliberately not called: it compiles shaders and
+	// builds GL objects, and there is no GL context under Vulkan. originalgrid
+	// is assigned only inside that function and is never initialised in a
+	// constructor, so it is nulled here to keep the destructor's delete safe.
     originalgrid = nullptr;
-
+	// gRenderer::init() also allocates rendercolor, but it is skipped under Vulkan;
+	// the 2D draw helpers read the current colour, so create a white default here.
     rendercolor = new gColor();
     rendercolor->set(255, 255, 255, 255);
-
+	// The primitive meshes are created by gRenderer::init() as well. They hold no GL
+	// objects until they are drawn, and the 2D ones now record through the backend's
+	// draw path, so drawLine / drawCircle / drawRectangle and friends need them here
+	// just as much as the OpenGL path does.
     if(!initVulkan()) {
         gLoge("gVKRenderEngine")
             << "Vulkan initialization failed; the Vulkan backend is not usable.";


### PR DESCRIPTION
Restored documentation comments in gVKRenderEngine.cpp and cleaned up the remaining Turkish comment in gRenderer.h header.