### PR TITLE
Let a canvas clear depth without calling OpenGL directly

### DIFF
--- a/engine/base/gBaseCanvas.cpp
+++ b/engine/base/gBaseCanvas.cpp
@@ -175,6 +175,10 @@ void gBaseCanvas::clearColor(gColor color) {
 	renderer->clearColor(color);
 }
 
+void gBaseCanvas::clearScreen(bool color, bool depth) {
+	renderer->clearScreen(color, depth);
+}
+
 void gBaseCanvas::enableLighting() {
 	renderer->enableLighting();
 }

--- a/engine/base/gBaseCanvas.h
+++ b/engine/base/gBaseCanvas.h
@@ -71,6 +71,10 @@ protected:
 	void clear();
 	void clearColor(int r, int g, int b, int a = 255);
 	void clearColor(gColor color);
+	// Clears the buffers named, leaving the others as they are. Clearing depth
+	// alone is how a scene draws something over what is already there without
+	// letting the two intersect - a first person weapon over the world.
+	void clearScreen(bool color = true, bool depth = true);
 
 	void enableLighting();
 	void disableLighting();


### PR DESCRIPTION
`gRenderer` has had `clearScreen(colour, depth)` for a long time, and `gShadowMap`
already uses it to clear depth by itself, but `gBaseCanvas` never passed it on.

A canvas that wants to keep the picture and forget how far away it was — a first
person weapon drawn over the world, so it cannot intersect the level — had no
engine call for it. `clear()` is no help, since it clears colour too. The only way
through was a raw `glClear(GL_DEPTH_BUFFER_BIT)`, which is exactly what the Vulkan
backend cannot serve directly, there being no OpenGL underneath it.

Passing the existing method on is the whole change. It also gives the
compatibility layer added in #1294 something to point at: its warning can now name
a real alternative instead of describing one that does not exist.

Verified with a full 3D game whose raw `glClear` was replaced by this call. The
level renders identically on both backends, Debug and Release.

---

An earlier revision of this PR also added `gStartEngine` overloads taking the
render backend as an `int`. That has been dropped on review — the call it was
meant to rescue is simply a call missing an argument, and belongs fixed at the
call site. This PR is now the `gBaseCanvas` passthrough only.
