### PR TITLE
Fix out-of-bounds RGB skybox reads on Vulkan

### DIFF
--- a/engine/graphics/gSkybox.cpp
+++ b/engine/graphics/gSkybox.cpp
@@ -470,7 +470,9 @@ unsigned int gSkybox::uploadVulkanFace(int faceWidth, int faceHeight, void* pixe
 
 	unsigned int texture = renderer->createTextures();
 	renderer->bindTexture(texture);
-	renderer->texImage2D(GL_TEXTURE_2D, GL_RGBA, faceWidth, faceHeight, GL_RGBA, GL_UNSIGNED_BYTE, source);
+	// HDR conversion produces RGBA; ordinary faces still contain packed RGB.
+	const GLenum sourceformat = hdr ? GL_RGBA : GL_RGB;
+	renderer->texImage2D(GL_TEXTURE_2D, GL_RGBA, faceWidth, faceHeight, sourceformat, GL_UNSIGNED_BYTE, source);
 	renderer->setWrappingAndFiltering(GL_TEXTURE_2D, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE, GL_LINEAR, GL_LINEAR);
 
 	return texture;


### PR DESCRIPTION
Ordinary skybox faces contain packed RGB pixels, but `uploadVulkanFace` passed them to `texImage2D` as RGBA. The Vulkan upload then read four bytes per pixel from a three-byte buffer, causing out-of-bounds reads and possible crashes or corrupted textures.

Select `GL_RGB` for ordinary faces and retain `GL_RGBA` for the HDR conversion, which produces four channels.

Validation:
- An isolated upload harness reproduces the original heap-buffer-overflow with AddressSanitizer.
- RGB and HDR cases pass with AddressSanitizer and UndefinedBehaviorSanitizer after the fix.
- A Release Vulkan build completes scene loading and reaches the game loop.
