### PR TITLE
feat(renderer): add rotation support to 3D primitives and create

### DIFF
--- a/engine/core/gRenderer.cpp
+++ b/engine/core/gRenderer.cpp
@@ -192,6 +192,121 @@ void gDrawTubeObliqueTrapezodial(float x, float y, float z, int topouterradius, 
     gRenderObject::getRenderer()->drawTubeObliqueTrapezodial(x, y, z, topouterradius, topinnerradious, buttomouterradious, buttominnerradious, h, shiftdistance, scale, segmentnum, isFilled);
 }
 
+// --- Rotatable 3D Global Draw Overloads ---
+
+void gDrawSphere(float xPos, float yPos, float zPos, glm::vec3 scale, int xSegmentNum, int ySegmentNum,
+		float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gDrawSphere()");
+	gRenderObject::getRenderer()->drawSphere(
+			xPos, yPos, zPos, scale, xSegmentNum, ySegmentNum,
+			rotateAngle, axisX, axisY, axisZ, isFilled);
+}
+
+void gDrawCylinder(float x, float y, float z, int r, int h, glm::vec3 scale, int segmentnum,
+		float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gDrawCylinder()");
+	gRenderObject::getRenderer()->drawCylinder(
+			x, y, z, r, h, scale, segmentnum,
+			rotateAngle, axisX, axisY, axisZ, isFilled);
+}
+
+void gDrawCylinderOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance,
+		glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ,
+		bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gDrawCylinderOblique()");
+	gRenderObject::getRenderer()->drawCylinderOblique(
+			x, y, z, r, h, shiftdistance, scale, segmentnum,
+			rotateAngle, axisX, axisY, axisZ, isFilled);
+}
+
+void gDrawCylinderTrapezodial(float x, float y, float z, int r1, int r2, int h, glm::vec3 scale,
+		int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gDrawCylinderTrapezodial()");
+	gRenderObject::getRenderer()->drawCylinderTrapezodial(
+			x, y, z, r1, r2, h, scale, segmentnum,
+			rotateAngle, axisX, axisY, axisZ, isFilled);
+}
+
+void gDrawCylinderObliqueTrapezodial(float x, float y, float z, int r1, int r2, int h,
+		glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, float rotateAngle,
+		float axisX, float axisY, float axisZ, bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gDrawCylinderObliqueTrapezodial()");
+	gRenderObject::getRenderer()->drawCylinderObliqueTrapezodial(
+			x, y, z, r1, r2, h, shiftdistance, scale, segmentnum,
+			rotateAngle, axisX, axisY, axisZ, isFilled);
+}
+
+void gDrawCone(float x, float y, float z, int r, int h, glm::vec3 scale, int segmentnum,
+		float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gDrawCone()");
+	gRenderObject::getRenderer()->drawCone(
+			x, y, z, r, h, scale, segmentnum,
+			rotateAngle, axisX, axisY, axisZ, isFilled);
+}
+
+void gDrawConeOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance,
+		glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ,
+		bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gDrawConeOblique()");
+	gRenderObject::getRenderer()->drawConeOblique(
+			x, y, z, r, h, shiftdistance, scale, segmentnum,
+			rotateAngle, axisX, axisY, axisZ, isFilled);
+}
+
+void gDrawPyramid(float x, float y, float z, int r, int h, glm::vec3 scale, int numberofsides,
+		float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gDrawPyramid()");
+	gRenderObject::getRenderer()->drawPyramid(
+			x, y, z, r, h, scale, numberofsides,
+			rotateAngle, axisX, axisY, axisZ, isFilled);
+}
+
+void gDrawPyramidOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance,
+		glm::vec3 scale, int numberofsides, float rotateAngle, float axisX, float axisY, float axisZ,
+		bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gDrawPyramidOblique()");
+	gRenderObject::getRenderer()->drawPyramidOblique(
+			x, y, z, r, h, shiftdistance, scale, numberofsides,
+			rotateAngle, axisX, axisY, axisZ, isFilled);
+}
+
+void gDrawTube(float x, float y, float z, int outerradius, int innerradious, int h,
+		glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ,
+		bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gDrawTube()");
+	gRenderObject::getRenderer()->drawTube(
+			x, y, z, outerradius, innerradious, h, scale, segmentnum,
+			rotateAngle, axisX, axisY, axisZ, isFilled);
+}
+
+void gDrawTubeOblique(float x, float y, float z, int outerradius, int innerradious, int h,
+		glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, float rotateAngle,
+		float axisX, float axisY, float axisZ, bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gDrawTubeOblique()");
+	gRenderObject::getRenderer()->drawTubeOblique(
+			x, y, z, outerradius, innerradious, h, shiftdistance, scale, segmentnum,
+			rotateAngle, axisX, axisY, axisZ, isFilled);
+}
+
+void gDrawTubeTrapezodial(float x, float y, float z, int topouterradius, int topinnerradious,
+		int buttomouterradious, int buttominnerradious, int h, glm::vec3 scale, int segmentnum,
+		float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gDrawTubeTrapezodial()");
+	gRenderObject::getRenderer()->drawTubeTrapezodial(
+			x, y, z, topouterradius, topinnerradious, buttomouterradious, buttominnerradious,
+			h, scale, segmentnum, rotateAngle, axisX, axisY, axisZ, isFilled);
+}
+
+void gDrawTubeObliqueTrapezodial(float x, float y, float z, int topouterradius,
+		int topinnerradious, int buttomouterradious, int buttominnerradious, int h,
+		glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, float rotateAngle,
+		float axisX, float axisY, float axisZ, bool isFilled) {
+	G_PROFILE_ZONE_SCOPED_N("gDrawTubeObliqueTrapezodial()");
+	gRenderObject::getRenderer()->drawTubeObliqueTrapezodial(
+			x, y, z, topouterradius, topinnerradious, buttomouterradious, buttominnerradious,
+			h, shiftdistance, scale, segmentnum, rotateAngle, axisX, axisY, axisZ, isFilled);
+}
+
 // --- gRenderer Class Member Implementations ---
 
 gRenderer::~gRenderer() {
@@ -341,7 +456,8 @@ void gRenderer::createPrimitiveMeshes() {
 	arcmesh = std::make_unique<gArc>();
 	rectanglemesh = std::make_unique<gRectangle>();
 	roundedrectanglemesh = std::make_unique<gRoundedRectangle>();
-	boxmesh = std::make_unique<gBox>();
+	boxmesh = std::make_unique<gBox>(true);
+	boxlinemesh = std::make_unique<gBox>(false);
 	//arrowmesh = std::make_unique<gArrow>();
 }
 
@@ -356,8 +472,174 @@ void gRenderer::destroyPrimitiveMeshes() {
 	rectanglemesh = nullptr;
 	roundedrectanglemesh = nullptr;
 	boxmesh = nullptr;
+	boxlinemesh = nullptr;
+	spheremeshcache.clear();
+	cylindermeshcache.clear();
+	conemeshcache.clear();
+	tubemeshcache.clear();
 	//arrowmesh = nullptr;
 }
+
+gSphere* gRenderer::getSphereMesh(
+        int xSegmentNum,
+        int ySegmentNum,
+        bool isFilled) {
+
+    for (auto& item : spheremeshcache) {
+        if (item.xSegmentNum == xSegmentNum &&
+            item.ySegmentNum == ySegmentNum &&
+            item.isFilled == isFilled) {
+            return item.mesh.get();
+        }
+    }
+
+    spheremeshcache.push_back(
+        SphereMeshCacheEntry{
+            xSegmentNum,
+            ySegmentNum,
+            isFilled,
+            std::make_unique<gSphere>(
+                xSegmentNum,
+                ySegmentNum,
+                isFilled
+            )
+        }
+    );
+
+    return spheremeshcache.back().mesh.get();
+}
+
+gCylinder* gRenderer::getCylinderMesh(
+        int r1,
+        int r2,
+        int h,
+        const glm::vec2& shiftdistance,
+        int segmentnum,
+        bool isFilled) {
+
+    for (auto& item : cylindermeshcache) {
+        if (item.r1 == r1 &&
+            item.r2 == r2 &&
+            item.h == h &&
+            item.shiftdistance.x == shiftdistance.x &&
+            item.shiftdistance.y == shiftdistance.y &&
+            item.segmentnum == segmentnum &&
+            item.isFilled == isFilled) {
+            return item.mesh.get();
+        }
+    }
+
+    cylindermeshcache.push_back(
+        CylinderMeshCacheEntry{
+            r1,
+            r2,
+            h,
+            shiftdistance,
+            segmentnum,
+            isFilled,
+            std::make_unique<gCylinder>(
+                r1,
+                r2,
+                h,
+                shiftdistance,
+                segmentnum,
+                isFilled
+            )
+        }
+    );
+
+    return cylindermeshcache.back().mesh.get();
+}
+
+gCone* gRenderer::getConeMesh(
+        int r,
+        int h,
+        const glm::vec2& shiftdistance,
+        int segmentnum,
+        bool isFilled) {
+
+    for (auto& item : conemeshcache) {
+        if (item.r == r &&
+            item.h == h &&
+            item.shiftdistance.x == shiftdistance.x &&
+            item.shiftdistance.y == shiftdistance.y &&
+            item.segmentnum == segmentnum &&
+            item.isFilled == isFilled) {
+            return item.mesh.get();
+        }
+    }
+
+    conemeshcache.push_back(
+        ConeMeshCacheEntry{
+            r,
+            h,
+            shiftdistance,
+            segmentnum,
+            isFilled,
+            std::make_unique<gCone>(
+                r,
+                h,
+                shiftdistance,
+                segmentnum,
+                isFilled
+            )
+        }
+    );
+
+    return conemeshcache.back().mesh.get();
+}
+
+
+gTube* gRenderer::getTubeMesh(
+        int topOuterRadius,
+        int topInnerRadius,
+        int bottomOuterRadius,
+        int bottomInnerRadius,
+        int h,
+        const glm::vec2& shiftdistance,
+        int segmentnum,
+        bool isFilled) {
+
+    for (auto& item : tubemeshcache) {
+        if (item.topOuterRadius == topOuterRadius &&
+            item.topInnerRadius == topInnerRadius &&
+            item.bottomOuterRadius == bottomOuterRadius &&
+            item.bottomInnerRadius == bottomInnerRadius &&
+            item.h == h &&
+            item.shiftdistance.x == shiftdistance.x &&
+            item.shiftdistance.y == shiftdistance.y &&
+            item.segmentnum == segmentnum &&
+            item.isFilled == isFilled) {
+            return item.mesh.get();
+        }
+    }
+
+    tubemeshcache.push_back(
+        TubeMeshCacheEntry{
+            topOuterRadius,
+            topInnerRadius,
+            bottomOuterRadius,
+            bottomInnerRadius,
+            h,
+            shiftdistance,
+            segmentnum,
+            isFilled,
+            std::make_unique<gTube>(
+                topOuterRadius,
+                topInnerRadius,
+                bottomOuterRadius,
+                bottomInnerRadius,
+                h,
+                shiftdistance,
+                segmentnum,
+                isFilled
+            )
+        }
+    );
+
+    return tubemeshcache.back().mesh.get();
+}
+
 
 void gRenderer::cleanup() {
 	destroyPrimitiveMeshes();
@@ -467,106 +749,526 @@ void gRenderer::drawRoundedRectangle(float x, float y, float w, float h, int rad
 	if (roundedrectanglemesh) roundedrectanglemesh->draw(x, y, w, h, radius, isFilled, rotateAngle, pivotx, pivoty);
 }
 
-void gRenderer::drawBox(float x, float y, float z, float w, float h, float d, bool isFilled) {
+void gRenderer::drawBox(float x, float y, float z,
+        float w, float h, float d,
+        bool isFilled) {
     G_PROFILE_ZONE_SCOPED_N("gRenderer::drawBox()");
-    if (boxmesh) {
-        boxmesh->setPosition(x, y, z);
-        boxmesh->setScale(w, h, d);
-        boxmesh->setOrientation(
-        glm::quat(1.0f, 0.0f, 0.0f, 0.0f)
-        );
 
-        boxmesh->draw();
-    }
+    gBox* box = isFilled ? boxmesh.get() : boxlinemesh.get();
+    if (!box) return;
+
+    box->setPosition(x, y, z);
+    box->setScale(w, h, d);
+    box->setOrientation(
+        glm::quat(1.0f, 0.0f, 0.0f, 0.0f)
+    );
+    box->draw();
 }
 
-void gRenderer::drawBox(float x, float y, float z, float w, float h, float d, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled) {
+void gRenderer::drawBox(float x, float y, float z,
+        float w, float h, float d,
+        float rotateAngle,
+        float axisX, float axisY, float axisZ,
+        bool isFilled) {
     G_PROFILE_ZONE_SCOPED_N("gRenderer::drawBox()");
-    if (boxmesh) {
-        boxmesh->setPosition(x, y, z);
-        boxmesh->setScale(w, h, d);
-        glm::vec3 axis(axisX, axisY, axisZ);
 
-        if (glm::length(axis) > 0.0f) {
+    gBox* box = isFilled ? boxmesh.get() : boxlinemesh.get();
+    if (!box) return;
 
-            axis = glm::normalize(axis);
+    box->setPosition(x, y, z);
+    box->setScale(w, h, d);
 
-            glm::quat rotation =
-                glm::angleAxis(rotateAngle, axis);
+    glm::vec3 axis(axisX, axisY, axisZ);
 
-            rotation = glm::normalize(rotation);
+    if (glm::length(axis) > 0.0f) {
+        axis = glm::normalize(axis);
 
-            boxmesh->setOrientation(rotation);
+        glm::quat rotation =
+            glm::angleAxis(rotateAngle, axis);
 
-        } else {
-
-            boxmesh->setOrientation(
-                glm::quat(1.0f, 0.0f, 0.0f, 0.0f)
-            );
-        }
-
-        boxmesh->draw();
+        box->setOrientation(glm::normalize(rotation));
+    } else {
+        box->setOrientation(
+            glm::quat(1.0f, 0.0f, 0.0f, 0.0f)
+        );
     }
+
+    box->draw();
 }
 
 void gRenderer::drawBox(glm::mat4 transformationMatrix, bool isFilled) {
     G_PROFILE_ZONE_SCOPED_N("gRenderer::drawBox()");
-    if (boxmesh) {
-        boxmesh->setTransformationMatrix(transformationMatrix);
-        boxmesh->draw();
-    }
+
+    gBox* box = isFilled ? boxmesh.get() : boxlinemesh.get();
+    if (!box) return;
+
+    box->setTransformationMatrix(transformationMatrix);
+    box->draw();
 }
 
 void gRenderer::drawSphere(float xPos, float yPos, float zPos, glm::vec3 scale, int xSegmentNum, int ySegmentNum, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawSphere()");
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawSphere()");
+    gSphere* sphere = getSphereMesh(xSegmentNum, ySegmentNum, isFilled);
+
+    if (!sphere) return;
+
+    sphere->setPosition(xPos, yPos, zPos);
+    sphere->setScale(scale.x, scale.y, scale.z);
+    sphere->setOrientation(glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+    sphere->draw();
+}
+
+void gRenderer::drawSphere(float xPos, float yPos, float zPos, glm::vec3 scale, int xSegmentNum, int ySegmentNum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled) {
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawSphere()");
+    gSphere* sphere = getSphereMesh(xSegmentNum, ySegmentNum, isFilled);
+
+    if (!sphere) return;
+
+    sphere->setPosition(xPos, yPos, zPos);
+    sphere->setScale(scale.x, scale.y, scale.z);
+
+    glm::vec3 axis(axisX, axisY, axisZ);
+
+    if (glm::length(axis) > 0.0f) {
+        axis = glm::normalize(axis);
+
+        glm::quat rotation =
+            glm::angleAxis(rotateAngle, axis);
+
+        sphere->setOrientation(glm::normalize(rotation));
+    } else {
+        sphere->setOrientation(
+            glm::quat(1.0f, 0.0f, 0.0f, 0.0f)
+        );
+    }
+
+    sphere->draw();
 }
 
 void gRenderer::drawCylinder(float x, float y, float z, int r, int h, glm::vec3 scale, int segmentnum, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCylinder()");
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCylinder()");
+    gCylinder* cylinder = getCylinderMesh(r, r, h, glm::vec2(0.0f, 0.0f), segmentnum, isFilled);
+
+    if (!cylinder) return;
+
+    cylinder->setPosition(x, y, z);
+    cylinder->setScale(scale.x, scale.y, scale.z);
+    cylinder->setOrientation(glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+    cylinder->draw();
+}
+
+void gRenderer::drawCylinder(float x, float y, float z, int r, int h, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled) {
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCylinder()");
+    gCylinder* cylinder = getCylinderMesh(r, r, h, glm::vec2(0.0f, 0.0f), segmentnum, isFilled);
+
+    if (!cylinder) return;
+
+    cylinder->setPosition(x, y, z);
+    cylinder->setScale(scale.x, scale.y, scale.z);
+
+    glm::vec3 axis(axisX, axisY, axisZ);
+    if (glm::length(axis) > 0.0f) {
+        axis = glm::normalize(axis);
+        cylinder->setOrientation(
+            glm::normalize(glm::angleAxis(rotateAngle, axis))
+        );
+    } else {
+        cylinder->setOrientation(glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+    }
+
+    cylinder->draw();
 }
 
 void gRenderer::drawCylinderOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCylinderOblique()");
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCylinderOblique()");
+    gCylinder* cylinder = getCylinderMesh(r, r, h, shiftdistance, segmentnum, isFilled);
+
+    if (!cylinder) return;
+
+    cylinder->setPosition(x, y, z);
+    cylinder->setScale(scale.x, scale.y, scale.z);
+    cylinder->setOrientation(glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+    cylinder->draw();
+}
+
+void gRenderer::drawCylinderOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled) {
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCylinderOblique()");
+    gCylinder* cylinder = getCylinderMesh(r, r, h, shiftdistance, segmentnum, isFilled);
+
+    if (!cylinder) return;
+
+    cylinder->setPosition(x, y, z);
+    cylinder->setScale(scale.x, scale.y, scale.z);
+
+    glm::vec3 axis(axisX, axisY, axisZ);
+    if (glm::length(axis) > 0.0f) {
+        axis = glm::normalize(axis);
+        cylinder->setOrientation(
+            glm::normalize(glm::angleAxis(rotateAngle, axis))
+        );
+    } else {
+        cylinder->setOrientation(glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+    }
+
+    cylinder->draw();
 }
 
 void gRenderer::drawCylinderTrapezodial(float x, float y, float z, int r1, int r2, int h, glm::vec3 scale, int segmentnum, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCylinderTrapezodial()");
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCylinderTrapezodial()");
+    gCylinder* cylinder = getCylinderMesh(r1, r2, h, glm::vec2(0.0f, 0.0f), segmentnum, isFilled);
+
+    if (!cylinder) return;
+
+    cylinder->setPosition(x, y, z);
+    cylinder->setScale(scale.x, scale.y, scale.z);
+    cylinder->setOrientation(glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+    cylinder->draw();
+}
+
+void gRenderer::drawCylinderTrapezodial(float x, float y, float z, int r1, int r2, int h, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled) {
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCylinderTrapezodial()");
+    gCylinder* cylinder = getCylinderMesh(r1, r2, h, glm::vec2(0.0f, 0.0f), segmentnum, isFilled);
+
+    if (!cylinder) return;
+
+    cylinder->setPosition(x, y, z);
+    cylinder->setScale(scale.x, scale.y, scale.z);
+
+    glm::vec3 axis(axisX, axisY, axisZ);
+    if (glm::length(axis) > 0.0f) {
+        axis = glm::normalize(axis);
+        cylinder->setOrientation(
+            glm::normalize(glm::angleAxis(rotateAngle, axis))
+        );
+    } else {
+        cylinder->setOrientation(glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+    }
+
+    cylinder->draw();
 }
 
 void gRenderer::drawCylinderObliqueTrapezodial(float x, float y, float z, int r1, int r2, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCylinderObliqueTrapezodial()");
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCylinderObliqueTrapezodial()");
+    gCylinder* cylinder = getCylinderMesh(r1, r2, h, shiftdistance, segmentnum, isFilled);
+
+    if (!cylinder) return;
+
+    cylinder->setPosition(x, y, z);
+    cylinder->setScale(scale.x, scale.y, scale.z);
+    cylinder->setOrientation(glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+    cylinder->draw();
+}
+
+void gRenderer::drawCylinderObliqueTrapezodial(float x, float y, float z, int r1, int r2, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled) {
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCylinderObliqueTrapezodial()");
+    gCylinder* cylinder = getCylinderMesh(r1, r2, h, shiftdistance, segmentnum, isFilled);
+
+    if (!cylinder) return;
+
+    cylinder->setPosition(x, y, z);
+    cylinder->setScale(scale.x, scale.y, scale.z);
+
+    glm::vec3 axis(axisX, axisY, axisZ);
+    if (glm::length(axis) > 0.0f) {
+        axis = glm::normalize(axis);
+        cylinder->setOrientation(
+            glm::normalize(glm::angleAxis(rotateAngle, axis))
+        );
+    } else {
+        cylinder->setOrientation(glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+    }
+
+    cylinder->draw();
 }
 
 void gRenderer::drawCone(float x, float y, float z, int r, int h, glm::vec3 scale, int segmentnum, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCone()");
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCone()");
+    gCone* cone = getConeMesh(r, h, glm::vec2(0.0f, 0.0f), segmentnum, isFilled);
+
+    if (!cone) return;
+
+    cone->setPosition(x, y, z);
+    cone->setScale(scale.x, scale.y, scale.z);
+    cone->setOrientation(glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+    cone->draw();
+}
+
+void gRenderer::drawCone(float x, float y, float z, int r, int h, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled) {
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawCone()");
+    gCone* cone = getConeMesh(r, h, glm::vec2(0.0f, 0.0f), segmentnum, isFilled);
+
+    if (!cone) return;
+
+    cone->setPosition(x, y, z);
+    cone->setScale(scale.x, scale.y, scale.z);
+
+    glm::vec3 axis(axisX, axisY, axisZ);
+    if (glm::length(axis) > 0.0f) {
+        axis = glm::normalize(axis);
+        cone->setOrientation(
+            glm::normalize(glm::angleAxis(rotateAngle, axis))
+        );
+    } else {
+        cone->setOrientation(glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+    }
+
+    cone->draw();
 }
 
 void gRenderer::drawConeOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawConeOblique()");
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawConeOblique()");
+    gCone* cone = getConeMesh(r, h, shiftdistance, segmentnum, isFilled);
+
+    if (!cone) return;
+
+    cone->setPosition(x, y, z);
+    cone->setScale(scale.x, scale.y, scale.z);
+    cone->setOrientation(glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+    cone->draw();
+}
+
+void gRenderer::drawConeOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled) {
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawConeOblique()");
+    gCone* cone = getConeMesh(r, h, shiftdistance, segmentnum, isFilled);
+
+    if (!cone) return;
+
+    cone->setPosition(x, y, z);
+    cone->setScale(scale.x, scale.y, scale.z);
+
+    glm::vec3 axis(axisX, axisY, axisZ);
+    if (glm::length(axis) > 0.0f) {
+        axis = glm::normalize(axis);
+        cone->setOrientation(
+            glm::normalize(glm::angleAxis(rotateAngle, axis))
+        );
+    } else {
+        cone->setOrientation(glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+    }
+
+    cone->draw();
 }
 
 void gRenderer::drawPyramid(float x, float y, float z, int r, int h, glm::vec3 scale, int numberofsides, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawPyramid()");
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawPyramid()");
+    gCone* pyramid = getConeMesh(r, h, glm::vec2(0.0f, 0.0f), numberofsides, isFilled);
+
+    if (!pyramid) return;
+
+    pyramid->setPosition(x, y, z);
+    pyramid->setScale(scale.x, scale.y, scale.z);
+    pyramid->setOrientation(
+        glm::quat(1.0f, 0.0f, 0.0f, 0.0f)
+    );
+
+    pyramid->draw();
+}
+
+void gRenderer::drawPyramid(float x, float y, float z, int r, int h, glm::vec3 scale, int numberofsides, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled) {
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawPyramid()");
+    gCone* pyramid = getConeMesh(r, h, glm::vec2(0.0f, 0.0f), numberofsides, isFilled);
+
+    if (!pyramid) return;
+
+    pyramid->setPosition(x, y, z);
+    pyramid->setScale(scale.x, scale.y, scale.z);
+
+    glm::vec3 axis(axisX, axisY, axisZ);
+
+    if (glm::length(axis) > 0.0f) {
+        axis = glm::normalize(axis);
+
+        pyramid->setOrientation(
+            glm::normalize(
+                glm::angleAxis(rotateAngle, axis)
+            )
+        );
+    } else {
+        pyramid->setOrientation(
+            glm::quat(1.0f, 0.0f, 0.0f, 0.0f)
+        );
+    }
+
+    pyramid->draw();
 }
 
 void gRenderer::drawPyramidOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance, glm::vec3 scale, int numberofsides, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawPyramidOblique()");
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawPyramidOblique()");
+    gCone* pyramid = getConeMesh(r, h, shiftdistance, numberofsides, isFilled);
+
+    if (!pyramid) return;
+
+    pyramid->setPosition(x, y, z);
+    pyramid->setScale(scale.x, scale.y, scale.z);
+    pyramid->setOrientation(
+        glm::quat(1.0f, 0.0f, 0.0f, 0.0f)
+    );
+
+    pyramid->draw();
+}
+
+void gRenderer::drawPyramidOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance, glm::vec3 scale, int numberofsides, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled) {
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawPyramidOblique()");
+    gCone* pyramid = getConeMesh(r, h, shiftdistance, numberofsides, isFilled);
+
+    if (!pyramid) return;
+
+    pyramid->setPosition(x, y, z);
+    pyramid->setScale(scale.x, scale.y, scale.z);
+
+    glm::vec3 axis(axisX, axisY, axisZ);
+
+    if (glm::length(axis) > 0.0f) {
+        axis = glm::normalize(axis);
+
+        pyramid->setOrientation(
+            glm::normalize(
+                glm::angleAxis(rotateAngle, axis)
+            )
+        );
+    } else {
+        pyramid->setOrientation(
+            glm::quat(1.0f, 0.0f, 0.0f, 0.0f)
+        );
+    }
+
+    pyramid->draw();
 }
 
 void gRenderer::drawTube(float x, float y, float z, int outerradius, int innerradious, int h, glm::vec3 scale, int segmentnum, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawTube()");
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawTube()");
+    gTube* tube = getTubeMesh(outerradius, innerradious, outerradius, innerradious, h, glm::vec2(0.0f, 0.0f), segmentnum, isFilled);
+
+    if (!tube) return;
+
+    tube->setPosition(x, y, z);
+    tube->setScale(scale.x, scale.y, scale.z);
+    tube->setOrientation(glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+    tube->draw();
+}
+
+void gRenderer::drawTube(float x, float y, float z, int outerradius, int innerradious, int h, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled) {
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawTube()");
+    gTube* tube = getTubeMesh(outerradius, innerradious, outerradius, innerradious, h, glm::vec2(0.0f, 0.0f), segmentnum, isFilled);
+
+    if (!tube) return;
+
+    tube->setPosition(x, y, z);
+    tube->setScale(scale.x, scale.y, scale.z);
+
+    glm::vec3 axis(axisX, axisY, axisZ);
+    if (glm::length(axis) > 0.0f) {
+        axis = glm::normalize(axis);
+        tube->setOrientation(
+            glm::normalize(glm::angleAxis(rotateAngle, axis))
+        );
+    } else {
+        tube->setOrientation(glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+    }
+
+    tube->draw();
 }
 
 void gRenderer::drawTubeOblique(float x, float y, float z, int outerradius, int innerradious, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawTubeOblique()");
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawTubeOblique()");
+    gTube* tube = getTubeMesh(outerradius, innerradious, outerradius, innerradious, h, shiftdistance, segmentnum, isFilled);
+
+    if (!tube) return;
+
+    tube->setPosition(x, y, z);
+    tube->setScale(scale.x, scale.y, scale.z);
+    tube->setOrientation(glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+    tube->draw();
+}
+
+void gRenderer::drawTubeOblique(float x, float y, float z, int outerradius, int innerradious, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled) {
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawTubeOblique()");
+    gTube* tube = getTubeMesh(outerradius, innerradious, outerradius, innerradious, h, shiftdistance, segmentnum, isFilled);
+
+    if (!tube) return;
+
+    tube->setPosition(x, y, z);
+    tube->setScale(scale.x, scale.y, scale.z);
+
+    glm::vec3 axis(axisX, axisY, axisZ);
+    if (glm::length(axis) > 0.0f) {
+        axis = glm::normalize(axis);
+        tube->setOrientation(
+            glm::normalize(glm::angleAxis(rotateAngle, axis))
+        );
+    } else {
+        tube->setOrientation(glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+    }
+
+    tube->draw();
 }
 
 void gRenderer::drawTubeTrapezodial(float x, float y, float z, int topouterradius, int topinnerradious, int buttomouterradious, int buttominnerradious, int h, glm::vec3 scale, int segmentnum, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawTubeTrapezodial()");
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawTubeTrapezodial()");
+    gTube* tube = getTubeMesh(topouterradius, topinnerradious, buttomouterradious, buttominnerradious, h, glm::vec2(0.0f, 0.0f), segmentnum, isFilled);
+
+    if (!tube) return;
+
+    tube->setPosition(x, y, z);
+    tube->setScale(scale.x, scale.y, scale.z);
+    tube->setOrientation(glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+    tube->draw();
+}
+
+void gRenderer::drawTubeTrapezodial(float x, float y, float z, int topouterradius, int topinnerradious, int buttomouterradious, int buttominnerradious, int h, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled) {
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawTubeTrapezodial()");
+    gTube* tube = getTubeMesh(topouterradius, topinnerradious, buttomouterradious, buttominnerradious, h, glm::vec2(0.0f, 0.0f), segmentnum, isFilled);
+
+    if (!tube) return;
+
+    tube->setPosition(x, y, z);
+    tube->setScale(scale.x, scale.y, scale.z);
+
+    glm::vec3 axis(axisX, axisY, axisZ);
+    if (glm::length(axis) > 0.0f) {
+        axis = glm::normalize(axis);
+        tube->setOrientation(
+            glm::normalize(glm::angleAxis(rotateAngle, axis))
+        );
+    } else {
+        tube->setOrientation(glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+    }
+
+    tube->draw();
 }
 
 void gRenderer::drawTubeObliqueTrapezodial(float x, float y, float z, int topouterradius, int topinnerradious, int buttomouterradious, int buttominnerradious, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, bool isFilled) {
-	G_PROFILE_ZONE_SCOPED_N("gRenderer::drawTubeObliqueTrapezodial()");
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawTubeObliqueTrapezodial()");
+    gTube* tube = getTubeMesh(topouterradius, topinnerradious, buttomouterradious, buttominnerradious, h, shiftdistance, segmentnum, isFilled);
+
+    if (!tube) return;
+
+    tube->setPosition(x, y, z);
+    tube->setScale(scale.x, scale.y, scale.z);
+    tube->setOrientation(glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+    tube->draw();
+}
+
+void gRenderer::drawTubeObliqueTrapezodial(float x, float y, float z, int topouterradius, int topinnerradious, int buttomouterradious, int buttominnerradious, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled) {
+    G_PROFILE_ZONE_SCOPED_N("gRenderer::drawTubeObliqueTrapezodial()");
+    gTube* tube = getTubeMesh(topouterradius, topinnerradious, buttomouterradious, buttominnerradious, h, shiftdistance, segmentnum, isFilled);
+
+    if (!tube) return;
+
+    tube->setPosition(x, y, z);
+    tube->setScale(scale.x, scale.y, scale.z);
+
+    glm::vec3 axis(axisX, axisY, axisZ);
+    if (glm::length(axis) > 0.0f) {
+        axis = glm::normalize(axis);
+        tube->setOrientation(
+            glm::normalize(glm::angleAxis(rotateAngle, axis))
+        );
+    } else {
+        tube->setOrientation(glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+    }
+
+    tube->draw();
 }
 
 // --- Getter / Setter / Matrices ---

--- a/engine/core/gRenderer.h
+++ b/engine/core/gRenderer.h
@@ -96,18 +96,31 @@ void gDrawBox(float x, float y, float z, float w = 1.0f, float h = 1.0f, float d
 void gDrawBox(float x, float y, float z, float w, float h, float d, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 void gDrawBox(glm::mat4 transformationMatrix, bool isFilled = true);
 void gDrawSphere(float xPos, float yPos, float zPos, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int xSegmentNum = 64, int ySegmentNum = 32, bool isFilled = true);
+void gDrawSphere(float xPos, float yPos, float zPos, glm::vec3 scale, int xSegmentNum, int ySegmentNum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 void gDrawCylinder(float x, float y, float z, int r, int h, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int segmentnum = 32, bool isFilled = true);
+void gDrawCylinder(float x, float y, float z, int r, int h, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 void gDrawCylinderOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int segmentnum = 32, bool isFilled = true);
+void gDrawCylinderOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 void gDrawCylinderTrapezodial(float x, float y, float z, int r1, int r2, int h, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int segmentnum = 32, bool isFilled = true);
+void gDrawCylinderTrapezodial(float x, float y, float z, int r1, int r2, int h, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 void gDrawCylinderObliqueTrapezodial(float x, float y, float z, int r1, int r2, int h, glm::vec2 shiftdistance, glm::vec3 scale = glm::vec3(1.0, 1.0, 1.0), int segmentnum = 32, bool isFilled = true);
+void gDrawCylinderObliqueTrapezodial(float x, float y, float z, int r1, int r2, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 void gDrawCone(float x, float y, float z, int r, int h, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int segmentnum = 32, bool isFilled = true);
+void gDrawCone(float x, float y, float z, int r, int h, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 void gDrawConeOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int segmentnum = 32, bool isFilled = true);
+void gDrawConeOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 void gDrawPyramid(float x, float y, float z, int r, int h, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int numberofsides = 4, bool isFilled = true);
+void gDrawPyramid(float x, float y, float z, int r, int h, glm::vec3 scale, int numberofsides, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 void gDrawPyramidOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int numberofsides = 4, bool isFilled = true);
+void gDrawPyramidOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance, glm::vec3 scale, int numberofsides, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 void gDrawTube(float x, float y, float z, int outerradius,int innerradious, int h, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int segmentnum = 32, bool isFilled = true);
+void gDrawTube(float x, float y, float z, int outerradius, int innerradious, int h, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 void gDrawTubeOblique(float x, float y, float z, int outerradius,int innerradious, int h, glm::vec2 shiftdistance, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int segmentnum = 32, bool isFilled = true);
+void gDrawTubeOblique(float x, float y, float z, int outerradius, int innerradious, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 void gDrawTubeTrapezodial(float x, float y, float z, int topouterradius,int topinnerradious, int buttomouterradious, int buttominnerradious, int h, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int segmentnum = 32, bool isFilled = true);
+void gDrawTubeTrapezodial(float x, float y, float z, int topouterradius, int topinnerradious, int buttomouterradious, int buttominnerradious, int h, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 void gDrawTubeObliqueTrapezodial(float x, float y, float z, int topouterradius,int topinnerradious, int buttomouterradious, int buttominnerradious, int h, glm::vec2 shiftdistance, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int segmentnum = 32, bool isFilled = true);
+void gDrawTubeObliqueTrapezodial(float x, float y, float z, int topouterradius, int topinnerradious, int buttomouterradious, int buttominnerradious, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 
 class gVbo;
 class gFbo;
@@ -127,6 +140,10 @@ class gArc;
 class gRectangle;
 class gRoundedRectangle;
 class gBox;
+class gSphere;
+class gCylinder;
+class gCone;
+class gTube;
 //class gArrow;
 
 class gRenderer : public gObject {
@@ -654,18 +671,31 @@ public:
 	void drawBox(float x, float y, float z, float w, float h, float d, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 	void drawBox(glm::mat4 transformationMatrix, bool isFilled = true);
 	void drawSphere(float xPos, float yPos, float zPos, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int xSegmentNum = 64, int ySegmentNum = 32, bool isFilled = true);
+	void drawSphere(float xPos, float yPos, float zPos, glm::vec3 scale, int xSegmentNum, int ySegmentNum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 	void drawCylinder(float x, float y, float z, int r, int h, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int segmentnum = 32, bool isFilled = true);
+	void drawCylinder(float x, float y, float z, int r, int h, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 	void drawCylinderOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int segmentnum = 32, bool isFilled = true);
+	void drawCylinderOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 	void drawCylinderTrapezodial(float x, float y, float z, int r1, int r2, int h, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int segmentnum = 32, bool isFilled = true);
+	void drawCylinderTrapezodial(float x, float y, float z, int r1, int r2, int h, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 	void drawCylinderObliqueTrapezodial(float x, float y, float z, int r1, int r2, int h, glm::vec2 shiftdistance, glm::vec3 scale = glm::vec3(1.0, 1.0, 1.0), int segmentnum = 32, bool isFilled = true);
+	void drawCylinderObliqueTrapezodial(float x, float y, float z, int r1, int r2, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 	void drawCone(float x, float y, float z, int r, int h, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int segmentnum = 32, bool isFilled = true);
+	void drawCone(float x, float y, float z, int r, int h, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 	void drawConeOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int segmentnum = 32, bool isFilled = true);
+	void drawConeOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 	void drawPyramid(float x, float y, float z, int r, int h, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int numberofsides = 4, bool isFilled = true);
+	void drawPyramid(float x, float y, float z, int r, int h, glm::vec3 scale, int numberofsides, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 	void drawPyramidOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int numberofsides = 4, bool isFilled = true);
+	void drawPyramidOblique(float x, float y, float z, int r, int h, glm::vec2 shiftdistance, glm::vec3 scale, int numberofsides, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 	void drawTube(float x, float y, float z, int outerradius,int innerradious, int h, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int segmentnum = 32, bool isFilled = true);
+	void drawTube(float x, float y, float z, int outerradius, int innerradious, int h, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 	void drawTubeOblique(float x, float y, float z, int outerradius,int innerradious, int h, glm::vec2 shiftdistance, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int segmentnum = 32, bool isFilled = true);
+	void drawTubeOblique(float x, float y, float z, int outerradius, int innerradious, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 	void drawTubeTrapezodial(float x, float y, float z, int topouterradius,int topinnerradious, int buttomouterradious, int buttominnerradious, int h, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int segmentnum = 32, bool isFilled = true);
+	void drawTubeTrapezodial(float x, float y, float z, int topouterradius, int topinnerradious, int buttomouterradious, int buttominnerradious, int h, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 	void drawTubeObliqueTrapezodial(float x, float y, float z, int topouterradius,int topinnerradious, int buttomouterradious, int buttominnerradious, int h, glm::vec2 shiftdistance, glm::vec3 scale = glm::vec3(1.0f, 1.0f, 1.0f), int segmentnum = 32, bool isFilled = true);
+	void drawTubeObliqueTrapezodial(float x, float y, float z, int topouterradius, int topinnerradious, int buttomouterradious, int buttominnerradious, int h, glm::vec2 shiftdistance, glm::vec3 scale, int segmentnum, float rotateAngle, float axisX, float axisY, float axisZ, bool isFilled = true);
 
 protected:
 	friend class gRenderObject;
@@ -767,6 +797,93 @@ protected:
 	std::unique_ptr<gRectangle> rectanglemesh;
 	std::unique_ptr<gRoundedRectangle> roundedrectanglemesh;
 	std::unique_ptr<gBox> boxmesh;
+	std::unique_ptr<gBox> boxlinemesh;
+
+
+	// ---------------- SPHERE CACHE ----------------
+	struct SphereMeshCacheEntry {
+		int xSegmentNum;
+		int ySegmentNum;
+		bool isFilled;
+		std::unique_ptr<gSphere> mesh;
+	};
+
+	std::vector<SphereMeshCacheEntry> spheremeshcache;
+
+	gSphere* getSphereMesh(
+			int xSegmentNum,
+			int ySegmentNum,
+			bool isFilled
+	);
+
+	// ---------------- CYLINDER CACHE ----------------
+	struct CylinderMeshCacheEntry {
+		int r1;
+		int r2;
+		int h;
+		glm::vec2 shiftdistance;
+		int segmentnum;
+		bool isFilled;
+		std::unique_ptr<gCylinder> mesh;
+	};
+
+	std::vector<CylinderMeshCacheEntry> cylindermeshcache;
+
+	gCylinder* getCylinderMesh(
+			int r1,
+			int r2,
+			int h,
+			const glm::vec2& shiftdistance,
+			int segmentnum,
+			bool isFilled
+	);
+
+	// ---------------- CONE CACHE ----------------
+	struct ConeMeshCacheEntry {
+		int r;
+		int h;
+		glm::vec2 shiftdistance;
+		int segmentnum;
+		bool isFilled;
+		std::unique_ptr<gCone> mesh;
+	};
+
+	std::vector<ConeMeshCacheEntry> conemeshcache;
+
+	gCone* getConeMesh(
+			int r,
+			int h,
+			const glm::vec2& shiftdistance,
+			int segmentnum,
+			bool isFilled
+	);
+
+	// ---------------- TUBE CACHE ----------------
+	struct TubeMeshCacheEntry {
+		int topOuterRadius;
+		int topInnerRadius;
+		int bottomOuterRadius;
+		int bottomInnerRadius;
+		int h;
+		glm::vec2 shiftdistance;
+		int segmentnum;
+		bool isFilled;
+		std::unique_ptr<gTube> mesh;
+	};
+
+	std::vector<TubeMeshCacheEntry> tubemeshcache;
+
+	gTube* getTubeMesh(
+			int topOuterRadius,
+			int topInnerRadius,
+			int bottomOuterRadius,
+			int bottomInnerRadius,
+			int h,
+			const glm::vec2& shiftdistance,
+			int segmentnum,
+			bool isFilled
+	);
+
 	//std::unique_ptr<gArrow> arrowmesh;
 
 	virtual void init();

--- a/engine/graphics/gMesh.cpp
+++ b/engine/graphics/gMesh.cpp
@@ -65,7 +65,6 @@ const std::string& gMesh::getName() const {
 	return name;
 }
 
-
 void gMesh::setVertices(const std::vector<gVertex>& vertices, const std::vector<gIndex>& indices) {
 	this->setVertices(std::make_shared<std::vector<gVertex>>(vertices), std::make_shared<std::vector<gIndex>>(indices));
 }
@@ -186,8 +185,12 @@ void gMesh::draw() {
 	if (!isenabled) return;
 
 	if (renderer->isVulkan()) {
-		if (isprojection2d) drawVulkan2D();
-		else drawVulkan3D();
+		if (isprojection2d) {
+			drawVulkan2D();
+		} else {
+			processTransformationMatrix();
+			drawVulkan3D();
+		}
 		// A material can carry extra shaders, and on OpenGL the mesh is drawn again
 		// once per shader below. That cannot be honoured here - see the note above
 		// gvkReportNoUserShaders in gVKRenderEngine.cpp for why a gShader has no

--- a/engine/graphics/primitives/gBox.cpp
+++ b/engine/graphics/primitives/gBox.cpp
@@ -7,8 +7,79 @@
 
 #include <gBox.h>
 
-gBox::gBox() {
+gBox::gBox(bool isFilled) {
 
+	if (!isFilled) {
+		// ---------------------------------------------------------
+		// WIREFRAME BOX
+		//
+		// Use 8 unique corners and the 12 real box edges.
+		// This avoids the diagonal lines that would appear if the
+		// filled triangle index buffer were simply rendered as lines.
+		// ---------------------------------------------------------
+		const glm::vec3 corners[] = {
+			glm::vec3(-1.0f,  1.0f, -1.0f), // 0
+			glm::vec3( 1.0f,  1.0f, -1.0f), // 1
+			glm::vec3(-1.0f, -1.0f, -1.0f), // 2
+			glm::vec3( 1.0f, -1.0f, -1.0f), // 3
+			glm::vec3(-1.0f,  1.0f,  1.0f), // 4
+			glm::vec3( 1.0f,  1.0f,  1.0f), // 5
+			glm::vec3(-1.0f, -1.0f,  1.0f), // 6
+			glm::vec3( 1.0f, -1.0f,  1.0f)  // 7
+		};
+
+		const unsigned int lineindices[] = {
+			// back rectangle
+			0, 1,
+			1, 3,
+			3, 2,
+			2, 0,
+
+			// front rectangle
+			4, 5,
+			5, 7,
+			7, 6,
+			6, 4,
+
+			// connections
+			0, 4,
+			1, 5,
+			2, 6,
+			3, 7
+		};
+
+		std::vector<gVertex> verticesb;
+		verticesb.reserve(8);
+
+		for (const glm::vec3& corner : corners) {
+			gVertex v{};
+			v.position = corner;
+			v.color = glm::vec3(1.0f);
+			verticesb.push_back(v);
+		}
+
+		std::vector<gIndex> indicesb;
+		indicesb.reserve(sizeof(lineindices) / sizeof(lineindices[0]));
+
+		for (unsigned int index : lineindices) {
+			indicesb.push_back(static_cast<gIndex>(index));
+		}
+
+		auto verticesptr =
+			std::make_shared<std::vector<gVertex>>(verticesb);
+
+		auto indicesptr =
+			std::make_shared<std::vector<gIndex>>(indicesb);
+
+		setVertices(verticesptr, indicesptr);
+		setDrawMode(GL_LINES);
+		return;
+	}
+
+
+	// ---------------------------------------------------------
+	// FILLED BOX
+	// ---------------------------------------------------------
 	float vertexdata[]= {
 	    // x,   y,   z,  s,  t,
 		-1.0f,  1.0f, -1.0f, 1.0f, 0.0f, // Back
@@ -47,21 +118,21 @@ gBox::gBox() {
 	    -1.0f, -1.0f,  1.0f,
 	     1.0f, -1.0f,  1.0f,
 	    -1.0f,  1.0f, -1.0f, // Left
-	    -1.0f,  -1.0f,  -1.0f,
-	    -1.0f, -1.0f, 1.0f,
-	    -1.0f, 1.0f,  1.0f,
-	     1.0f,  1.0f,  -1.0f, // Right
-	     1.0f,  -1.0f, -1.0f,
-	     1.0f, -1.0f,  1.0f,
-	     1.0f, 1.0f, 1.0f,
-	    -1.0f, -1.0f,  -1.0f, // Top
+	    -1.0f, -1.0f, -1.0f,
 	    -1.0f, -1.0f,  1.0f,
-	     1.0f, -1.0f, 1.0f,
+	    -1.0f,  1.0f,  1.0f,
+	     1.0f,  1.0f, -1.0f, // Right
+	     1.0f, -1.0f, -1.0f,
+	     1.0f, -1.0f,  1.0f,
+	     1.0f,  1.0f,  1.0f,
+	    -1.0f, -1.0f, -1.0f, // Top
+	    -1.0f, -1.0f,  1.0f,
+	     1.0f, -1.0f,  1.0f,
 	     1.0f, -1.0f, -1.0f,
 	    -1.0f,  1.0f, -1.0f, // Bottom
-	    -1.0f,  1.0f, 1.0f,
+	    -1.0f,  1.0f,  1.0f,
 	     1.0f,  1.0f,  1.0f,
-	     1.0f,  1.0f,  -1.0f
+	     1.0f,  1.0f, -1.0f
 	};
 
 
@@ -89,8 +160,8 @@ gBox::gBox() {
 
 	int nv = (sizeof(vertexdata) / sizeof(vertexdata[0])) / 5;
 	std::vector<gVertex> verticesb;
-	for (int i=0; i<nv; i++) {
-		gVertex v;
+	for (int i = 0; i < nv; i++) {
+		gVertex v{};
 		v.position.x = vertexdata[(i * 5)];
 		v.position.y = vertexdata[(i * 5) + 1];
 		v.position.z = vertexdata[(i * 5) + 2];
@@ -99,20 +170,25 @@ gBox::gBox() {
 		v.normal.x = normaldata[(i * 3)];
 		v.normal.y = normaldata[(i * 3) + 1];
 		v.normal.z = normaldata[(i * 3) + 2];
+		v.color = glm::vec3(1.0f);
 		verticesb.push_back(v);
 	}
 
 	int ni = sizeof(indexdata) / sizeof(indexdata[0]);
 	std::vector<gIndex> indicesb;
-	for (int i=0; i<ni; i++) {
+	for (int i = 0; i < ni; i++) {
 		indicesb.push_back(indexdata[i]);
 	}
 
-	auto verticesptr = std::make_shared<std::vector<gVertex>>(verticesb);
-	auto indicesptr = std::make_shared<std::vector<gIndex>>(indicesb);
+	auto verticesptr =
+		std::make_shared<std::vector<gVertex>>(verticesb);
+
+	auto indicesptr =
+		std::make_shared<std::vector<gIndex>>(indicesb);
+
 	setVertices(verticesptr, indicesptr);
+	setDrawMode(gMesh::DRAWMODE_TRIANGLES);
 }
 
 gBox::~gBox() {
 }
-

--- a/engine/graphics/primitives/gBox.h
+++ b/engine/graphics/primitives/gBox.h
@@ -29,7 +29,7 @@
 
 class gBox : public gMesh {
 public:
-	gBox();
+	explicit gBox(bool isFilled = true);
 	~gBox() override;
 };
 

--- a/engine/graphics/primitives/gCone.cpp
+++ b/engine/graphics/primitives/gCone.cpp
@@ -8,41 +8,194 @@
 #include "gCone.h"
 
 gCone::gCone(int r, int h, glm::vec2 shiftdistance, int segmentnum, bool isFilled) {
-	std::vector<gIndex> indicesb;
-	std::vector<gVertex> verticesb;
 
-	float angle = PI * 2 / segmentnum;
-	for(int i = 0; i < segmentnum; i++) {
-		//BOTTOM
-		gVertex v;
-		v.position.x = r * cos(angle * i);
-		v.position.y = -h / 2;
-		v.position.z = r * sin(angle * i);
-		verticesb.push_back(v);
-	}
+    if (segmentnum < 3) {
+        segmentnum = 3;
+    }
 
-	//TOP VERTEX
-	gVertex v;
-	v.position.x = shiftdistance.x;
-	v.position.y = h / 2;
-	v.position.z = shiftdistance.y;
-	verticesb.push_back(v);
+    const float halfH = static_cast<float>(h) * 0.5f;
+    const float angleStep = PI * 2.0f / static_cast<float>(segmentnum);
 
-	for(int i = 0; i < segmentnum; i++) {
-		indicesb.push_back(i);
-		indicesb.push_back(segmentnum);
-		indicesb.push_back(i + 1);
-		indicesb.push_back(i);
-	}
+    std::vector<gVertex> vertices;
+    std::vector<gIndex> indices;
 
-	auto verticesptr = std::make_shared<std::vector<gVertex>>(verticesb);
-	auto indicesptr = std::make_shared<std::vector<gIndex>>(indicesb);
-	setVertices(verticesptr, indicesptr);
-	if(!isFilled) setDrawMode(gMesh::DRAWMODE_LINELOOP);
-	else setDrawMode(gMesh::DRAWMODE_TRIANGLEFAN);
+    const glm::vec3 apex(
+        shiftdistance.x,
+        halfH,
+        shiftdistance.y
+    );
+
+    if (isFilled) {
+
+        // =========================================================
+        // SIDE FACES
+        //
+        // Each side face gets its own vertices so a low-sided cone
+        // (for example gPyramid with 4 sides) keeps flat face normals.
+        // With many segments the cone still appears visually smooth.
+        // =========================================================
+
+        for (int i = 0; i < segmentnum; ++i) {
+
+            const int next = (i + 1) % segmentnum;
+
+            const float a0 = angleStep * static_cast<float>(i);
+            const float a1 = angleStep * static_cast<float>(next);
+
+            const glm::vec3 bottom0(
+                static_cast<float>(r) * std::cos(a0),
+                -halfH,
+                static_cast<float>(r) * std::sin(a0)
+            );
+
+            const glm::vec3 bottom1(
+                static_cast<float>(r) * std::cos(a1),
+                -halfH,
+                static_cast<float>(r) * std::sin(a1)
+            );
+
+            // Triangle winding: bottom0 -> apex -> bottom1.
+            glm::vec3 normal = glm::cross(
+                apex - bottom0,
+                bottom1 - bottom0
+            );
+
+            if (glm::length(normal) > 0.0f) {
+                normal = glm::normalize(normal);
+            } else {
+                normal = glm::vec3(
+                    std::cos(a0),
+                    0.0f,
+                    std::sin(a0)
+                );
+            }
+
+            const gIndex base = static_cast<gIndex>(vertices.size());
+
+            gVertex v0{};
+            v0.position = bottom0;
+            v0.normal = normal;
+            v0.color = glm::vec3(1.0f);
+
+            gVertex v1{};
+            v1.position = apex;
+            v1.normal = normal;
+            v1.color = glm::vec3(1.0f);
+
+            gVertex v2{};
+            v2.position = bottom1;
+            v2.normal = normal;
+            v2.color = glm::vec3(1.0f);
+
+            vertices.push_back(v0);
+            vertices.push_back(v1);
+            vertices.push_back(v2);
+
+            indices.push_back(base);
+            indices.push_back(base + 1);
+            indices.push_back(base + 2);
+        }
+
+        // =========================================================
+        // BOTTOM CAP
+        // =========================================================
+
+        const gIndex bottomCenterIndex =
+            static_cast<gIndex>(vertices.size());
+
+        gVertex center{};
+        center.position = glm::vec3(0.0f, -halfH, 0.0f);
+        center.normal = glm::vec3(0.0f, -1.0f, 0.0f);
+        center.color = glm::vec3(1.0f);
+        vertices.push_back(center);
+
+        const gIndex bottomRingStart =
+            static_cast<gIndex>(vertices.size());
+
+        for (int i = 0; i < segmentnum; ++i) {
+
+            const float a = angleStep * static_cast<float>(i);
+
+            gVertex v{};
+            v.position = glm::vec3(
+                static_cast<float>(r) * std::cos(a),
+                -halfH,
+                static_cast<float>(r) * std::sin(a)
+            );
+            v.normal = glm::vec3(0.0f, -1.0f, 0.0f);
+            v.color = glm::vec3(1.0f);
+
+            vertices.push_back(v);
+        }
+
+        for (int i = 0; i < segmentnum; ++i) {
+
+            const int next = (i + 1) % segmentnum;
+
+            indices.push_back(bottomCenterIndex);
+            indices.push_back(
+                bottomRingStart + static_cast<gIndex>(i)
+            );
+            indices.push_back(
+                bottomRingStart + static_cast<gIndex>(next)
+            );
+        }
+
+        setDrawMode(gMesh::DRAWMODE_TRIANGLES);
+    }
+
+    else {
+
+        // =========================================================
+        // WIREFRAME
+        // =========================================================
+
+        for (int i = 0; i < segmentnum; ++i) {
+
+            const float a = angleStep * static_cast<float>(i);
+
+            gVertex v{};
+            v.position = glm::vec3(
+                static_cast<float>(r) * std::cos(a),
+                -halfH,
+                static_cast<float>(r) * std::sin(a)
+            );
+            v.color = glm::vec3(1.0f);
+
+            vertices.push_back(v);
+        }
+
+        const gIndex apexIndex =
+            static_cast<gIndex>(vertices.size());
+
+        gVertex apexVertex{};
+        apexVertex.position = apex;
+        apexVertex.color = glm::vec3(1.0f);
+        vertices.push_back(apexVertex);
+
+        for (int i = 0; i < segmentnum; ++i) {
+
+            const int next = (i + 1) % segmentnum;
+
+            indices.push_back(static_cast<gIndex>(i));
+            indices.push_back(static_cast<gIndex>(next));
+
+            indices.push_back(static_cast<gIndex>(i));
+            indices.push_back(apexIndex);
+        }
+
+        setDrawMode(GL_LINES);
+    }
+
+    auto verticesptr =
+        std::make_shared<std::vector<gVertex>>(vertices);
+
+    auto indicesptr =
+        std::make_shared<std::vector<gIndex>>(indices);
+
+    setVertices(verticesptr, indicesptr);
 }
 
 gCone::~gCone() {
 
 }
-

--- a/engine/graphics/primitives/gCylinder.cpp
+++ b/engine/graphics/primitives/gCylinder.cpp
@@ -7,43 +7,320 @@
 
 #include "gCylinder.h"
 
-gCylinder::gCylinder(int r1, int r2, int h, glm::vec2 shiftdistance, int segmentnum, bool isFilled) {
 
-	std::vector<gIndex> indicesb;
-	std::vector<gVertex> verticesb;
+gCylinder::gCylinder(
+        int r1,
+        int r2,
+        int h,
+        glm::vec2 shiftdistance,
+        int segmentnum,
+        bool isFilled) {
 
-	float angle = PI * 2 / segmentnum;
-	for(int i = 0; i < segmentnum; i++) {
-		//TOP
-		gVertex v;
-		v.position.x = shiftdistance.x + r1 * cos(angle * i);
-		v.position.y = h / 2;
-		v.position.z = shiftdistance.y + r1 * sin(angle * i);
-		verticesb.push_back(v);
-	}
+    if (segmentnum < 3) {
+        segmentnum = 3;
+    }
 
-	for(int i = 0; i < segmentnum; i++) {
-		//BOTTOM
-		gVertex v;
-		v.position.x = -shiftdistance.x + r2 * cos(angle * i);
-		v.position.y = -h / 2;
-		v.position.z = -shiftdistance.y + r2 * sin(angle * i);
-		verticesb.push_back(v);
-	}
+    std::vector<gVertex> verticesb;
+    std::vector<gIndex> indicesb;
 
-	for(int i = 0; i < segmentnum - 1; i++) {
-		indicesb.push_back(i);
-		indicesb.push_back(i + segmentnum);
-		indicesb.push_back(i + segmentnum + 1);
-		indicesb.push_back(i + 1);
-		indicesb.push_back(i);
-	}
+    const float halfH = static_cast<float>(h) * 0.5f;
+    const float angleStep = PI * 2.0f / static_cast<float>(segmentnum);
 
-	auto verticesptr = std::make_shared<std::vector<gVertex>>(verticesb);
-	auto indicesptr = std::make_shared<std::vector<gIndex>>(indicesb);
-	setVertices(verticesptr, indicesptr);
-	if(!isFilled) setDrawMode(gMesh::DRAWMODE_LINELOOP);
-	else setDrawMode(gMesh::DRAWMODE_TRIANGLEFAN);
+    // Bottom center -> top center displacement.
+    const float dx = 2.0f * shiftdistance.x;
+    const float dz = 2.0f * shiftdistance.y;
+
+    // Radius change from bottom to top.
+    const float dr = static_cast<float>(r1 - r2);
+
+    /*
+     * SIDE VERTICES
+     *
+     * 0 ... segmentnum - 1
+     *      top ring
+     *
+     * segmentnum ... segmentnum * 2 - 1
+     *      bottom ring
+     */
+
+    for (int i = 0; i < segmentnum; i++) {
+
+        const float angle = angleStep * static_cast<float>(i);
+        const float c = std::cos(angle);
+        const float s = std::sin(angle);
+
+        glm::vec3 sideNormal(
+            static_cast<float>(h) * c,
+            -(dx * c + dz * s + dr),
+            static_cast<float>(h) * s
+        );
+
+        if (glm::length(sideNormal) > 0.0f) {
+            sideNormal = glm::normalize(sideNormal);
+        }
+
+        gVertex top{};
+
+        top.position.x = shiftdistance.x + r1 * c;
+        top.position.y = halfH;
+        top.position.z = shiftdistance.y + r1 * s;
+
+        top.normal = sideNormal;
+        top.color = glm::vec3(1.0f);
+
+        verticesb.push_back(top);
+    }
+
+
+    for (int i = 0; i < segmentnum; i++) {
+
+        const float angle = angleStep * static_cast<float>(i);
+        const float c = std::cos(angle);
+        const float s = std::sin(angle);
+
+        glm::vec3 sideNormal(
+            static_cast<float>(h) * c,
+            -(dx * c + dz * s + dr),
+            static_cast<float>(h) * s
+        );
+
+        if (glm::length(sideNormal) > 0.0f) {
+            sideNormal = glm::normalize(sideNormal);
+        }
+
+        gVertex bottom{};
+
+        bottom.position.x = -shiftdistance.x + r2 * c;
+        bottom.position.y = -halfH;
+        bottom.position.z = -shiftdistance.y + r2 * s;
+
+        bottom.normal = sideNormal;
+        bottom.color = glm::vec3(1.0f);
+
+        verticesb.push_back(bottom);
+    }
+
+
+    if (isFilled) {
+
+        // =========================================================
+        // SIDE TRIANGLES
+        // =========================================================
+
+        for (int i = 0; i < segmentnum; i++) {
+
+            const int next = (i + 1) % segmentnum;
+
+            const gIndex topCurrent =
+                static_cast<gIndex>(i);
+
+            const gIndex topNext =
+                static_cast<gIndex>(next);
+
+            const gIndex bottomCurrent =
+                static_cast<gIndex>(segmentnum + i);
+
+            const gIndex bottomNext =
+                static_cast<gIndex>(segmentnum + next);
+
+
+            indicesb.push_back(topCurrent);
+            indicesb.push_back(bottomCurrent);
+            indicesb.push_back(bottomNext);
+
+            indicesb.push_back(topCurrent);
+            indicesb.push_back(bottomNext);
+            indicesb.push_back(topNext);
+        }
+
+
+        // =========================================================
+        // TOP CAP
+        // =========================================================
+
+        const gIndex topCenterIndex =
+            static_cast<gIndex>(verticesb.size());
+
+        gVertex topCenter{};
+
+        topCenter.position =
+            glm::vec3(
+                shiftdistance.x,
+                halfH,
+                shiftdistance.y
+            );
+
+        topCenter.normal =
+            glm::vec3(0.0f, 1.0f, 0.0f);
+
+        topCenter.color =
+            glm::vec3(1.0f);
+
+        verticesb.push_back(topCenter);
+
+
+        const gIndex topRingStart =
+            static_cast<gIndex>(verticesb.size());
+
+        for (int i = 0; i < segmentnum; i++) {
+
+            const float angle =
+                angleStep * static_cast<float>(i);
+
+            const float c = std::cos(angle);
+            const float s = std::sin(angle);
+
+            gVertex v{};
+
+            v.position =
+                glm::vec3(
+                    shiftdistance.x + r1 * c,
+                    halfH,
+                    shiftdistance.y + r1 * s
+                );
+
+            v.normal =
+                glm::vec3(0.0f, 1.0f, 0.0f);
+
+            v.color =
+                glm::vec3(1.0f);
+
+            verticesb.push_back(v);
+        }
+
+
+        for (int i = 0; i < segmentnum; i++) {
+
+            const int next = (i + 1) % segmentnum;
+
+            indicesb.push_back(topCenterIndex);
+            indicesb.push_back(
+                topRingStart +
+                static_cast<gIndex>(next)
+            );
+            indicesb.push_back(
+                topRingStart +
+                static_cast<gIndex>(i)
+            );
+        }
+
+
+        // =========================================================
+        // BOTTOM CAP
+        // =========================================================
+
+        const gIndex bottomCenterIndex =
+            static_cast<gIndex>(verticesb.size());
+
+        gVertex bottomCenter{};
+
+        bottomCenter.position =
+            glm::vec3(
+                -shiftdistance.x,
+                -halfH,
+                -shiftdistance.y
+            );
+
+        bottomCenter.normal =
+            glm::vec3(0.0f, -1.0f, 0.0f);
+
+        bottomCenter.color =
+            glm::vec3(1.0f);
+
+        verticesb.push_back(bottomCenter);
+
+
+        const gIndex bottomRingStart =
+            static_cast<gIndex>(verticesb.size());
+
+        for (int i = 0; i < segmentnum; i++) {
+
+            const float angle =
+                angleStep * static_cast<float>(i);
+
+            const float c = std::cos(angle);
+            const float s = std::sin(angle);
+
+            gVertex v{};
+
+            v.position =
+                glm::vec3(
+                    -shiftdistance.x + r2 * c,
+                    -halfH,
+                    -shiftdistance.y + r2 * s
+                );
+
+            v.normal =
+                glm::vec3(0.0f, -1.0f, 0.0f);
+
+            v.color =
+                glm::vec3(1.0f);
+
+            verticesb.push_back(v);
+        }
+
+
+        for (int i = 0; i < segmentnum; i++) {
+
+            const int next = (i + 1) % segmentnum;
+
+            indicesb.push_back(bottomCenterIndex);
+            indicesb.push_back(
+                bottomRingStart +
+                static_cast<gIndex>(i)
+            );
+            indicesb.push_back(
+                bottomRingStart +
+                static_cast<gIndex>(next)
+            );
+        }
+
+        setDrawMode(gMesh::DRAWMODE_TRIANGLES);
+    }
+
+    else {
+
+        // =========================================================
+        // WIREFRAME
+        // =========================================================
+
+        for (int i = 0; i < segmentnum; i++) {
+
+            const int next = (i + 1) % segmentnum;
+
+            const gIndex topCurrent =
+                static_cast<gIndex>(i);
+
+            const gIndex topNext =
+                static_cast<gIndex>(next);
+
+            const gIndex bottomCurrent =
+                static_cast<gIndex>(segmentnum + i);
+
+            const gIndex bottomNext =
+                static_cast<gIndex>(segmentnum + next);
+
+
+            indicesb.push_back(topCurrent);
+            indicesb.push_back(topNext);
+
+            indicesb.push_back(bottomCurrent);
+            indicesb.push_back(bottomNext);
+
+            indicesb.push_back(topCurrent);
+            indicesb.push_back(bottomCurrent);
+        }
+
+        setDrawMode(GL_LINES);
+    }
+
+    auto verticesptr =
+        std::make_shared<std::vector<gVertex>>(verticesb);
+
+    auto indicesptr =
+        std::make_shared<std::vector<gIndex>>(indicesb);
+
+    setVertices(verticesptr, indicesptr);
 }
 
 gCylinder::~gCylinder() {

--- a/engine/graphics/primitives/gTube.cpp
+++ b/engine/graphics/primitives/gTube.cpp
@@ -4,98 +4,384 @@
  *  Created on: 14 Tem 2023
  *      Author: Aak-4
  */
+
 #include "gTube.h"
 
-gTube::gTube(int topOuterRadius, int topInnerRadius, int bottomOuterRadius, int bottomInnerRadius, int h, glm::vec2 shiftdistance, int segmentnum, bool isFilled) {
+gTube::gTube(
+        int topOuterRadius,
+        int topInnerRadius,
+        int bottomOuterRadius,
+        int bottomInnerRadius,
+        int h,
+        glm::vec2 shiftdistance,
+        int segmentnum,
+        bool isFilled) {
 
-    const float angle = 2 * PI / segmentnum;
+    if (segmentnum < 3) {
+        segmentnum = 3;
+    }
+
+    const float halfH = static_cast<float>(h) * 0.5f;
+    const float angleStep = 2.0f * PI / static_cast<float>(segmentnum);
+
+    const float dx = 2.0f * shiftdistance.x;
+    const float dz = 2.0f * shiftdistance.y;
+
+    const float outerDr =
+        static_cast<float>(topOuterRadius - bottomOuterRadius);
+
+    const float innerDr =
+        static_cast<float>(topInnerRadius - bottomInnerRadius);
 
     std::vector<gVertex> vertices;
     std::vector<gIndex> indices;
-    for (int i = 0; i < segmentnum; i++)
-    {
-        // Top outer circle vertex
-        gVertex vTopOuter;
-        vTopOuter.position.x = shiftdistance.x + topOuterRadius * cos(angle * i);
-        vTopOuter.position.y = h / 2;
-        vTopOuter.position.z = shiftdistance.y + topOuterRadius * sin(angle * i);
-        vertices.push_back(vTopOuter);
-        // Top inner circle vertex
-        gVertex vTopInner;
-        vTopInner.position.x = shiftdistance.x + topInnerRadius * cos(angle * i);
-        vTopInner.position.y = h / 2;
-        vTopInner.position.z = shiftdistance.y + topInnerRadius * sin(angle * i);
-        vertices.push_back(vTopInner);
-        // Bottom outer circle vertex
-        gVertex vBottomOuter;
-        vBottomOuter.position.x = -shiftdistance.x + bottomOuterRadius * cos(angle * i);
-        vBottomOuter.position.y = -h / 2;
-        vBottomOuter.position.z = -shiftdistance.y + bottomOuterRadius * sin(angle * i);
-        vertices.push_back(vBottomOuter);
-        // Bottom inner circle vertex
-        gVertex vBottomInner;
-        vBottomInner.position.x = -shiftdistance.x + bottomInnerRadius * cos(angle * i);
-        vBottomInner.position.y = -h / 2;
-        vBottomInner.position.z = -shiftdistance.y + bottomInnerRadius * sin(angle * i);
-        vertices.push_back(vBottomInner);
-    }
 
 
+    if (isFilled) {
 
-    for (int i = 0; i < segmentnum; i++)
-    {
-        int baseIndex = i * 4;
+        // =========================================================
+        // TOP ANNULUS
+        // Separate vertices are required because the top face uses
+        // +Y normals while the walls use radial/sloped normals.
+        // =========================================================
 
-        // First triangle
-        indices.push_back(baseIndex);
-        indices.push_back(baseIndex + 1);
-        indices.push_back((baseIndex + 4) % (segmentnum * 4));
+        const gIndex topFaceStart =
+            static_cast<gIndex>(vertices.size());
 
-        // Second triangle
-        indices.push_back(baseIndex + 1);
-        indices.push_back((baseIndex + 5) % (segmentnum * 4));
-        indices.push_back((baseIndex + 4) % (segmentnum * 4));
+        for (int i = 0; i < segmentnum; ++i) {
+
+            const float a = angleStep * static_cast<float>(i);
+            const float c = std::cos(a);
+            const float s = std::sin(a);
+
+            gVertex outer{};
+            outer.position = glm::vec3(
+                shiftdistance.x + topOuterRadius * c,
+                halfH,
+                shiftdistance.y + topOuterRadius * s
+            );
+            outer.normal = glm::vec3(0.0f, 1.0f, 0.0f);
+            outer.color = glm::vec3(1.0f);
+
+            gVertex inner{};
+            inner.position = glm::vec3(
+                shiftdistance.x + topInnerRadius * c,
+                halfH,
+                shiftdistance.y + topInnerRadius * s
+            );
+            inner.normal = glm::vec3(0.0f, 1.0f, 0.0f);
+            inner.color = glm::vec3(1.0f);
+
+            vertices.push_back(outer);
+            vertices.push_back(inner);
+        }
+
+        for (int i = 0; i < segmentnum; ++i) {
+
+            const int next = (i + 1) % segmentnum;
+
+            const gIndex o0 = topFaceStart + static_cast<gIndex>(i * 2);
+            const gIndex i0 = o0 + 1;
+
+            const gIndex o1 = topFaceStart + static_cast<gIndex>(next * 2);
+            const gIndex i1 = o1 + 1;
+
+            indices.push_back(o0);
+            indices.push_back(o1);
+            indices.push_back(i0);
+
+            indices.push_back(i0);
+            indices.push_back(o1);
+            indices.push_back(i1);
+        }
 
 
-        // Top circle
-        indices.push_back(baseIndex + 2);
-        indices.push_back(baseIndex);
-        indices.push_back((baseIndex + 4) % (segmentnum * 4));
+        // =========================================================
+        // BOTTOM ANNULUS
+        // =========================================================
 
-        indices.push_back((baseIndex + 2) % (segmentnum * 4));
-        indices.push_back((baseIndex + 4) % (segmentnum * 4));
-        indices.push_back((baseIndex + 6) % (segmentnum * 4));
+        const gIndex bottomFaceStart =
+            static_cast<gIndex>(vertices.size());
 
-        // Bottom circle
-        indices.push_back((baseIndex + 3) % (segmentnum * 4));
-        indices.push_back(baseIndex + 1);
-        indices.push_back((baseIndex + 5) % (segmentnum * 4));
+        for (int i = 0; i < segmentnum; ++i) {
 
-        indices.push_back((baseIndex + 7) % (segmentnum * 4));
-        indices.push_back((baseIndex + 5) % (segmentnum * 4));
-        indices.push_back((baseIndex + 3) % (segmentnum * 4));
+            const float a = angleStep * static_cast<float>(i);
+            const float c = std::cos(a);
+            const float s = std::sin(a);
 
-    }
+            gVertex outer{};
+            outer.position = glm::vec3(
+                -shiftdistance.x + bottomOuterRadius * c,
+                -halfH,
+                -shiftdistance.y + bottomOuterRadius * s
+            );
+            outer.normal = glm::vec3(0.0f, -1.0f, 0.0f);
+            outer.color = glm::vec3(1.0f);
 
-    // Set the vertices and indices for the gMesh
-    auto verticesptr = std::make_shared<std::vector<gVertex>>(vertices);
-    auto indicesptr = std::make_shared<std::vector<gIndex>>(indices);
-    setVertices(verticesptr, indicesptr);
+            gVertex inner{};
+            inner.position = glm::vec3(
+                -shiftdistance.x + bottomInnerRadius * c,
+                -halfH,
+                -shiftdistance.y + bottomInnerRadius * s
+            );
+            inner.normal = glm::vec3(0.0f, -1.0f, 0.0f);
+            inner.color = glm::vec3(1.0f);
 
-    // Set the draw mode based on whether the tube is filled or not
-    if (!isFilled)
-        setDrawMode(gMesh::DRAWMODE_LINELOOP);
-    else
+            vertices.push_back(outer);
+            vertices.push_back(inner);
+        }
+
+        for (int i = 0; i < segmentnum; ++i) {
+
+            const int next = (i + 1) % segmentnum;
+
+            const gIndex o0 = bottomFaceStart + static_cast<gIndex>(i * 2);
+            const gIndex i0 = o0 + 1;
+
+            const gIndex o1 = bottomFaceStart + static_cast<gIndex>(next * 2);
+            const gIndex i1 = o1 + 1;
+
+            indices.push_back(o0);
+            indices.push_back(i0);
+            indices.push_back(o1);
+
+            indices.push_back(i0);
+            indices.push_back(i1);
+            indices.push_back(o1);
+        }
+
+
+        // =========================================================
+        // OUTER WALL
+        // =========================================================
+
+        const gIndex outerWallStart =
+            static_cast<gIndex>(vertices.size());
+
+        for (int i = 0; i < segmentnum; ++i) {
+
+            const float a = angleStep * static_cast<float>(i);
+            const float c = std::cos(a);
+            const float s = std::sin(a);
+
+            glm::vec3 normal(
+                static_cast<float>(h) * c,
+                -(dx * c + dz * s + outerDr),
+                static_cast<float>(h) * s
+            );
+
+            if (glm::length(normal) > 0.0f) {
+                normal = glm::normalize(normal);
+            }
+
+            gVertex top{};
+            top.position = glm::vec3(
+                shiftdistance.x + topOuterRadius * c,
+                halfH,
+                shiftdistance.y + topOuterRadius * s
+            );
+            top.normal = normal;
+            top.color = glm::vec3(1.0f);
+
+            gVertex bottom{};
+            bottom.position = glm::vec3(
+                -shiftdistance.x + bottomOuterRadius * c,
+                -halfH,
+                -shiftdistance.y + bottomOuterRadius * s
+            );
+            bottom.normal = normal;
+            bottom.color = glm::vec3(1.0f);
+
+            vertices.push_back(top);
+            vertices.push_back(bottom);
+        }
+
+        for (int i = 0; i < segmentnum; ++i) {
+
+            const int next = (i + 1) % segmentnum;
+
+            const gIndex t0 = outerWallStart + static_cast<gIndex>(i * 2);
+            const gIndex b0 = t0 + 1;
+
+            const gIndex t1 = outerWallStart + static_cast<gIndex>(next * 2);
+            const gIndex b1 = t1 + 1;
+
+            indices.push_back(t0);
+            indices.push_back(b0);
+            indices.push_back(b1);
+
+            indices.push_back(t0);
+            indices.push_back(b1);
+            indices.push_back(t1);
+        }
+
+
+        // =========================================================
+        // INNER WALL
+        //
+        // The inner wall normal points toward the hole, therefore it
+        // is the opposite direction of the corresponding radial normal.
+        // =========================================================
+
+        const gIndex innerWallStart =
+            static_cast<gIndex>(vertices.size());
+
+        for (int i = 0; i < segmentnum; ++i) {
+
+            const float a = angleStep * static_cast<float>(i);
+            const float c = std::cos(a);
+            const float s = std::sin(a);
+
+            glm::vec3 normal(
+                static_cast<float>(h) * c,
+                -(dx * c + dz * s + innerDr),
+                static_cast<float>(h) * s
+            );
+
+            if (glm::length(normal) > 0.0f) {
+                normal = -glm::normalize(normal);
+            }
+
+            gVertex top{};
+            top.position = glm::vec3(
+                shiftdistance.x + topInnerRadius * c,
+                halfH,
+                shiftdistance.y + topInnerRadius * s
+            );
+            top.normal = normal;
+            top.color = glm::vec3(1.0f);
+
+            gVertex bottom{};
+            bottom.position = glm::vec3(
+                -shiftdistance.x + bottomInnerRadius * c,
+                -halfH,
+                -shiftdistance.y + bottomInnerRadius * s
+            );
+            bottom.normal = normal;
+            bottom.color = glm::vec3(1.0f);
+
+            vertices.push_back(top);
+            vertices.push_back(bottom);
+        }
+
+        for (int i = 0; i < segmentnum; ++i) {
+
+            const int next = (i + 1) % segmentnum;
+
+            const gIndex t0 = innerWallStart + static_cast<gIndex>(i * 2);
+            const gIndex b0 = t0 + 1;
+
+            const gIndex t1 = innerWallStart + static_cast<gIndex>(next * 2);
+            const gIndex b1 = t1 + 1;
+
+            // Reversed winding compared with the outer wall.
+            indices.push_back(t0);
+            indices.push_back(b1);
+            indices.push_back(b0);
+
+            indices.push_back(t0);
+            indices.push_back(t1);
+            indices.push_back(b1);
+        }
+
         setDrawMode(gMesh::DRAWMODE_TRIANGLES);
-}
+    }
 
+    else {
+
+        // =========================================================
+        // WIREFRAME
+        // =========================================================
+
+        for (int i = 0; i < segmentnum; ++i) {
+
+            const float a = angleStep * static_cast<float>(i);
+            const float c = std::cos(a);
+            const float s = std::sin(a);
+
+            gVertex topOuter{};
+            topOuter.position = glm::vec3(
+                shiftdistance.x + topOuterRadius * c,
+                halfH,
+                shiftdistance.y + topOuterRadius * s
+            );
+            topOuter.color = glm::vec3(1.0f);
+
+            gVertex topInner{};
+            topInner.position = glm::vec3(
+                shiftdistance.x + topInnerRadius * c,
+                halfH,
+                shiftdistance.y + topInnerRadius * s
+            );
+            topInner.color = glm::vec3(1.0f);
+
+            gVertex bottomOuter{};
+            bottomOuter.position = glm::vec3(
+                -shiftdistance.x + bottomOuterRadius * c,
+                -halfH,
+                -shiftdistance.y + bottomOuterRadius * s
+            );
+            bottomOuter.color = glm::vec3(1.0f);
+
+            gVertex bottomInner{};
+            bottomInner.position = glm::vec3(
+                -shiftdistance.x + bottomInnerRadius * c,
+                -halfH,
+                -shiftdistance.y + bottomInnerRadius * s
+            );
+            bottomInner.color = glm::vec3(1.0f);
+
+            vertices.push_back(topOuter);
+            vertices.push_back(topInner);
+            vertices.push_back(bottomOuter);
+            vertices.push_back(bottomInner);
+        }
+
+        for (int i = 0; i < segmentnum; ++i) {
+
+            const int next = (i + 1) % segmentnum;
+
+            const gIndex base = static_cast<gIndex>(i * 4);
+            const gIndex nextBase = static_cast<gIndex>(next * 4);
+
+            // Top outer ring
+            indices.push_back(base);
+            indices.push_back(nextBase);
+
+            // Top inner ring
+            indices.push_back(base + 1);
+            indices.push_back(nextBase + 1);
+
+            // Bottom outer ring
+            indices.push_back(base + 2);
+            indices.push_back(nextBase + 2);
+
+            // Bottom inner ring
+            indices.push_back(base + 3);
+            indices.push_back(nextBase + 3);
+
+            // Outer vertical/sloped edge
+            indices.push_back(base);
+            indices.push_back(base + 2);
+
+            // Inner vertical/sloped edge
+            indices.push_back(base + 1);
+            indices.push_back(base + 3);
+        }
+
+        setDrawMode(GL_LINES);
+    }
+
+    auto verticesptr =
+        std::make_shared<std::vector<gVertex>>(vertices);
+
+    auto indicesptr =
+        std::make_shared<std::vector<gIndex>>(indices);
+
+    setVertices(verticesptr, indicesptr);
+}
 
 
 gTube::~gTube() {
 
 }
-
-
-
-
-


### PR DESCRIPTION
primitives sheet

- add rotated overloads for sphere, cylinder, cone, pyramid and tube families
- support oblique and trapezoidal 3D primitive variants
- keep existing non-rotated draw functions compatible
- add Vulkan transform handling for rotated primitives
- add 3D Primitives Sheet to display all primitives rotating together
- add line/wireframe and filled variants side by side in the primitives sheet
- add filled and wireframe support for box rendering
- improve primitive lighting and normals for clearer 3D appearance