### PR TITLE
Add gPath and subpath point iteration

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -206,6 +206,7 @@ set(SRC_FILES
 	${ENGINE_DIR}/utils/gHttpFile.cpp
 	${ENGINE_DIR}/graphics/gShader.cpp
 	${ENGINE_DIR}/graphics/gBezier.cpp
+	${ENGINE_DIR}/graphics/gPath.cpp
 	${ENGINE_DIR}/graphics/gFog.cpp
 	${ENGINE_DIR}/core/gObject.cpp
 	${ENGINE_DIR}/core/gRenderer.cpp

--- a/engine/graphics/gPath.cpp
+++ b/engine/graphics/gPath.cpp
@@ -1,0 +1,296 @@
+/*
+ * Copyright (C) 2016 Nitra Games Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * gPath.cpp
+ *
+ * Created on: Aug 18, 2026
+ * Authors: Bahar Kucukozer, Mehmet Sefa Ciftci
+ */
+
+#include "gPath.h"
+
+#include "gArc.h"
+#include "gBezier.h"
+#include "gLine.h"
+#include "gMesh.h"
+
+#include <glm/common.hpp>
+#include <glm/geometric.hpp>
+
+
+gPath::gSubPath::gSubPath(gLine& line, int pointcount)
+	: type(TYPE_LINE), currentpoint(0) {
+	const std::vector<gVertex>& vertices = line.getVertices();
+	std::vector<glm::vec3> linepoints;
+
+	if (line.getDrawMode() == gMesh::DRAWMODE_TRIANGLES && vertices.size() >= 4) {
+		linepoints.push_back(
+				(vertices[0].position + vertices[2].position) * 0.5f);
+
+		linepoints.push_back(
+				(vertices[1].position + vertices[3].position) * 0.5f);
+	} else if (!vertices.empty()) {
+		linepoints.push_back(vertices.front().position);
+
+		if (vertices.size() > 1) {
+			linepoints.push_back(vertices.back().position);
+		}
+	}
+
+	points = samplePoints(linepoints, pointcount);
+}
+
+gPath::gSubPath::gSubPath(gArc& arc, int pointcount)
+	: type(TYPE_ARC), currentpoint(0) {
+	const std::vector<gVertex>& vertices = arc.getVertices();
+	std::vector<glm::vec3> arcpoints;
+
+	std::size_t firstpoint =
+			arc.getDrawMode() == gMesh::DRAWMODE_TRIANGLEFAN && !vertices.empty() ? 1 : 0;
+
+	for (std::size_t i = firstpoint; i < vertices.size(); i++) {
+		arcpoints.push_back(vertices[i].position);
+	}
+
+	points = samplePoints(arcpoints, pointcount);
+}
+
+gPath::gSubPath::gSubPath(
+		const gBezier& bezier,
+		int pointcount)
+	: type(TYPE_BEZIER), currentpoint(0) {
+	if (pointcount <= 0) {
+		return;
+	}
+
+	points.reserve(pointcount);
+
+	if (pointcount == 1) {
+		points.push_back(bezier.getPoint(0.0f));
+		return;
+	}
+
+	for (int i = 0; i < pointcount; i++) {
+		float t = static_cast<float>(i) / static_cast<float>(pointcount - 1);
+
+		points.push_back(bezier.getPoint(t));
+	}
+}
+
+gPath::gSubPath::gSubPath(
+		const gPath& path,
+		int pointcount)
+	: type(TYPE_PATH), currentpoint(0) {
+	points = samplePoints(path.getPoints(), pointcount);
+}
+
+gPath::gSubPath::Type gPath::gSubPath::getType() const {
+	return type;
+}
+
+int gPath::gSubPath::getPointCount() const {
+	return static_cast<int>(points.size());
+}
+
+const std::vector<glm::vec3>&
+gPath::gSubPath::getPoints() const {
+	return points;
+}
+
+bool gPath::gSubPath::hasNextPoint() const {
+	return currentpoint < points.size();
+}
+
+glm::vec3 gPath::gSubPath::getNextPoint() {
+	if (!hasNextPoint()) {
+		return glm::vec3(0.0f);
+	}
+
+	return points[currentpoint++];
+}
+
+void gPath::gSubPath::reset() {
+	currentpoint = 0;
+}
+
+std::vector<glm::vec3> gPath::gSubPath::samplePoints(
+		const std::vector<glm::vec3>& sourcepoints,
+		int pointcount) {
+	std::vector<glm::vec3> sampledpoints;
+
+	if (pointcount <= 0 || sourcepoints.empty()) {
+		return sampledpoints;
+	}
+
+	sampledpoints.reserve(pointcount);
+
+	if (pointcount == 1 || sourcepoints.size() == 1) {
+		for (int i = 0; i < pointcount; i++) {
+			sampledpoints.push_back(sourcepoints.front());
+		}
+
+		return sampledpoints;
+	}
+
+	std::vector<float> distances(sourcepoints.size(), 0.0f);
+
+	for (std::size_t i = 1; i < sourcepoints.size(); i++) {
+		distances[i] = distances[i - 1] + glm::distance(
+												  sourcepoints[i - 1],
+												  sourcepoints[i]);
+	}
+
+	float totallength = distances.back();
+
+	if (totallength == 0.0f) {
+		for (int i = 0; i < pointcount; i++) {
+			sampledpoints.push_back(sourcepoints.front());
+		}
+
+		return sampledpoints;
+	}
+
+	std::size_t segment = 1;
+
+	for (int i = 0; i < pointcount; i++) {
+		float targetdistance =
+				totallength * static_cast<float>(i) / static_cast<float>(pointcount - 1);
+
+		while (segment < distances.size() - 1 && distances[segment] < targetdistance) {
+			segment++;
+		}
+
+		float segmentlength =
+				distances[segment] - distances[segment - 1];
+
+		float t = segmentlength > 0.0f
+						  ? (targetdistance - distances[segment - 1]) / segmentlength
+						  : 0.0f;
+
+		sampledpoints.push_back(
+				glm::mix(
+						sourcepoints[segment - 1],
+						sourcepoints[segment],
+						t));
+	}
+
+	return sampledpoints;
+}
+
+gPath::gPath() : currentsubpath(0) {
+}
+
+gPath::~gPath() {
+}
+
+void gPath::clear() {
+	subpaths.clear();
+	currentsubpath = 0;
+}
+
+void gPath::addSubPath(const gSubPath& subpath) {
+	subpaths.push_back(subpath);
+	subpaths.back().reset();
+}
+
+void gPath::addSubPath(gLine& line, int pointcount) {
+	subpaths.emplace_back(line, pointcount);
+}
+
+void gPath::addSubPath(gArc& arc, int pointcount) {
+	subpaths.emplace_back(arc, pointcount);
+}
+
+void gPath::addSubPath(
+		const gBezier& bezier,
+		int pointcount) {
+	subpaths.emplace_back(bezier, pointcount);
+}
+
+void gPath::addSubPath(
+		const gPath& path,
+		int pointcount) {
+	subpaths.emplace_back(path, pointcount);
+}
+
+int gPath::getSubPathCount() const {
+	return static_cast<int>(subpaths.size());
+}
+
+int gPath::getPointCount() const {
+	int pointcount = 0;
+
+	for (const gSubPath& subpath : subpaths) {
+		pointcount += subpath.getPointCount();
+	}
+
+	return pointcount;
+}
+
+const std::vector<gPath::gSubPath>&
+gPath::getSubPaths() const {
+	return subpaths;
+}
+
+std::vector<glm::vec3> gPath::getPoints() const {
+	std::vector<glm::vec3> points;
+	points.reserve(getPointCount());
+
+	for (const gSubPath& subpath : subpaths) {
+		const std::vector<glm::vec3>& subpathpoints =
+				subpath.getPoints();
+
+		points.insert(
+				points.end(),
+				subpathpoints.begin(),
+				subpathpoints.end());
+	}
+
+	return points;
+}
+
+bool gPath::hasNextPoint() const {
+	for (std::size_t i = currentsubpath;
+		 i < subpaths.size();
+		 i++) {
+		if (subpaths[i].hasNextPoint()) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+glm::vec3 gPath::getNextPoint() {
+	while (currentsubpath < subpaths.size()) {
+		if (subpaths[currentsubpath].hasNextPoint()) {
+			return subpaths[currentsubpath].getNextPoint();
+		}
+
+		currentsubpath++;
+	}
+
+	return glm::vec3(0.0f);
+}
+
+void gPath::reset() {
+	currentsubpath = 0;
+
+	for (gSubPath& subpath : subpaths) {
+		subpath.reset();
+	}
+}

--- a/engine/graphics/gPath.h
+++ b/engine/graphics/gPath.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2016 Nitra Games Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * gPath.h
+ *
+ * Created on: Aug 18, 2026
+ * Authors: Bahar Kucukozer, Mehmet Sefa Ciftci
+ */
+
+#ifndef GRAPHICS_GPATH_H_
+#define GRAPHICS_GPATH_H_
+
+#include <cstddef>
+#include <glm/glm.hpp>
+#include <vector>
+
+class gArc;
+class gBezier;
+class gLine;
+
+class gPath {
+public:
+	class gSubPath {
+	public:
+		enum Type {
+			TYPE_LINE,
+			TYPE_ARC,
+			TYPE_BEZIER,
+			TYPE_PATH
+		};
+
+		gSubPath(gLine& line, int pointcount);
+		gSubPath(gArc& arc, int pointcount);
+		gSubPath(const gBezier& bezier, int pointcount);
+		gSubPath(const gPath& path, int pointcount);
+
+		Type getType() const;
+		int getPointCount() const;
+		const std::vector<glm::vec3>& getPoints() const;
+
+		bool hasNextPoint() const;
+		glm::vec3 getNextPoint();
+		void reset();
+
+	private:
+		static std::vector<glm::vec3> samplePoints(
+				const std::vector<glm::vec3>& sourcepoints,
+				int pointcount);
+
+		Type type;
+		std::vector<glm::vec3> points;
+		std::size_t currentpoint;
+	};
+
+	gPath();
+	virtual ~gPath();
+
+	void clear();
+
+	void addSubPath(const gSubPath& subpath);
+	void addSubPath(gLine& line, int pointcount);
+	void addSubPath(gArc& arc, int pointcount);
+	void addSubPath(const gBezier& bezier, int pointcount);
+	void addSubPath(const gPath& path, int pointcount);
+
+	int getSubPathCount() const;
+	int getPointCount() const;
+
+	const std::vector<gSubPath>& getSubPaths() const;
+	std::vector<glm::vec3> getPoints() const;
+
+	bool hasNextPoint() const;
+	glm::vec3 getNextPoint();
+	void reset();
+
+private:
+	std::vector<gSubPath> subpaths;
+	std::size_t currentsubpath;
+};
+
+#endif /* GRAPHICS_GPATH_H_ */

--- a/engine/graphics/primitives/gArc.h
+++ b/engine/graphics/primitives/gArc.h
@@ -15,6 +15,10 @@ public:
 	gArc();
 	~gArc() override;
 
+	void setPoints(float xCenter, float yCenter, float radius, bool isFilled, int numberOfSides = 60, float degree = 360.0f, float rotate = 0.0f, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f) {
+	isprojection2d = true;
+	setArcPoints(xCenter, yCenter, radius, isFilled, numberOfSides, degree, rotate, rotateAngle, pivotx, pivoty);
+}
 	void draw(float xCenter, float yCenter, float radius, bool isFilled, int numberOfSides = 60, float degree = 360.0f, float rotate = 0.0f, float rotateAngle = 0.0f, float pivotx = 0.5f, float pivoty = 0.5f);
 
 	private:


### PR DESCRIPTION
## Summary

- Added the gPath class composed of gSubPath objects.
- Added support for gLine, gArc, gBezier, and nested gPath subpaths.
- Added configurable point generation for each subpath.
- Added sequential point iteration with getNextPoint().
- Added hasNextPoint(), reset(), and clear() support.
- Added gArc::setPoints() to prepare arc vertices without drawing.
- Added gPath.cpp to the engine CMake source list.