### PR TITLE
Add gPath point accessors and gBezierQuad support

### DIFF
--- a/engine/graphics/gPath.cpp
+++ b/engine/graphics/gPath.cpp
@@ -106,6 +106,14 @@ int gPath::gSubPath::getPointCount() const {
 	return static_cast<int>(points.size());
 }
 
+glm::vec3 gPath::gSubPath::getPoint(int pointno) {
+	if (pointno < 0 || pointno >= getPointCount()) {
+		return glm::vec3(0.0f);
+	}
+
+	return points[pointno];
+}
+
 const std::vector<glm::vec3>&
 gPath::gSubPath::getPoints() const {
 	return points;
@@ -239,6 +247,32 @@ int gPath::getPointCount() const {
 	}
 
 	return pointcount;
+}
+
+glm::vec3 gPath::getPoint(int pointno) {
+	if (pointno < 0) {
+		return glm::vec3(0.0f);
+	}
+
+	for (gSubPath& subpath : subpaths) {
+		int subpathpointcount = subpath.getPointCount();
+
+		if (pointno < subpathpointcount) {
+			return subpath.getPoint(pointno);
+		}
+
+		pointno -= subpathpointcount;
+	}
+
+	return glm::vec3(0.0f);
+}
+
+glm::vec3 gPath::getPoint(int subpathno, int subpathpointno) {
+	if (subpathno < 0 || subpathno >= getSubPathCount()) {
+		return glm::vec3(0.0f);
+	}
+
+	return subpaths[subpathno].getPoint(subpathpointno);
 }
 
 const std::vector<gPath::gSubPath>&

--- a/engine/graphics/gPath.cpp
+++ b/engine/graphics/gPath.cpp
@@ -27,6 +27,7 @@
 #include "gBezier.h"
 #include "gLine.h"
 #include "gMesh.h"
+#include "gBezierQuad.h"
 
 #include <glm/common.hpp>
 #include <glm/geometric.hpp>
@@ -88,6 +89,28 @@ gPath::gSubPath::gSubPath(
 		float t = static_cast<float>(i) / static_cast<float>(pointcount - 1);
 
 		points.push_back(bezier.getPoint(t));
+	}
+}
+gPath::gSubPath::gSubPath(
+		const gBezierQuad& bezierquad,
+		int pointcount)
+	: type(TYPE_BEZIERQUAD), currentpoint(0) {
+	if (pointcount <= 0) {
+		return;
+	}
+
+	points.reserve(pointcount);
+
+	if (pointcount == 1) {
+		points.push_back(bezierquad.getPoint(0.0f));
+		return;
+	}
+
+	for (int i = 0; i < pointcount; i++) {
+		float t = static_cast<float>(i) /
+				  static_cast<float>(pointcount - 1);
+
+		points.push_back(bezierquad.getPoint(t));
 	}
 }
 
@@ -227,6 +250,12 @@ void gPath::addSubPath(
 		const gBezier& bezier,
 		int pointcount) {
 	subpaths.emplace_back(bezier, pointcount);
+}
+
+void gPath::addSubPath(
+		const gBezierQuad& bezierquad,
+		int pointcount) {
+	subpaths.emplace_back(bezierquad, pointcount);
 }
 
 void gPath::addSubPath(

--- a/engine/graphics/gPath.h
+++ b/engine/graphics/gPath.h
@@ -31,6 +31,7 @@
 class gArc;
 class gBezier;
 class gLine;
+class gBezierQuad;
 
 class gPath {
 public:
@@ -40,6 +41,7 @@ public:
 			TYPE_LINE,
 			TYPE_ARC,
 			TYPE_BEZIER,
+			TYPE_BEZIERQUAD,
 			TYPE_PATH
 		};
 
@@ -47,6 +49,7 @@ public:
 		gSubPath(gArc& arc, int pointcount);
 		gSubPath(const gBezier& bezier, int pointcount);
 		gSubPath(const gPath& path, int pointcount);
+		gSubPath(const gBezierQuad& bezierquad, int pointcount);
 
 		Type getType() const;
 		int getPointCount() const;
@@ -77,6 +80,7 @@ public:
 	void addSubPath(gArc& arc, int pointcount);
 	void addSubPath(const gBezier& bezier, int pointcount);
 	void addSubPath(const gPath& path, int pointcount);
+	void addSubPath(const gBezierQuad& bezierquad, int pointcount);
 
 	int getSubPathCount() const;
 	int getPointCount() const;

--- a/engine/graphics/gPath.h
+++ b/engine/graphics/gPath.h
@@ -50,6 +50,7 @@ public:
 
 		Type getType() const;
 		int getPointCount() const;
+		glm::vec3 getPoint(int pointno);
 		const std::vector<glm::vec3>& getPoints() const;
 
 		bool hasNextPoint() const;
@@ -79,6 +80,8 @@ public:
 
 	int getSubPathCount() const;
 	int getPointCount() const;
+	glm::vec3 getPoint(int pointno);
+	glm::vec3 getPoint(int subpathno, int subpathpointno);
 
 	const std::vector<gSubPath>& getSubPaths() const;
 	std::vector<glm::vec3> getPoints() const;


### PR DESCRIPTION
## Summary

* Add indexed point accessors to `gPath` and `gSubPath`.
* Support both global and subpath-specific point lookup with safe out-of-range handling.
* Add `gBezierQuad` as a supported `gPath` subpath type.
* Sample `gBezierQuad` curves using the requested point count.

## Testing

* Built GlistEngine in Release configuration on Windows.
* Build completed successfully with 0 errors.
