### PR TITLE
Survive a full memory heap, and choose the GPU rather than take the first

### DIFF
--- a/engine/core/gGLRenderEngine.cpp
+++ b/engine/core/gGLRenderEngine.cpp
@@ -863,6 +863,15 @@ void gGLRenderEngine::init() {
 		glDebugMessageCallback(openglErrorCallback, nullptr);
 	}
 #endif
+	// The counterpart of the Vulkan backend's startup line: which backend this run
+	// actually got, and on what. A game that asked for one backend and quietly got
+	// the other looks the same in every other line of the log, so the difference
+	// only ever showed up as a frame counter nobody could explain.
+	const GLubyte* devicename = glGetString(GL_RENDERER);
+	const GLubyte* deviceversion = glGetString(GL_VERSION);
+	gLogi("gGLRenderEngine") << "Renderer: OpenGL "
+			<< (deviceversion != nullptr ? reinterpret_cast<const char*>(deviceversion) : "of an unreported version")
+			<< " on " << (devicename != nullptr ? reinterpret_cast<const char*>(devicename) : "an unnamed device") << ".";
 	gRenderer::init();
 }
 

--- a/engine/core/gVKBuffer.cpp
+++ b/engine/core/gVKBuffer.cpp
@@ -12,14 +12,24 @@
 
 // Returns UINT32_MAX rather than logging when nothing matches, so a caller can ask
 // for memory it would like and fall back to memory it needs.
+// The first memory type the buffer can use that carries every one of `properties`,
+// or UINT32_MAX if there is none.
+//
+// A type whose heap is smaller than `size` is passed over, because matching flags
+// is not the same as having room. It matters for one heap in particular: a discrete
+// GPU exposes the part of its video memory that the CPU can also write as a heap of
+// its own, and on Windows that heap is 256 MB unless the machine has resizable BAR
+// turned on. Every persistently mapped buffer here asks for that heap first, so it
+// is the one that runs out - and a caller told "no such memory type" can fall back,
+// while one told nothing at all simply fails.
 static uint32_t gvkTryFindMemoryType(gVKContext& ctx, uint32_t typeFilter,
-		VkMemoryPropertyFlags properties) {
+		VkMemoryPropertyFlags properties, VkDeviceSize size = 0) {
 	VkPhysicalDeviceMemoryProperties* memprops = ctx.getDeviceMemoryProperties();
 	for(uint32_t i = 0; i < memprops->memoryTypeCount; i++) {
-		if((typeFilter & (1u << i)) &&
-				(memprops->memoryTypes[i].propertyFlags & properties) == properties) {
-			return i;
-		}
+		if((typeFilter & (1u << i)) == 0) continue;
+		if((memprops->memoryTypes[i].propertyFlags & properties) != properties) continue;
+		if(size > memprops->memoryHeaps[memprops->memoryTypes[i].heapIndex].size) continue;
+		return i;
 	}
 	return UINT32_MAX;
 }
@@ -54,16 +64,49 @@ bool gvkCreateBuffer(gVKContext& ctx, VkDeviceSize size, VkBufferUsageFlags usag
 	// local memory that the CPU can also write, which is where a buffer the CPU
 	// rewrites every frame belongs: plain host visible memory lives in system RAM and
 	// the GPU reads it across the bus on every draw.
+	uint32_t required = gvkTryFindMemoryType(ctx, memreq.memoryTypeBits, properties, memreq.size);
+	// Should the size filter leave nothing at all, ask again without it and let the
+	// driver be the one to refuse. The filter exists to keep a buffer out of a heap
+	// it plainly cannot fit - not to answer on the driver's behalf, which is what
+	// refusing here on a heap size the driver itself reported would amount to.
+	if(required == UINT32_MAX) required = gvkTryFindMemoryType(ctx, memreq.memoryTypeBits, properties);
 	uint32_t memtype = UINT32_MAX;
-	if(preferred != 0) memtype = gvkTryFindMemoryType(ctx, memreq.memoryTypeBits, preferred);
-	if(memtype == UINT32_MAX) memtype = gvkFindMemoryType(ctx, memreq.memoryTypeBits, properties);
+	if(preferred != 0) memtype = gvkTryFindMemoryType(ctx, memreq.memoryTypeBits, preferred, memreq.size);
+	if(memtype == UINT32_MAX) memtype = required;
+	if(memtype == UINT32_MAX) {
+		gLoge("gVKBuffer") << "No memory type on this GPU can hold a " << memreq.size << " byte buffer.";
+		vkDestroyBuffer(device, outBuffer, nullptr);
+		outBuffer = VK_NULL_HANDLE;
+		outMemory = VK_NULL_HANDLE;
+		return false;
+	}
 
 	VkMemoryAllocateInfo allocinfo{};
 	allocinfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
 	allocinfo.allocationSize = memreq.size;
 	allocinfo.memoryTypeIndex = memtype;
-	if(vkAllocateMemory(device, &allocinfo, nullptr, &outMemory) != VK_SUCCESS) {
-		gLoge("gVKBuffer") << "vkAllocateMemory failed.";
+	VkResult allocated = vkAllocateMemory(device, &allocinfo, nullptr, &outMemory);
+
+	// A heap large enough on paper can still be full, and the preferred one is the
+	// first to go: on a discrete GPU it is a slice of video memory that every
+	// persistently mapped buffer in the engine competes for. The required properties
+	// name memory that is slower, not absent, so the allocation is worth retrying
+	// there rather than failing.
+	//
+	// What failing costs is out of proportion to what it looks like. gvkCreateBuffer
+	// returning false for the mesh arena leaves the engine with no arena at all, and
+	// every gathered run of identical meshes then goes back to one draw call per
+	// object - the Vulkan backend quietly gives up the thing that made it faster than
+	// OpenGL, while still drawing the correct picture.
+	if(allocated != VK_SUCCESS && memtype != required && required != UINT32_MAX) {
+		gLogw("gVKBuffer") << "The preferred memory heap could not hold a " << memreq.size
+				<< " byte buffer, so it goes to memory the GPU reads across the bus. "
+				<< "On a discrete GPU this heap is 256 MB without resizable BAR.";
+		allocinfo.memoryTypeIndex = required;
+		allocated = vkAllocateMemory(device, &allocinfo, nullptr, &outMemory);
+	}
+	if(allocated != VK_SUCCESS) {
+		gLoge("gVKBuffer") << "vkAllocateMemory failed for a " << memreq.size << " byte buffer.";
 		vkDestroyBuffer(device, outBuffer, nullptr);
 		outBuffer = VK_NULL_HANDLE;
 		outMemory = VK_NULL_HANDLE;

--- a/engine/core/gVKContext.h
+++ b/engine/core/gVKContext.h
@@ -1026,6 +1026,11 @@ private:
 	std::vector<VkDeviceSize> mesharenaoffsets;
 	VkDeviceSize mesharenacapacity = 0;
 	VkDeviceSize mesharenahighwater = 0;
+	// A capacity the device refused. The frame loop asks for the arena to grow
+	// whenever the high-water mark is above what it holds, so without remembering
+	// this it would ask again on the next frame, and the next - each attempt
+	// draining the device first. Cleared as soon as any growth succeeds.
+	VkDeviceSize mesharenarefusedcapacity = 0;
 	uint64_t meshgeneration = 0;
 
 	VkPipeline recordedpipeline = VK_NULL_HANDLE;

--- a/engine/core/gVKDraw.cpp
+++ b/engine/core/gVKDraw.cpp
@@ -29,28 +29,52 @@ static constexpr VkDeviceSize GVK_MESH_ARENA_INITIAL_CAPACITY = 8 * 1024 * 1024;
 bool gvkEnsureMeshArena(gVKContext& ctx, VkDeviceSize capacity) {
 	if(ctx.device == VK_NULL_HANDLE || capacity == 0) return false;
 	if(capacity <= ctx.mesharenacapacity) return true;
+	// A size the device has already refused is not worth asking for a second time.
+	// The caller drains the device before every attempt, so retrying each frame
+	// would cost a full stall per frame for as long as the scene kept wanting it.
+	if(ctx.mesharenarefusedcapacity != 0 && capacity >= ctx.mesharenarefusedcapacity) return false;
 
-	gvkDestroyMeshArena(ctx);
-
+	// Built beside the arena in use rather than in place of it. Growing used to
+	// destroy what was there before finding out whether the replacement could be
+	// allocated, so a growth the device refused left no arena at all - and an arena
+	// that is merely too small still holds most of a frame's slices, while one that
+	// is gone sends every gathered draw back to one draw call per object.
 	const int frames = GVK_MAX_FRAMES_IN_FLIGHT;
-	ctx.mesharenacapacity = capacity;
-	ctx.mesharenabuffers.assign(frames, VK_NULL_HANDLE);
-	ctx.mesharenamemories.assign(frames, VK_NULL_HANDLE);
-	ctx.mesharenamapped.assign(frames, nullptr);
-	ctx.mesharenaoffsets.assign(frames, 0);
+	std::vector<VkBuffer> buffers(frames, VK_NULL_HANDLE);
+	std::vector<VkDeviceMemory> memories(frames, VK_NULL_HANDLE);
+	std::vector<void*> mapped(frames, nullptr);
 	for(int i = 0; i < frames; i++) {
 		if(!gvkCreateBuffer(ctx, capacity, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
 				VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-				ctx.mesharenabuffers[i], ctx.mesharenamemories[i],
+				buffers[i], memories[i],
 				VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT
-						| VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)) {
-			gLoge("gVKDraw") << "Could not create the " << capacity
-					<< " byte mesh arena; animated meshes fall back to one buffer each.";
-			gvkDestroyMeshArena(ctx);
+						| VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)
+				|| vkMapMemory(ctx.device, memories[i], 0, capacity, 0, &mapped[i]) != VK_SUCCESS) {
+			gLogw("gVKDraw") << "Could not grow the mesh arena to " << capacity
+					<< " bytes; keeping the " << ctx.mesharenacapacity << " byte one.";
+			for(int j = 0; j <= i; j++) {
+				if(mapped[j] != nullptr) vkUnmapMemory(ctx.device, memories[j]);
+				if(buffers[j] != VK_NULL_HANDLE) vkDestroyBuffer(ctx.device, buffers[j], nullptr);
+				if(memories[j] != VK_NULL_HANDLE) vkFreeMemory(ctx.device, memories[j], nullptr);
+			}
+			ctx.mesharenarefusedcapacity = capacity;
 			return false;
 		}
-		vkMapMemory(ctx.device, ctx.mesharenamemories[i], 0, capacity, 0, &ctx.mesharenamapped[i]);
 	}
+
+	// Only now, with a replacement in hand, does the old one go - and the device is
+	// drained here rather than by the caller, because this is the one moment it is
+	// needed: the buffers about to be freed may still be referenced by a frame that
+	// has not finished. Draining before the allocation, as the frame loop used to,
+	// spent a full stall on attempts that turned out to fail.
+	vkDeviceWaitIdle(ctx.device);
+	gvkDestroyMeshArena(ctx);
+	ctx.mesharenacapacity = capacity;
+	ctx.mesharenabuffers = std::move(buffers);
+	ctx.mesharenamemories = std::move(memories);
+	ctx.mesharenamapped = std::move(mapped);
+	ctx.mesharenaoffsets.assign(frames, 0);
+	ctx.mesharenarefusedcapacity = 0;
 	return true;
 }
 

--- a/engine/core/gVKFrame.cpp
+++ b/engine/core/gVKFrame.cpp
@@ -111,11 +111,12 @@ bool gvkBeginFrame(gVKContext& ctx, gBaseWindow* window) {
 	// the draw path can refill it from the start.
 	ctx.resetDynamicVertices();
 	// Rewind the mesh arena too, and grow it first if the last frames wanted more
-	// than it holds. Growing here means draining the device, which is why it is
-	// done at a frame boundary and only when the high-water mark says it is
-	// needed - in practice a handful of times while a level loads, then never.
+	// than it holds. A frame boundary is where that belongs, because replacing the
+	// arena drains the device - gvkEnsureMeshArena does that itself, at the point
+	// the old buffers are actually freed, and returns without spending a stall when
+	// there is nothing it can do. In practice this grows a handful of times while a
+	// level loads, then never.
 	if(ctx.mesharenahighwater > ctx.mesharenacapacity) {
-		vkDeviceWaitIdle(ctx.device);
 		gvkEnsureMeshArena(ctx, ctx.mesharenahighwater * 2);
 	}
 	ctx.resetMeshArena();

--- a/engine/core/gVKRenderEngine.cpp
+++ b/engine/core/gVKRenderEngine.cpp
@@ -1748,6 +1748,32 @@ void gVKRenderEngine::popMatrix() {
 
 static const char* const GVK_VALIDATION_LAYER = "VK_LAYER_KHRONOS_validation";
 
+// How much a GPU is worth to a renderer that has to hit a frame deadline, best
+// first. Only the class of device is weighed, because that is the part of the
+// answer that does not depend on the scene: a GPU with its own memory beats one
+// sharing the CPU's, and anything with hardware behind it beats an emulation of
+// one.
+static int gvkRateDeviceType(VkPhysicalDeviceType type) {
+	switch(type) {
+		case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU: return 4;
+		case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU: return 3;
+		case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU: return 2;
+		case VK_PHYSICAL_DEVICE_TYPE_CPU: return 1;
+		default: return 0;
+	}
+}
+
+// The same classes, for the startup line.
+static const char* gvkDeviceTypeName(VkPhysicalDeviceType type) {
+	switch(type) {
+		case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU: return "discrete";
+		case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU: return "integrated";
+		case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU: return "virtual";
+		case VK_PHYSICAL_DEVICE_TYPE_CPU: return "software";
+		default: return "an unreported kind of";
+	}
+}
+
 // True the first time this exact message is seen. The same text repeated carries
 // no new information and buries what does: MoltenVK reports each Metal limitation
 // once per pipeline built, which is eighty identical lines about one thing. Past
@@ -2065,7 +2091,17 @@ bool gVKRenderEngine::initVulkan() {
 	// It must also meet the version floor: the device's own apiVersion - not the
 	// loader's - is what caps the core features actually available on it, so a
 	// device below minapiversion cannot deliver what the engine requires.
+	//
+	// Among the usable ones the best is taken rather than the first. Enumeration
+	// order is the loader's business, and on a laptop with switchable graphics the
+	// integrated GPU is commonly the one listed first - so a machine that reaches
+	// for its discrete GPU under OpenGL would run Vulkan on the slow half of
+	// itself, which reads as the Vulkan backend being no faster than OpenGL rather
+	// than as the wrong GPU. The two hints that pull OpenGL onto the discrete GPU,
+	// NvOptimusEnablement and AmdPowerXpressRequestHighPerformance, say nothing to
+	// Vulkan: here the choice belongs to the application, so it is made.
 	bool rejectedforversion = false;
+	int bestrating = -1;
 	for(const auto& dev : ctx->physicaldevices) {
 		uint32_t familycount = 0;
 		vkGetPhysicalDeviceQueueFamilyProperties(dev, &familycount, nullptr);
@@ -2095,6 +2131,12 @@ bool gVKRenderEngine::initVulkan() {
 				rejectedforversion = true;
 				continue;
 			}
+			// Strictly better only, so a tie leaves the device found earlier in
+			// place and a machine with a single GPU ends up exactly where it did
+			// before there was a choice to make.
+			const int rating = gvkRateDeviceType(devprops.deviceType);
+			if(rating <= bestrating) continue;
+			bestrating = rating;
 			ctx->physicaldevice = dev;
 			ctx->graphicsfamily = graphics;
 			ctx->presentfamily = present;
@@ -2102,7 +2144,6 @@ bool gVKRenderEngine::initVulkan() {
 			// and which of them can present, so later phases need no re-query.
 			ctx->queuefamilyproperties = families;
 			ctx->queuefamilypresentsupport = presentsupportlist;
-			break;
 		}
 	}
 	if(ctx->physicaldevice == VK_NULL_HANDLE) {
@@ -2117,6 +2158,20 @@ bool gVKRenderEngine::initVulkan() {
 		cleanupVulkan();
 		return false;
 	}
+
+	// Which backend this run actually got, and on what. Both backends print a line
+	// like this because from inside a running game the two are indistinguishable -
+	// the log is otherwise identical either way - and a frame counter read against
+	// a wrong assumption about which one is underneath has cost more than one
+	// investigation.
+	VkPhysicalDeviceProperties chosenprops{};
+	vkGetPhysicalDeviceProperties(ctx->physicaldevice, &chosenprops);
+	gLogi("gVKRenderEngine") << "Renderer: Vulkan " << VK_API_VERSION_MAJOR(chosenprops.apiVersion)
+			<< "." << VK_API_VERSION_MINOR(chosenprops.apiVersion) << " on "
+			<< chosenprops.deviceName << ", " << gvkDeviceTypeName(chosenprops.deviceType)
+			<< " of " << ctx->devicecount << " GPU(s) offered. Validation "
+			<< (ctx->validationactive ? "on - every command goes through the layer, so this "
+					"build is not one to judge performance by" : "off") << ".";
 
 	/* ---------------- logical device ---------------- */
 	// A set, because graphics and present are usually the same family and the


### PR DESCRIPTION
Three problems the Vulkan backend has on a discrete GPU and cannot have on the machines it was written on. They came out of a report that the backend ran a full 3D game no faster than OpenGL, where it had been well ahead of it.

### A memory heap that can fill

Every buffer the engine keeps mapped — the mesh arena, the dynamic vertex ring, the per-frame copies of an animated mesh, the GUI's uniforms — asks for memory that is both device local and host visible, because that is where a buffer the CPU rewrites every frame belongs.

On a GPU that shares the CPU's memory this is simply all of it, which is why it has never come up here. On a discrete GPU it is a heap of its own, and on Windows that heap is 256 MB unless the machine has resizable BAR turned on.

`gvkCreateBuffer` matched the property flags and never looked at the size of the heap behind them, and when `vkAllocateMemory` then refused it gave up — rather than falling back to memory the GPU can still read and only reads more slowly. The memory type is now chosen with the allocation size in hand, and a refusal is retried against the required properties before a buffer is declared impossible.

### What that failure costs

`gvkEnsureMeshArena` returning false leaves no arena at all, and without one every gathered run of identical meshes goes back to one draw call per object. The backend quietly gives up the thing that made it faster than OpenGL, while still drawing the correct picture — which is exactly how the report reads.

Growing the arena made this worse than it had to be, because it destroyed the arena in use before finding out whether the replacement could be allocated, and an arena that is merely too small still holds most of a frame's slices. Three changes:

- the replacement is built beside the old one and adopted only once it exists;
- the device is drained where the old buffers are actually freed, not before every attempt;
- a size the device has already refused is not asked for again.

The last one matters most. The frame loop asks for growth whenever the high-water mark is above what the arena holds, so a single refusal turned into a full `vkDeviceWaitIdle` on every frame from then on.

### The GPU itself

The device search took the first GPU that could both render and present, and enumeration order belongs to the loader: on a laptop with switchable graphics the integrated GPU is commonly the one listed first. Neither of the hints that pull OpenGL onto the discrete GPU, `NvOptimusEnablement` and `AmdPowerXpressRequestHighPerformance`, says anything to Vulkan — so one machine could end up running a backend on each.

The search now rates what it finds and keeps the best. A tie leaves the device found earlier in place, so a machine with a single GPU ends up exactly where it did before there was a choice to make.

### Saying which backend is running

Both backends now name themselves at startup, along with the GPU they got and, on Vulkan, whether the validation layer is loaded — that last one because a build carrying it is not one to judge performance by.

```
[INFO] gVKRenderEngine: Renderer: Vulkan 1.4 on Apple M4, integrated of 1 GPU(s) offered. Validation off.
[INFO] gGLRenderEngine: Renderer: OpenGL 4.1 Metal - 90.5 on Apple M4.
```

Their logs were otherwise byte-identical, and a frame counter read against a wrong assumption about which backend was underneath has cost more than one investigation.

### Testing

Built and run on both backends against current `main`, on macOS with MoltenVK: no renderer errors on either, and the startup lines above are what they print. Every backend is compiled as before; nothing here changes what is built.

The machines available here have one memory heap and one GPU, so what can be shown locally is that these paths still behave — the heap and GPU choices they change only ever differ on a discrete GPU. The warning added alongside the fallback is what will confirm it there:

```
The preferred memory heap could not hold a N byte buffer, so it goes to memory
the GPU reads across the bus. On a discrete GPU this heap is 256 MB without
resizable BAR.
```